### PR TITLE
Add more schema search paths when importing schemas

### DIFF
--- a/iModelJsNodeAddon/IModelJsNative.h
+++ b/iModelJsNodeAddon/IModelJsNative.h
@@ -461,7 +461,7 @@ private:
     static void GetRowAsJson(BeJsValue json, BeSQLite::EC::ECSqlStatement &);
     static void RegisterOptionalDomains();
     static void InitializeSolidKernel();
-
+    static void AddSchemaSearchPaths(ECSchemaReadContextPtr schemaContext);
 public:
     static void HandleAssertion(WCharCP msg, WCharCP file, unsigned line, BeAssertFunctions::AssertType type);
     static void GetECValuesCollectionAsJson(BeJsValue json, ECN::ECValuesCollectionCR);

--- a/iModelJsNodeAddon/JsInterop.cpp
+++ b/iModelJsNodeAddon/JsInterop.cpp
@@ -820,6 +820,7 @@ DbResult JsInterop::ImportSchema(ECDbR ecdb, BeFileNameCR pathname)
         return BE_SQLITE_NOTFOUND;
 
     ECSchemaReadContextPtr schemaContext = ECSchemaReadContext::CreateContext(false /*=acceptLegacyImperfectLatestCompatibleMatch*/, true /*=includeFilesWithNoVerExt*/);
+    JsInterop::AddSchemaSearchPaths(schemaContext);
     schemaContext->SetFinalSchemaLocater(ecdb.GetSchemaLocater());
 
     ECSchemaPtr schema;
@@ -839,12 +840,35 @@ DbResult JsInterop::ImportSchema(ECDbR ecdb, BeFileNameCR pathname)
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //---------------------------------------------------------------------------------------
+void JsInterop::AddSchemaSearchPaths(ECSchemaReadContextPtr schemaContext) 
+    {
+    BeFileName rootDir = PlatformLib::GetHost().GetIKnownLocationsAdmin().GetDgnPlatformAssetsDirectory();
+    rootDir.AppendToPath(L"ECSchemas");
+    BeFileName dgnPath = rootDir;
+    dgnPath.AppendToPath(L"Dgn");
+    dgnPath.AppendSeparator();
+    BeFileName domainPath = rootDir;
+    domainPath.AppendToPath(L"Domain");
+    domainPath.AppendSeparator();
+    BeFileName ecdbPath = rootDir;
+    ecdbPath.AppendToPath(L"ECDb");
+    ecdbPath.AppendSeparator();
+    schemaContext->AddSchemaPath(dgnPath);
+    schemaContext->AddSchemaPath(domainPath);
+    schemaContext->AddSchemaPath(ecdbPath);
+    return;
+    }
+
+//---------------------------------------------------------------------------------------
+// @bsimethod
+//---------------------------------------------------------------------------------------
 DbResult JsInterop::ImportSchemasDgnDb(DgnDbR dgndb, bvector<Utf8String> const& schemaFileNames)
     {
     if (0 == schemaFileNames.size())
         return BE_SQLITE_NOTFOUND;
 
     ECSchemaReadContextPtr schemaContext = ECSchemaReadContext::CreateContext(false /*=acceptLegacyImperfectLatestCompatibleMatch*/, true /*=includeFilesWithNoVerExt*/);
+    JsInterop::AddSchemaSearchPaths(schemaContext);
     schemaContext->SetFinalSchemaLocater(dgndb.GetSchemaLocater());
     bvector<ECSchemaCP> schemas;
 

--- a/iModelJsNodeAddon/JsInterop.cpp
+++ b/iModelJsNodeAddon/JsInterop.cpp
@@ -845,14 +845,11 @@ void JsInterop::AddSchemaSearchPaths(ECSchemaReadContextPtr schemaContext)
     BeFileName rootDir = PlatformLib::GetHost().GetIKnownLocationsAdmin().GetDgnPlatformAssetsDirectory();
     rootDir.AppendToPath(L"ECSchemas");
     BeFileName dgnPath = rootDir;
-    dgnPath.AppendToPath(L"Dgn");
-    dgnPath.AppendSeparator();
+    dgnPath.AppendToPath(L"Dgn").AppendSeparator();
     BeFileName domainPath = rootDir;
-    domainPath.AppendToPath(L"Domain");
-    domainPath.AppendSeparator();
+    domainPath.AppendToPath(L"Domain").AppendSeparator();
     BeFileName ecdbPath = rootDir;
-    ecdbPath.AppendToPath(L"ECDb");
-    ecdbPath.AppendSeparator();
+    ecdbPath.AppendToPath(L"ECDb").AppendSeparator();
     schemaContext->AddSchemaPath(dgnPath);
     schemaContext->AddSchemaPath(domainPath);
     schemaContext->AddSchemaPath(ecdbPath);
@@ -910,6 +907,7 @@ DbResult JsInterop::ImportXmlSchemas(DgnDbR dgndb, bvector<Utf8String> const& se
         return BE_SQLITE_NOTFOUND;
 
     ECSchemaReadContextPtr schemaContext = ECSchemaReadContext::CreateContext(false /*=acceptLegacyImperfectLatestCompatibleMatch*/, true /*=includeFilesWithNoVerExt*/);
+    JsInterop::AddSchemaSearchPaths(schemaContext);
     schemaContext->SetFinalSchemaLocater(dgndb.GetSchemaLocater());
     bvector<ECSchemaCP> schemas;
 

--- a/iModelJsNodeAddon/api_package/ts/src/test/index.ts
+++ b/iModelJsNodeAddon/api_package/ts/src/test/index.ts
@@ -8,6 +8,7 @@ import * as Mocha from "mocha";
 import * as path from "path";
 import { Logger, LogLevel, OpenMode } from "@itwin/core-bentley";
 import { iModelJsNative } from "./utils";
+import { UpgradeOptions } from "@itwin/core-common";
 
 // Run mocha tests on all *.test.ts files
 function runMochaTests() {
@@ -32,9 +33,9 @@ Logger.initializeToConsole();
 Logger.setLevelDefault(LogLevel.Error);
 iModelJsNative.logger = Logger;
 
-export function openDgnDb(filename: string) {
+export function openDgnDb(filename: string, upgradeOptions?: UpgradeOptions) {
   const db = new iModelJsNative.DgnDb();
-  db.openIModel(filename, OpenMode.ReadWrite);
+  db.openIModel(filename, OpenMode.ReadWrite, upgradeOptions);
   return db;
 }
 


### PR DESCRIPTION
These extra schema search paths are all the paths we currently add schemas to in the node addon. This PR resolves a long-standing bug where importing a schema results in us being potentially unable to find any of its referenced schemas. This bug was hidden by the fact that most of our iModels already contained the referenced BisCore schema (version 01.00.00) in PresentationRules.ecschema. Since PresentationRules.ecschema now references a newer version of the BisCore schema (01.00.15) which our iModels (atleast the seed files in presentation tests) didn't have, this bug showed up. Even though the BisCore schema at version 01.00.15 was packaged in the node addon, it was unable to be found when importing the PresentationRules schema, because we've never told the schemaLocaters to look in the /Assets/ECSchemas/Dgn folder.