### PR TITLE
Lock down PhysicalMaterial and Functional Schemas

### DIFF
--- a/iModelJsNodeAddon/IModelJsNative.cpp
+++ b/iModelJsNodeAddon/IModelJsNative.cpp
@@ -1208,7 +1208,7 @@ struct NativeDgnDb : BeObjectWrap<NativeDgnDb>, SQLiteOps
 
     void OpenDgnDb(BeFileNameCR dbname, DgnDb::OpenParams& openParams) {
         if (!openParams.IsReadonly())
-            openParams.SetBusyRetry(new BeSQLite::BusyRetry(40, 500)); // retry 40 times, 1/2 second intervals (20 seconds total) s
+            openParams.SetBusyRetry(new BeSQLite::BusyRetry(40, 500)); // retry 40 times, 1/2 second intervals (20 seconds total)
         NativeLogging::CategoryLogger("BeSQLite").infov(L"Opening DgnDb %ls", dbname.c_str());
 
         DbResult result;


### PR DESCRIPTION
We're seeing test failures in our pipeline like: " Error: error opening iModel [D:\vsts_b\174\s\imodel-native\iModelJsNodeAddon\api_package\ts\lib\test\assets\test.bim]: the schemas found in the database need to be upgraded"

This is due to some new Schemas from the BisSchemas repo(?). Locking the versions down allows our tests to pass. I confirmed this locally.

Not locking down will also cause iModels in the wild to fail with a similar error. 