### PR TITLE
DgnDomain SchemaUpgradeRequired Fix

### DIFF
--- a/iModelCore/iModelPlatform/DgnCore/DgnDomain.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/DgnDomain.cpp
@@ -558,10 +558,12 @@ SchemaStatus DgnDomains::DoValidateSchemas(bvector<ECSchemaPtr>* schemasToImport
             return locStatus;
 
         BeAssert(locStatus == SchemaStatus::SchemaNotFound || locStatus == SchemaStatus::SchemaUpgradeRequired || locStatus == SchemaStatus::SchemaUpgradeRecommended);
-        if ((locStatus == SchemaStatus::SchemaUpgradeRecommended && status != SchemaStatus::SchemaUpgradeRequired) || (locStatus == SchemaStatus::SchemaNotFound && status == SchemaStatus::SchemaUpgradeRecommended))
+        // A referenced schema that is not found does not make a recommended domain schema upgrade required
+        if (status != SchemaStatus::SchemaUpgradeRequired && (locStatus == SchemaStatus::SchemaUpgradeRecommended || locStatus == SchemaStatus::SchemaNotFound))
             status = SchemaStatus::SchemaUpgradeRecommended;
         else
             status = SchemaStatus::SchemaUpgradeRequired;
+        
         if (schemasToImport)
             schemasToImport->push_back(schema);
         }

--- a/iModelCore/iModelPlatform/DgnCore/DgnDomain.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/DgnDomain.cpp
@@ -558,7 +558,7 @@ SchemaStatus DgnDomains::DoValidateSchemas(bvector<ECSchemaPtr>* schemasToImport
             return locStatus;
 
         BeAssert(locStatus == SchemaStatus::SchemaNotFound || locStatus == SchemaStatus::SchemaUpgradeRequired || locStatus == SchemaStatus::SchemaUpgradeRecommended);
-        if (locStatus == SchemaStatus::SchemaUpgradeRecommended && status != SchemaStatus::SchemaUpgradeRequired)
+        if ((locStatus == SchemaStatus::SchemaUpgradeRecommended && status != SchemaStatus::SchemaUpgradeRequired) || (locStatus == SchemaStatus::SchemaNotFound && status == SchemaStatus::SchemaUpgradeRecommended))
             status = SchemaStatus::SchemaUpgradeRecommended;
         else
             status = SchemaStatus::SchemaUpgradeRequired;

--- a/iModelCore/iModelPlatform/Tests/DgnProject/ECSchemas/SchemaVersionTest.02.02.06.ecschema.xml
+++ b/iModelCore/iModelPlatform/Tests/DgnProject/ECSchemas/SchemaVersionTest.02.02.06.ecschema.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- =====================================================================================
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See COPYRIGHT.md in the repository root for full copyright notice.
+========================================================================================== -->
+<ECSchema schemaName="SchemaVersionTest" alias="vertest" version="02.02.06" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2" description="This is a test schema.">
+    <ECSchemaReference name="BisCore" version="01.00.00" alias="bis"/>
+    <ECSchemaReference name="ECDbMap" version="02.00.00" alias="ecdbmap"/>
+    <ECSchemaReference name="CoreCustomAttributes" version="01.00.00" alias="CoreCA"/>
+	<ECSchemaReference name="TestSchema" version="01.00.00" alias="testSchema"/>
+
+    <ECEntityClass typeName="TestElement" displayLabel="Test label" description="Test element description.">
+        <BaseClass>bis:PhysicalElement</BaseClass>
+        <ECCustomAttributes>
+            <ClassHasHandler xmlns="BisCore.01.00.00"/>
+        </ECCustomAttributes>
+        <ECProperty propertyName="StringProperty1" typeName="string" description="Test property."/>
+    </ECEntityClass>
+</ECSchema>

--- a/iModelCore/iModelPlatform/Tests/DgnProject/ECSchemas/SchemaVersionTest.02.02.07.ecschema.xml
+++ b/iModelCore/iModelPlatform/Tests/DgnProject/ECSchemas/SchemaVersionTest.02.02.07.ecschema.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- =====================================================================================
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See COPYRIGHT.md in the repository root for full copyright notice.
+========================================================================================== -->
+<ECSchema schemaName="SchemaVersionTest" alias="vertest" version="02.02.07" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2" description="This is a test schema.">
+    <ECSchemaReference name="BisCore" version="01.00.00" alias="bis"/>
+    <ECSchemaReference name="ECDbMap" version="02.00.00" alias="ecdbmap"/>
+    <ECSchemaReference name="CoreCustomAttributes" version="01.00.00" alias="CoreCA"/>
+	
+    <ECEntityClass typeName="TestElement" displayLabel="Test label1" description="Test element description.">
+        <BaseClass>bis:PhysicalElement</BaseClass>
+        <ECCustomAttributes>
+            <ClassHasHandler xmlns="BisCore.01.00.00"/>
+        </ECCustomAttributes>
+        <ECProperty propertyName="IntegerProperty1" typeName="int" description="Test property1."/>
+		<ECProperty propertyName="IntegerProperty2" typeName="int" description="Test property2."/>
+		<ECProperty propertyName="IntegerProperty3" typeName="int" description="Test property3."/>
+		<ECProperty propertyName="IntegerProperty4" typeName="int" description="Test property4."/>
+    </ECEntityClass>
+
+    <ECEntityClass typeName="AnotherTestElement" displayLabel="Test label2" description="Test element description.">
+        <BaseClass>bis:PhysicalElement</BaseClass>
+        <ECCustomAttributes>
+            <ClassHasHandler xmlns="BisCore.01.00.00"/>
+        </ECCustomAttributes>
+        <ECProperty propertyName="IntegerProperty5" typeName="int" description="Test property5."/>
+    </ECEntityClass>
+</ECSchema>

--- a/iModelCore/iModelPlatform/Tests/DgnProject/ECSchemas/TestSchema.01.00.00.ecschema.xml
+++ b/iModelCore/iModelPlatform/Tests/DgnProject/ECSchemas/TestSchema.01.00.00.ecschema.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- =====================================================================================
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See COPYRIGHT.md in the repository root for full copyright notice.
+========================================================================================== -->
+<ECSchema schemaName="TestSchema" alias="testSchema" version="01.00.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+    <ECEnumeration typeName="SchemaLayer" backingTypeName="string" isStrict="true" description="Defines the layers in the BIS schema hierarchy.">
+        <ECEnumerator name="Core"               displayLabel="Core"                value="Core"               description="Layer for schemas that define the most fundamental concepts and key organizational strategies for all other BIS schemas."/>
+        <ECEnumerator name="Common"             displayLabel="Common"              value="Common"             description="Layer for schemas that define abstract concepts and patterns used by multiple disciplines."/>
+        <ECEnumerator name="DisciplinePhysical" displayLabel="Discipline-Physical" value="DisciplinePhysical" description="Layer for schemas that focus on physical/spatial and closely associated concepts, in light of a specific discipline."/>
+        <ECEnumerator name="DisciplineOther"    displayLabel="Discipline-Other"    value="DisciplineOther"    description="Layer for schemas that define concepts from modeling perspectives other than physical, in light of a specific discipline."/>
+        <ECEnumerator name="Application"        displayLabel="Application"         value="Application"        description="Layer for schemas that define concepts that no other schema would need or want to reference."/>
+    </ECEnumeration>
+
+    <ECCustomAttributeClass typeName="SchemaLayerInfo" appliesTo="Schema" modifier="Sealed" description="Declares the target layer in the BIS schema hierarchy for a schema.">
+        <ECProperty propertyName="Value" typeName="SchemaLayer" description="Layer in the BIS schema hierarchy that a schema targets." />
+    </ECCustomAttributeClass>
+</ECSchema>


### PR DESCRIPTION
When the status of registered domain is `SchemaUpgradeRecommended` and on its one of reference schema's we get `SchemaNotFound` status then in this case we should be returning the same status as domain schema. 

TS: 4682