### PR TITLE
Presentation: API for convenient hierarchy validation

### DIFF
--- a/iModelCore/ECPresentation/Tests/NonPublished/Helpers/TestHelpers.cpp
+++ b/iModelCore/ECPresentation/Tests/NonPublished/Helpers/TestHelpers.cpp
@@ -739,16 +739,30 @@ static void VerifyInstanceKeysMatch(bvector<RefCountedPtr<IECInstance const>> co
 /*---------------------------------------------------------------------------------**//**
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/
-void RulesEngineTestHelpers::ValidateNodeInstances(ECDbCR connection, NavNodeCR node, bvector<RefCountedPtr<IECInstance const>> const& instances)
+void RulesEngineTestHelpers::ValidateNodeInstances(ECDbCR db, NavNodeCR node, bvector<RefCountedPtr<IECInstance const>> const& instances)
     {
-    auto nodeInstanceKeys = ReadNodeInstanceKeys(connection, static_cast<NavNodeCR>(node));
+    auto nodeInstanceKeys = ReadNodeInstanceKeys(db, static_cast<NavNodeCR>(node));
     VerifyInstanceKeysMatch(instances, nodeInstanceKeys);
 
     if (node.GetKey()->AsECInstanceNodeKey())
+        VerifyInstanceKeysMatch(instances, GetECInstanceNodeKeys(node));
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+void RulesEngineTestHelpers::ValidateNodeInstances(INodeInstanceKeysProvider const& instanceKeysProvider, NavNodeCR node, bvector<RefCountedPtr<IECInstance const>> const& instances)
+    {
+    bset<ECInstanceKey> nodeInstanceKeys;
+    instanceKeysProvider.IterateInstanceKeys(node, [&nodeInstanceKeys](ECInstanceKeyCR k)
         {
-        auto nodeKeyInstanceKeys = GetECInstanceNodeKeys(node);
-        VerifyInstanceKeysMatch(instances, nodeKeyInstanceKeys);
-        }
+        nodeInstanceKeys.insert(k);
+        return true;
+        });
+    VerifyInstanceKeysMatch(instances, nodeInstanceKeys);
+
+    if (node.GetKey()->AsECInstanceNodeKey())
+        VerifyInstanceKeysMatch(instances, GetECInstanceNodeKeys(node));
     }
 
 /*---------------------------------------------------------------------------------**//**

--- a/iModelCore/ECPresentation/Tests/NonPublished/Helpers/TestHelpers.h
+++ b/iModelCore/ECPresentation/Tests/NonPublished/Helpers/TestHelpers.h
@@ -111,7 +111,8 @@ struct RulesEngineTestHelpers
     static void ValidateContentSet(bvector<ECN::IECInstanceCP> instances, Content const& content, bool validateOrder = false);
     static void ValidateContentSet(bvector<InstanceInputAndResult> instances, Content const& content, bool validateOrder = false);
     static void ValidateNodesPagination(std::function<NodesResponse(PageOptionsCR)> getter, bvector<NavNodeCPtr> const& expectedNodes);
-    static void ValidateNodeInstances(ECDbCR connection, NavNodeCR node, bvector<RefCountedPtr<IECInstance const>> const& instances);
+    static void ValidateNodeInstances(ECDbCR, NavNodeCR node, bvector<RefCountedPtr<IECInstance const>> const& instances);
+    static void ValidateNodeInstances(INodeInstanceKeysProvider const&, NavNodeCR node, bvector<RefCountedPtr<IECInstance const>> const& instances);
     static void ValidateNodeGroupedValues(NavNodeCR node, bvector<ECValue> const& groupedValues);
     static NavNodesContainer GetValidatedNodes(std::function<NodesResponse()> getter);
     static NavNodesContainer GetValidatedNodes(std::function<NodesResponse(PageOptionsCR)> nodesGetter, std::function<NodesCountResponse()> countGetter);

--- a/iModelCore/ECPresentation/Tests/NonPublished/Integration/Hierarchies/HierarchiesWithRulesetVariablesTests.cpp
+++ b/iModelCore/ECPresentation/Tests/NonPublished/Integration/Hierarchies/HierarchiesWithRulesetVariablesTests.cpp
@@ -23,34 +23,30 @@ TEST_F(RulesDrivenECPresentationManagerNavigationTests, RulesetVariables_Returns
     RootNodeRule* rootRule = new RootNodeRule("", 1000, false, TargetTree_Both, true);
     rules->AddPresentationRule(*rootRule);
     rootRule->AddSpecification(*new InstanceNodesOfSpecificClassesSpecification(1, ChildrenHint::Unknown, false, false, false, false,
-        "GetVariableIntValue(\"instance_id\")=this.ECInstanceId", classA->GetFullName(), false));
+        "GetVariableIntValue(\"instance_id\") = this.ECInstanceId", classA->GetFullName(), false));
 
-    // request for nodes
-    DataContainer<NavNodeCPtr> rootNodesWithDefaultVariables = RulesEngineTestHelpers::GetValidatedNodes(
-        [&](PageOptionsCR pageOptions){ return m_manager->GetNodes(MakePaged(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables(), nullptr), pageOptions)).get(); },
-        [&](){ return m_manager->GetNodesCount(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables(), nullptr)).get(); }
-        );
-    ASSERT_EQ(0, rootNodesWithDefaultVariables.GetSize());
+    // 0 root nodes with no ruleset variables
+    ValidateHierarchy(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables(), nullptr),
+        {
+        });
 
+    // returns node for `instance1`
     RulesetVariables rulesetVariables1{
         RulesetVariableEntry("instance_id", BeInt64Id::FromString(instance1->GetInstanceId().c_str())),
         };
-    DataContainer<NavNodeCPtr> rootNodes1 = RulesEngineTestHelpers::GetValidatedNodes(
-        [&](PageOptionsCR pageOptions){ return m_manager->GetNodes(MakePaged(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), rulesetVariables1, nullptr), pageOptions)).get(); },
-        [&](){ return m_manager->GetNodesCount(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), rulesetVariables1, nullptr)).get(); }
-        );
-    ASSERT_EQ(1, rootNodes1.GetSize());
-    VerifyNodeInstance(*rootNodes1[0], *instance1);
+    ValidateHierarchy(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), rulesetVariables1, nullptr),
+        {
+        CreateInstanceNodeValidator({ instance1 }),
+        });
 
+    // returns node for `instance2`
     RulesetVariables rulesetVariables2{
         RulesetVariableEntry("instance_id", BeInt64Id::FromString(instance2->GetInstanceId().c_str())),
         };
-    DataContainer<NavNodeCPtr> rootNodes2 = RulesEngineTestHelpers::GetValidatedNodes(
-        [&](PageOptionsCR pageOptions){ return m_manager->GetNodes(MakePaged(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), rulesetVariables2, nullptr), pageOptions)).get(); },
-        [&](){ return m_manager->GetNodesCount(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), rulesetVariables2, nullptr)).get(); }
-        );
-    ASSERT_EQ(1, rootNodes2.GetSize());
-    VerifyNodeInstance(*rootNodes2[0], *instance2);
+    ValidateHierarchy(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), rulesetVariables2, nullptr),
+        {
+        CreateInstanceNodeValidator({ instance2 }),
+        });
     }
 
 /*---------------------------------------------------------------------------------**//**
@@ -72,27 +68,20 @@ TEST_F(RulesDrivenECPresentationManagerNavigationTests, RulesetVariables_Returns
     rules->AddPresentationRule(*rootRule);
     rootRule->AddSpecification(*new InstanceNodesOfSpecificClassesSpecification(1, ChildrenHint::Unknown, false, false, false, false,
         "GetVariableBoolValue(\"show_instances\")", classA->GetFullName(), false));
+    rootRule->AddSpecification(*CreateCustomNodeSpecification("custom"));
 
-    rootRule->AddSpecification(*new CustomNodeSpecification(1, false, "TYPE_Custom", "Custom Node", "", ""));
+    // doesn't return nodes from disabled spec
+    ValidateHierarchy(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables(), nullptr),
+        {
+        CreateCustomNodeValidator("custom"),
+        });
 
-    // request for nodes
-    DataContainer<NavNodeCPtr> rootNodesWithDefaultVariables = RulesEngineTestHelpers::GetValidatedNodes(
-        [&](PageOptionsCR pageOptions){ return m_manager->GetNodes(MakePaged(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables(), nullptr), pageOptions)).get(); },
-        [&](){ return m_manager->GetNodesCount(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables(), nullptr)).get(); }
-        );
-    ASSERT_EQ(1, rootNodesWithDefaultVariables.GetSize());
-    EXPECT_STREQ("Custom Node", rootNodesWithDefaultVariables[0]->GetLabelDefinition().GetDisplayValue().c_str());
-
-    RulesetVariables rulesetVariables{
-        RulesetVariableEntry("show_instances", true),
-        };
-    DataContainer<NavNodeCPtr> rootNodesWithVariables = RulesEngineTestHelpers::GetValidatedNodes(
-        [&](PageOptionsCR pageOptions){ return m_manager->GetNodes(MakePaged(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), rulesetVariables, nullptr), pageOptions)).get(); },
-        [&](){ return m_manager->GetNodesCount(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), rulesetVariables, nullptr)).get(); }
-        );
-    ASSERT_EQ(2, rootNodesWithVariables.GetSize());
-    VerifyNodeInstance(*rootNodesWithVariables[0], *instance);
-    EXPECT_STREQ("Custom Node", rootNodesWithVariables[1]->GetLabelDefinition().GetDisplayValue().c_str());
+    // returns nodes from enabled spec
+    ValidateHierarchy(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables({ RulesetVariableEntry("show_instances", true) }), nullptr),
+        {
+        CreateInstanceNodeValidator({ instance }),
+        CreateCustomNodeValidator("custom"),
+        });
     }
 
 /*---------------------------------------------------------------------------------**//**
@@ -115,32 +104,22 @@ TEST_F(RulesDrivenECPresentationManagerNavigationTests, RulesetVariables_Returns
     rootRule->AddSpecification(*new InstanceNodesOfSpecificClassesSpecification(1, ChildrenHint::Unknown, false, false, false, false,
         "NOT GetVariableBoolValue(\"hide_instances\")", classA->GetFullName(), false));
 
-    // request for nodes
-    DataContainer<NavNodeCPtr> rootNodes = RulesEngineTestHelpers::GetValidatedNodes(
-        [&](PageOptionsCR pageOptions){ return m_manager->GetNodes(MakePaged(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables(), nullptr), pageOptions)).get(); },
-        [&](){ return m_manager->GetNodesCount(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables(), nullptr)).get(); }
-        );
-    ASSERT_EQ(1, rootNodes.GetSize());
-    VerifyNodeInstance(*rootNodes[0], *instance);
+    // returns nodes when variable is not set
+    ValidateHierarchy(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables(), nullptr),
+        {
+        CreateInstanceNodeValidator({ instance }),
+        });
 
-    RulesetVariables rulesetVariables1{
-        RulesetVariableEntry("hide_instances", false),
-        };
-    rootNodes = RulesEngineTestHelpers::GetValidatedNodes(
-        [&](PageOptionsCR pageOptions){ return m_manager->GetNodes(MakePaged(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), rulesetVariables1, nullptr), pageOptions)).get(); },
-        [&](){ return m_manager->GetNodesCount(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), rulesetVariables1, nullptr)).get(); }
-        );
-    ASSERT_EQ(1, rootNodes.GetSize());
-    VerifyNodeInstance(*rootNodes[0], *instance);
+    // returns nodes when `hide_instances = false`
+    ValidateHierarchy(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables({ RulesetVariableEntry("hide_instances", false) }), nullptr),
+        {
+        CreateInstanceNodeValidator({ instance }),
+        });
 
-    RulesetVariables rulesetVariables2{
-        RulesetVariableEntry("hide_instances", true),
-        };
-    rootNodes = RulesEngineTestHelpers::GetValidatedNodes(
-        [&](PageOptionsCR pageOptions){ return m_manager->GetNodes(MakePaged(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), rulesetVariables2, nullptr), pageOptions)).get(); },
-        [&](){ return m_manager->GetNodesCount(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), rulesetVariables2, nullptr)).get(); }
-        );
-    ASSERT_EQ(0, rootNodes.GetSize());
+    // doesn't return nodes when `hide_instances = true`
+    ValidateHierarchy(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables({ RulesetVariableEntry("hide_instances", true) }), nullptr),
+        {
+        });
     }
 
 /*---------------------------------------------------------------------------------**//**
@@ -162,38 +141,27 @@ TEST_F(RulesDrivenECPresentationManagerNavigationTests, RulesetVariables_Returns
     rules->AddPresentationRule(*rootRule);
     rootRule->AddSpecification(*new InstanceNodesOfSpecificClassesSpecification(1, ChildrenHint::Unknown, false, false, false, false,
         "NOT GetVariableBoolValue(\"hide_instances\")", classA->GetFullName(), false));
+    rootRule->AddSpecification(*CreateCustomNodeSpecification("custom"));
 
-    rootRule->AddSpecification(*new CustomNodeSpecification(1, false, "TYPE_Custom", "Custom Node", "", ""));
+    // returns nodes from both specs when variable is not set
+    ValidateHierarchy(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables(), nullptr),
+        {
+        CreateInstanceNodeValidator({ instance }),
+        CreateCustomNodeValidator("custom"),
+        });
 
-    // request for nodes
-    DataContainer<NavNodeCPtr> rootNodes = RulesEngineTestHelpers::GetValidatedNodes(
-        [&](PageOptionsCR pageOptions){ return m_manager->GetNodes(MakePaged(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables(), nullptr), pageOptions)).get(); },
-        [&](){ return m_manager->GetNodesCount(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables(), nullptr)).get(); }
-        );
-    ASSERT_EQ(2, rootNodes.GetSize());
-    VerifyNodeInstance(*rootNodes[0], *instance);
-    EXPECT_STREQ("Custom Node", rootNodes[1]->GetLabelDefinition().GetDisplayValue().c_str());
+    // returns nodes from both specs when `hide_instances = false`
+    ValidateHierarchy(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables({ RulesetVariableEntry("hide_instances", false) }), nullptr),
+        {
+        CreateInstanceNodeValidator({ instance }),
+        CreateCustomNodeValidator("custom"),
+        });
 
-    RulesetVariables rulesetVariables1{
-        RulesetVariableEntry("hide_instances", false),
-        };
-    rootNodes = RulesEngineTestHelpers::GetValidatedNodes(
-        [&](PageOptionsCR pageOptions){ return m_manager->GetNodes(MakePaged(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), rulesetVariables1, nullptr), pageOptions)).get(); },
-        [&](){ return m_manager->GetNodesCount(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), rulesetVariables1, nullptr)).get(); }
-        );
-    ASSERT_EQ(2, rootNodes.GetSize());
-    VerifyNodeInstance(*rootNodes[0], *instance);
-    EXPECT_STREQ("Custom Node", rootNodes[1]->GetLabelDefinition().GetDisplayValue().c_str());
-
-    RulesetVariables rulesetVariables2{
-        RulesetVariableEntry("hide_instances", true),
-        };
-    rootNodes = RulesEngineTestHelpers::GetValidatedNodes(
-        [&](PageOptionsCR pageOptions){ return m_manager->GetNodes(MakePaged(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), rulesetVariables2, nullptr), pageOptions)).get(); },
-        [&](){ return m_manager->GetNodesCount(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), rulesetVariables2, nullptr)).get(); }
-        );
-    ASSERT_EQ(1, rootNodes.GetSize());
-    EXPECT_STREQ("Custom Node", rootNodes[0]->GetLabelDefinition().GetDisplayValue().c_str());
+    // returns node from only one spec when `hide_instances = true`
+    ValidateHierarchy(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables({ RulesetVariableEntry("hide_instances", true) }), nullptr),
+        {
+        CreateCustomNodeValidator("custom"),
+        });
     }
 
 /*---------------------------------------------------------------------------------**//**
@@ -221,30 +189,22 @@ TEST_F(RulesDrivenECPresentationManagerNavigationTests, RulesetVariables_Returns
     rootRule->AddSpecification(*new InstanceNodesOfSpecificClassesSpecification(1, ChildrenHint::Unknown, false, false, false, false,
         "GetVariableBoolValue(\"show_b\")", classB->GetFullName(), false));
 
-    // request for nodes
-    DataContainer<NavNodeCPtr> rootNodes = RulesEngineTestHelpers::GetValidatedNodes(
-        [&](PageOptionsCR pageOptions){ return m_manager->GetNodes(MakePaged(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables(), nullptr), pageOptions)).get(); },
-        [&](){ return m_manager->GetNodesCount(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables(), nullptr)).get(); }
-        );
-    ASSERT_EQ(1, rootNodes.GetSize());
-    VerifyNodeInstance(*rootNodes[0], *a);
+    // returns nodes from A spec when no variables are set
+    ValidateHierarchy(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables(), nullptr),
+        {
+        CreateInstanceNodeValidator({ a }),
+        });
 
-    RulesetVariables rulesetVariables{
-        RulesetVariableEntry("hide_a", true),
-        };
-    rootNodes = RulesEngineTestHelpers::GetValidatedNodes(
-        [&](PageOptionsCR pageOptions){ return m_manager->GetNodes(MakePaged(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), rulesetVariables, nullptr), pageOptions)).get(); },
-        [&](){ return m_manager->GetNodesCount(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), rulesetVariables, nullptr)).get(); }
-        );
-    ASSERT_EQ(0, rootNodes.GetSize());
+    // returns no nodes when `hide_a = true`
+    ValidateHierarchy(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables({ RulesetVariableEntry("hide_a", true) }), nullptr),
+        {
+        });
 
-    rulesetVariables.SetBoolValue("show_b", true);
-    rootNodes = RulesEngineTestHelpers::GetValidatedNodes(
-        [&](PageOptionsCR pageOptions){ return m_manager->GetNodes(MakePaged(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), rulesetVariables, nullptr), pageOptions)).get(); },
-        [&](){ return m_manager->GetNodesCount(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), rulesetVariables, nullptr)).get(); }
-        );
-    ASSERT_EQ(1, rootNodes.GetSize());
-    VerifyNodeInstance(*rootNodes[0], *b);
+    // returns nodes from B spec when `hide_a = true` and `show_b = true`
+    ValidateHierarchy(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables({ RulesetVariableEntry("hide_a", true), RulesetVariableEntry("show_b", true) }), nullptr),
+        {
+        CreateInstanceNodeValidator({ b }),
+        });
     }
 
 /*---------------------------------------------------------------------------------**//**
@@ -272,30 +232,22 @@ TEST_F(RulesDrivenECPresentationManagerNavigationTests, RulesetVariables_Returns
     rootRule->AddSpecification(*new InstanceNodesOfSpecificClassesSpecification(1, ChildrenHint::Unknown, false, false, false, false,
         "NOT GetVariableBoolValue(\"hide_b\")", classB->GetFullName(), false));
 
-    // request for nodes
-    DataContainer<NavNodeCPtr> rootNodes = RulesEngineTestHelpers::GetValidatedNodes(
-        [&](PageOptionsCR pageOptions){ return m_manager->GetNodes(MakePaged(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables(), nullptr), pageOptions)).get(); },
-        [&](){ return m_manager->GetNodesCount(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables(), nullptr)).get(); }
-        );
-    ASSERT_EQ(1, rootNodes.GetSize());
-    VerifyNodeInstance(*rootNodes[0], *b);
+    // returns nodes from B spec when no variables are set
+    ValidateHierarchy(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables(), nullptr),
+        {
+        CreateInstanceNodeValidator({ b }),
+        });
 
-    RulesetVariables rulesetVariables{
-        RulesetVariableEntry("hide_b", true),
-        };
-    rootNodes = RulesEngineTestHelpers::GetValidatedNodes(
-        [&](PageOptionsCR pageOptions){ return m_manager->GetNodes(MakePaged(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), rulesetVariables, nullptr), pageOptions)).get(); },
-        [&](){ return m_manager->GetNodesCount(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), rulesetVariables, nullptr)).get(); }
-        );
-    ASSERT_EQ(0, rootNodes.GetSize());
+    // returns no nodes when `hide_b = true`
+    ValidateHierarchy(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables({ RulesetVariableEntry("hide_b", true) }), nullptr),
+        {
+        });
 
-    rulesetVariables.SetBoolValue("show_a", true);
-    rootNodes = RulesEngineTestHelpers::GetValidatedNodes(
-        [&](PageOptionsCR pageOptions){ return m_manager->GetNodes(MakePaged(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), rulesetVariables, nullptr), pageOptions)).get(); },
-        [&](){ return m_manager->GetNodesCount(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), rulesetVariables, nullptr)).get(); }
-        );
-    ASSERT_EQ(1, rootNodes.GetSize());
-    VerifyNodeInstance(*rootNodes[0], *a);
+    // returns nodes from A spec when `hide_b = true` and `show_a = true`
+    ValidateHierarchy(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables({ RulesetVariableEntry("hide_b", true), RulesetVariableEntry("show_a", true) }), nullptr),
+        {
+        CreateInstanceNodeValidator({ a }),
+        });
     }
 
 /*---------------------------------------------------------------------------------**//**
@@ -342,37 +294,21 @@ TEST_F(RulesDrivenECPresentationManagerNavigationTests, RulesetVariables_Returns
         new RepeatableRelationshipPathSpecification(*new RepeatableRelationshipStepSpecification(rel->GetFullName(), RequiredRelationDirection_Forward)),
         }));
 
-    // request for nodes
-    DataContainer<NavNodeCPtr> rootNodes = RulesEngineTestHelpers::GetValidatedNodes(
-        [&](PageOptionsCR pageOptions){ return m_manager->GetNodes(MakePaged(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables(), nullptr), pageOptions)).get(); },
-        [&](){ return m_manager->GetNodesCount(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables(), nullptr)).get(); }
-        );
-    ASSERT_EQ(1, rootNodes.GetSize());
-    VerifyNodeInstance(*rootNodes[0], *a);
+    // returns no children when no variables set
+    ValidateHierarchy(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables(), nullptr),
+        {
+        CreateInstanceNodeValidator({ a }),
+        });
 
-    DataContainer<NavNodeCPtr> aChildren = RulesEngineTestHelpers::GetValidatedNodes(
-        [&](PageOptionsCR pageOptions){ return m_manager->GetNodes(MakePaged(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables(), rootNodes[0].get()), pageOptions)).get(); },
-        [&](){ return m_manager->GetNodesCount(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables(), rootNodes[0].get())).get(); }
-        );
-    ASSERT_EQ(0, aChildren.GetSize());
-
-    RulesetVariables rulesetVariables{
-        RulesetVariableEntry("show_children", true),
-        };
-    rootNodes = RulesEngineTestHelpers::GetValidatedNodes(
-        [&](PageOptionsCR pageOptions){ return m_manager->GetNodes(MakePaged(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), rulesetVariables, nullptr), pageOptions)).get(); },
-        [&](){ return m_manager->GetNodesCount(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), rulesetVariables, nullptr)).get(); }
-        );
-    ASSERT_EQ(1, rootNodes.GetSize());
-    VerifyNodeInstance(*rootNodes[0], *a);
-
-    aChildren = RulesEngineTestHelpers::GetValidatedNodes(
-        [&](PageOptionsCR pageOptions){ return m_manager->GetNodes(MakePaged(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), rulesetVariables, rootNodes[0].get()), pageOptions)).get(); },
-        [&](){ return m_manager->GetNodesCount(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), rulesetVariables, rootNodes[0].get())).get(); }
-        );
-    ASSERT_EQ(2, aChildren.GetSize());
-    VerifyNodeInstance(*aChildren[0], *b1);
-    VerifyNodeInstance(*aChildren[1], *b2);
+    // returns children when `show_children = true`
+    ValidateHierarchy(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables({ RulesetVariableEntry("show_children", true) }), nullptr),
+        {
+        ExpectedHierarchyDef(CreateInstanceNodeValidator({ a }),
+            {
+            CreateInstanceNodeValidator({ b1 }),
+            CreateInstanceNodeValidator({ b2 }),
+            }),
+        });
     }
 
 /*---------------------------------------------------------------------------------**//**
@@ -418,42 +354,27 @@ TEST_F(RulesDrivenECPresentationManagerNavigationTests, RulesetVariables_Returns
         {
         new RepeatableRelationshipPathSpecification(*new RepeatableRelationshipStepSpecification(rel->GetFullName(), RequiredRelationDirection_Forward)),
         }));
+    childRule->AddSpecification(*CreateCustomNodeSpecification("custom"));
 
-    childRule->AddSpecification(*new CustomNodeSpecification(1, false, "TYPE_Custom", "Custom Node", "", ""));
+    // returns only custom node child when no variables set
+    ValidateHierarchy(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables(), nullptr),
+        {
+        ExpectedHierarchyDef(CreateInstanceNodeValidator({ a }),
+            {
+            CreateCustomNodeValidator("custom"),
+            }),
+        });
 
-    // request for nodes
-    DataContainer<NavNodeCPtr> rootNodes = RulesEngineTestHelpers::GetValidatedNodes(
-        [&](PageOptionsCR pageOptions){ return m_manager->GetNodes(MakePaged(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables(), nullptr), pageOptions)).get(); },
-        [&](){ return m_manager->GetNodesCount(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables(), nullptr)).get(); }
-        );
-    ASSERT_EQ(1, rootNodes.GetSize());
-    VerifyNodeInstance(*rootNodes[0], *a);
-
-    DataContainer<NavNodeCPtr> aChildren = RulesEngineTestHelpers::GetValidatedNodes(
-        [&](PageOptionsCR pageOptions){ return m_manager->GetNodes(MakePaged(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables(), rootNodes[0].get()), pageOptions)).get(); },
-        [&](){ return m_manager->GetNodesCount(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables(), rootNodes[0].get())).get(); }
-        );
-    ASSERT_EQ(1, aChildren.GetSize());
-    EXPECT_STREQ("Custom Node", aChildren[0]->GetLabelDefinition().GetDisplayValue().c_str());
-
-    RulesetVariables rulesetVariables{
-        RulesetVariableEntry("show_children", true),
-        };
-    rootNodes = RulesEngineTestHelpers::GetValidatedNodes(
-        [&](PageOptionsCR pageOptions){ return m_manager->GetNodes(MakePaged(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), rulesetVariables, nullptr), pageOptions)).get(); },
-        [&](){ return m_manager->GetNodesCount(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), rulesetVariables, nullptr)).get(); }
-        );
-    ASSERT_EQ(1, rootNodes.GetSize());
-    VerifyNodeInstance(*rootNodes[0], *a);
-
-    aChildren = RulesEngineTestHelpers::GetValidatedNodes(
-        [&](PageOptionsCR pageOptions){ return m_manager->GetNodes(MakePaged(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), rulesetVariables, rootNodes[0].get()), pageOptions)).get(); },
-        [&](){ return m_manager->GetNodesCount(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), rulesetVariables, rootNodes[0].get())).get(); }
-        );
-    ASSERT_EQ(3, aChildren.GetSize());
-    VerifyNodeInstance(*aChildren[0], *b1);
-    VerifyNodeInstance(*aChildren[1], *b2);
-    EXPECT_STREQ("Custom Node", aChildren[2]->GetLabelDefinition().GetDisplayValue().c_str());
+    // returns all children when `show_children = true`
+    ValidateHierarchy(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables({ RulesetVariableEntry("show_children", true) }), nullptr),
+        {
+        ExpectedHierarchyDef(CreateInstanceNodeValidator({ a }),
+            {
+            CreateInstanceNodeValidator({ b1 }),
+            CreateInstanceNodeValidator({ b2 }),
+            CreateCustomNodeValidator("custom"),
+            }),
+        });
     }
 
 /*---------------------------------------------------------------------------------**//**
@@ -488,30 +409,22 @@ TEST_F(RulesDrivenECPresentationManagerNavigationTests, RulesetVariables_Returns
     bCondition->AddSpecification(*new InstanceNodesOfSpecificClassesSpecification(1, ChildrenHint::Unknown, false, false, false, false,
         "", classB->GetFullName(), false));
 
-    // request for nodes
-    DataContainer<NavNodeCPtr> rootNodes = RulesEngineTestHelpers::GetValidatedNodes(
-        [&](PageOptionsCR pageOptions){ return m_manager->GetNodes(MakePaged(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables(), nullptr), pageOptions)).get(); },
-        [&](){ return m_manager->GetNodesCount(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables(), nullptr)).get(); }
-        );
-    ASSERT_EQ(0, rootNodes.GetSize());
+    // doesn't return nodes when no variables set
+    ValidateHierarchy(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables(), nullptr),
+        {
+        });
 
-    RulesetVariables rulesetVariables{
-        RulesetVariableEntry("ViewType", "A"),
-        };
-    rootNodes = RulesEngineTestHelpers::GetValidatedNodes(
-        [&](PageOptionsCR pageOptions){ return m_manager->GetNodes(MakePaged(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), rulesetVariables, nullptr), pageOptions)).get(); },
-        [&](){ return m_manager->GetNodesCount(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), rulesetVariables, nullptr)).get(); }
-        );
-    ASSERT_EQ(1, rootNodes.GetSize());
-    VerifyNodeInstance(*rootNodes[0], *a);
+    // returns A nodes when `ViewType = "A"`
+    ValidateHierarchy(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables({ RulesetVariableEntry("ViewType", "A") }), nullptr),
+        {
+        CreateInstanceNodeValidator({ a }),
+        });
 
-    rulesetVariables.SetStringValue("ViewType", "B");
-    rootNodes = RulesEngineTestHelpers::GetValidatedNodes(
-        [&](PageOptionsCR pageOptions){ return m_manager->GetNodes(MakePaged(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), rulesetVariables, nullptr), pageOptions)).get(); },
-        [&](){ return m_manager->GetNodesCount(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), rulesetVariables, nullptr)).get(); }
-        );
-    ASSERT_EQ(1, rootNodes.GetSize());
-    VerifyNodeInstance(*rootNodes[0], *b);
+    // returns B nodes when `ViewType = "B"`
+    ValidateHierarchy(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables({ RulesetVariableEntry("ViewType", "B") }), nullptr),
+        {
+        CreateInstanceNodeValidator({ b }),
+        });
     }
 
 /*---------------------------------------------------------------------------------**//**
@@ -531,24 +444,20 @@ TEST_F(RulesDrivenECPresentationManagerNavigationTests, RulesetVariables_Returns
     rules->AddPresentationRule(*childRule);
     childRule->AddSpecification(*CreateCustomNodeSpecification("child"));
 
-    // verify nodes
-    RulesetVariables rulesetVariables{
-        RulesetVariableEntry("show_child", true),
-        };
-    DataContainer<NavNodeCPtr> rootNodes1 = RulesEngineTestHelpers::GetValidatedNodes(
-        [&](PageOptionsCR pageOptions){ return m_manager->GetNodes(MakePaged(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), rulesetVariables, nullptr), pageOptions)).get(); },
-        [&](){ return m_manager->GetNodesCount(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), rulesetVariables, nullptr)).get(); }
-        );
-    ASSERT_EQ(1, rootNodes1.GetSize());
-    EXPECT_STREQ("root", rootNodes1[0]->GetType().c_str());
-    EXPECT_TRUE(rootNodes1[0]->HasChildren());
+    // returns children when `show_child = true`
+    ValidateHierarchy(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables({ RulesetVariableEntry("show_child", true) }), nullptr),
+        {
+        ExpectedHierarchyDef(CreateCustomNodeValidator("root"),
+            {
+            CreateCustomNodeValidator("child")
+            }),
+        });
 
-    rulesetVariables.SetBoolValue("show_child", false);
-    DataContainer<NavNodeCPtr> rootNodes2 = RulesEngineTestHelpers::GetValidatedNodes(
-        [&](PageOptionsCR pageOptions){ return m_manager->GetNodes(MakePaged(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), rulesetVariables, nullptr), pageOptions)).get(); },
-        [&](){ return m_manager->GetNodesCount(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), rulesetVariables, nullptr)).get(); }
-        );
-    ASSERT_EQ(1, rootNodes2.GetSize());
-    EXPECT_STREQ("root", rootNodes2[0]->GetType().c_str());
-    EXPECT_FALSE(rootNodes2[0]->HasChildren());
+    // doesn't return children when `show_child = false`
+    ValidateHierarchy(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables({ RulesetVariableEntry("show_child", false) }), nullptr),
+        {
+        ExpectedHierarchyDef(CreateCustomNodeValidator("root"),
+            {
+            }),
+        });
     }

--- a/iModelCore/ECPresentation/Tests/NonPublished/Integration/Hierarchies/HierarchyIntegrationTests.cpp
+++ b/iModelCore/ECPresentation/Tests/NonPublished/Integration/Hierarchies/HierarchyIntegrationTests.cpp
@@ -13883,7 +13883,7 @@ TEST_F(RulesDrivenECPresentationManagerNavigationTests, CreateChildGroupingNodeW
         [&](){return m_manager->GetNodesCount(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables(), nullptr)).get();}
     );
     ASSERT_EQ(1, groupingNodesA.GetSize());
-    VerifyClassGroupingNode(*groupingNodesA[0], { a }, classA, true, false);
+    VerifyClassGroupingNode(*groupingNodesA[0], { a }, classA, true);
 
     DataContainer<NavNodeCPtr> instanceNodesA = RulesEngineTestHelpers::GetValidatedNodes(
         [&](PageOptionsCR pageOptions){return m_manager->GetNodes(MakePaged(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables(), groupingNodesA[0].get()), pageOptions)).get();},
@@ -13904,7 +13904,7 @@ TEST_F(RulesDrivenECPresentationManagerNavigationTests, CreateChildGroupingNodeW
         [&](){return m_manager->GetNodesCount(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables(), instanceNodesB[0].get())).get(); }
     );
     ASSERT_EQ(1, groupingNodesA2.GetSize());
-    VerifyClassGroupingNode(*groupingNodesA2[0], { a }, classA, true, false);
+    VerifyClassGroupingNode(*groupingNodesA2[0], { a }, classA, true);
 
     DataContainer<NavNodeCPtr> noInstanceNodesA = RulesEngineTestHelpers::GetValidatedNodes(
         [&](PageOptionsCR pageOptions){return m_manager->GetNodes(MakePaged(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables(), groupingNodesA2[0].get()), pageOptions)).get(); },

--- a/iModelCore/ECPresentation/Tests/NonPublished/Integration/PresentationManagerIntegrationTests.cpp
+++ b/iModelCore/ECPresentation/Tests/NonPublished/Integration/PresentationManagerIntegrationTests.cpp
@@ -3,6 +3,7 @@
 * See LICENSE.md in the repository root for full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 #include "PresentationManagerIntegrationTests.h"
+#include "../../../Source/PresentationManagerImpl.h"
 
 USING_NAMESPACE_BENTLEY_EC
 USING_NAMESPACE_BENTLEY_SQLITE_EC
@@ -192,38 +193,38 @@ void PresentationManagerIntegrationTests::SetUpDefaultLabelRule(PresentationRule
 /*---------------------------------------------------------------------------------**//**
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/
-void PresentationManagerIntegrationTests::VerifyNodeInstances(NavNodeCR node, bvector<RefCountedPtr<IECInstance const>> const& instances)
+void PresentationManagerIntegrationTests::VerifyNodeInstances(NavNodeCR node, bvector<RefCountedPtr<IECInstance const>> const& expectedInstances)
     {
-    RulesEngineTestHelpers::ValidateNodeInstances(s_project->GetECDb(), node, instances);
+    auto connection = m_manager->GetConnections().GetConnection(_GetProject());
+    auto instanceKeysProvider = m_manager->GetImpl().CreateNodeInstanceKeysProvider(RequestWithRulesetImplParams::Create(*connection, nullptr, NavNodeExtendedData(node).GetRulesetId(), RulesetVariables()));
+    RulesEngineTestHelpers::ValidateNodeInstances(*instanceKeysProvider, node, expectedInstances);
     }
 
 /*---------------------------------------------------------------------------------**//**
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/
-void PresentationManagerIntegrationTests::VerifyPropertyGroupingNode(NavNodeCR node, bvector<RefCountedPtr<IECInstance const>> const& groupedInstances, bvector<ECValue> const& groupedValues, bool validateInstances)
+void PresentationManagerIntegrationTests::VerifyPropertyGroupingNode(NavNodeCR node, bvector<RefCountedPtr<IECInstance const>> const& groupedInstances, bvector<ECValue> const& groupedValues)
     {
     ASSERT_STREQ(NAVNODE_TYPE_ECPropertyGroupingNode, node.GetType().c_str());
     ASSERT_TRUE(nullptr != node.GetKey()->AsECPropertyGroupingNodeKey());
     RulesEngineTestHelpers::ValidateNodeGroupedValues(node, groupedValues);
-    if (validateInstances)
-        RulesEngineTestHelpers::ValidateNodeInstances(s_project->GetECDb(), node, groupedInstances);
+    VerifyNodeInstances(node, groupedInstances);
     }
 
 /*---------------------------------------------------------------------------------**//**
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/
-void PresentationManagerIntegrationTests::VerifyPropertyRangeGroupingNode(NavNodeCR node, bvector<RefCountedPtr<IECInstance const>> const& groupedInstances, bool validateInstances)
+void PresentationManagerIntegrationTests::VerifyPropertyRangeGroupingNode(NavNodeCR node, bvector<RefCountedPtr<IECInstance const>> const& groupedInstances)
     {
     ASSERT_STREQ(NAVNODE_TYPE_ECPropertyGroupingNode, node.GetType().c_str());
     ASSERT_TRUE(nullptr != node.GetKey()->AsECPropertyGroupingNodeKey());
-    if (validateInstances)
-        RulesEngineTestHelpers::ValidateNodeInstances(s_project->GetECDb(), node, groupedInstances);
+    VerifyNodeInstances(node, groupedInstances);
     }
 
 /*---------------------------------------------------------------------------------**//**
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/
-void PresentationManagerIntegrationTests::VerifyClassGroupingNode(NavNodeCR node, bvector<RefCountedPtr<IECInstance const>> const& groupedInstances, ECClassCP groupingClass, bool isPolymorphicGrouping, bool validateInstances)
+void PresentationManagerIntegrationTests::VerifyClassGroupingNode(NavNodeCR node, bvector<RefCountedPtr<IECInstance const>> const& groupedInstances, ECClassCP groupingClass, bool isPolymorphicGrouping)
     {
     ASSERT_STREQ(NAVNODE_TYPE_ECClassGroupingNode, node.GetType().c_str());
     ASSERT_TRUE(nullptr != node.GetKey()->AsECClassGroupingNodeKey());
@@ -232,19 +233,134 @@ void PresentationManagerIntegrationTests::VerifyClassGroupingNode(NavNodeCR node
         EXPECT_EQ(groupingClass, &node.GetKey()->AsECClassGroupingNodeKey()->GetECClass());
         EXPECT_EQ(isPolymorphicGrouping, node.GetKey()->AsECClassGroupingNodeKey()->IsPolymorphic());
         }
-    if (validateInstances)
-        RulesEngineTestHelpers::ValidateNodeInstances(s_project->GetECDb(), node, groupedInstances);
+    VerifyNodeInstances(node, groupedInstances);
     }
 
 /*---------------------------------------------------------------------------------**//**
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/
-void PresentationManagerIntegrationTests::VerifyLabelGroupingNode(NavNodeCR node, bvector<RefCountedPtr<IECInstance const>> const& groupedInstances, bool validateInstances)
+void PresentationManagerIntegrationTests::VerifyLabelGroupingNode(NavNodeCR node, bvector<RefCountedPtr<IECInstance const>> const& groupedInstances)
     {
     ASSERT_STREQ(NAVNODE_TYPE_DisplayLabelGroupingNode, node.GetType().c_str());
     ASSERT_TRUE(nullptr != node.GetKey()->AsLabelGroupingNodeKey());
-    if (validateInstances)
-        RulesEngineTestHelpers::ValidateNodeInstances(s_project->GetECDb(), node, groupedInstances);
+    VerifyNodeInstances(node, groupedInstances);
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+void PresentationManagerIntegrationTests::VerifyCustomNode(NavNodeCR node, Utf8StringCR type, Nullable<Utf8String> const& label)
+    {
+    ASSERT_STREQ(type.c_str(), node.GetType().c_str());
+    if (!label.IsNull())
+        ASSERT_STREQ(label.Value().c_str(), node.GetLabelDefinition().GetDisplayValue().c_str());
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+bvector<HierarchyDef<>> PresentationManagerIntegrationTests::ValidateHierarchy(AsyncHierarchyRequestParams params, std::function<void(AsyncHierarchyRequestParams&)> const& configureParams, bvector<ExpectedHierarchyDef> const& expectedHierarchy)
+    {
+    if (configureParams)
+        configureParams(params);
+    bvector<HierarchyDef<>> h;
+    auto nodes = RulesEngineTestHelpers::GetValidatedNodes(
+        [&](PageOptions pageOptions) { return m_manager->GetNodes(MakePaged(params, pageOptions)).get(); },
+        [&]() { return m_manager->GetNodesCount(params).get(); }
+    );
+    EXPECT_EQ(expectedHierarchy.size(), nodes.GetSize());
+    for (size_t i = 0; i < expectedHierarchy.size() && i < nodes.GetSize(); ++i)
+        {
+        NavNodeCPtr actualNode = nodes[i];
+        h.push_back(actualNode);
+
+        ExpectedHierarchyDef const& expectation = expectedHierarchy[i];
+        if (expectation.node)
+            expectation.node(*actualNode, params);
+
+        bool expectChildren = expectation.children.size() > 0;
+        EXPECT_EQ(expectChildren, actualNode->HasChildren());
+
+        AsyncHierarchyRequestParams childParams(params);
+        childParams.SetParentNode(actualNode.get());
+        h.back().children = ValidateHierarchy(childParams, configureParams, expectation.children);
+        }
+    return h;
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+bvector<HierarchyDef<>> PresentationManagerIntegrationTests::ValidateHierarchy(AsyncHierarchyRequestParams const& params, bvector<ExpectedHierarchyDef> const& expectedHierarchy)
+    {
+    return ValidateHierarchy(params, nullptr, expectedHierarchy);
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+std::function<void(NavNodeCR, HierarchyRequestParams const&)> PresentationManagerIntegrationTests::CreateInstanceNodeValidator(bvector<RefCountedPtr<IECInstance const>> const& expectedInstances)
+    {
+    return [this, expectedInstances](NavNodeCR n, HierarchyRequestParams const& requestParams)
+        {
+        VerifyNodeInstances(n, expectedInstances);
+        };
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+std::function<void(NavNodeCR, HierarchyRequestParams const&)> PresentationManagerIntegrationTests::CreateClassGroupingNodeValidator(ECClassCR ecClass, bool isPolymorphic, bvector<RefCountedPtr<IECInstance const>> const& expectedInstances)
+    {
+    return [this, &ecClass, isPolymorphic, expectedInstances](NavNodeCR n, HierarchyRequestParams const& requestParams)
+        {
+        VerifyClassGroupingNode(n, expectedInstances, &ecClass, isPolymorphic);
+        };
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+std::function<void(NavNodeCR, HierarchyRequestParams const&)> PresentationManagerIntegrationTests::CreateLabelGroupingNodeValidator(Utf8StringCR label, bvector<RefCountedPtr<IECInstance const>> const& expectedInstances)
+    {
+    return [this, label, expectedInstances](NavNodeCR n, HierarchyRequestParams const& requestParams)
+        {
+        VerifyLabelGroupingNode(n, expectedInstances);
+        EXPECT_STREQ(label.c_str(), n.GetLabelDefinition().GetDisplayValue().c_str());
+        };
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+std::function<void(NavNodeCR, HierarchyRequestParams const&)> PresentationManagerIntegrationTests::CreatePropertyGroupingNodeValidator(bvector<RefCountedPtr<IECInstance const>> const& expectedInstances, ValueList const& groupedValues)
+    {
+    return [this, expectedInstances, groupedValues](NavNodeCR n, HierarchyRequestParams const& requestParams)
+        {
+        VerifyPropertyGroupingNode(n, expectedInstances, groupedValues);
+        };
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+std::function<void(NavNodeCR, HierarchyRequestParams const&)> PresentationManagerIntegrationTests::CreateCustomNodeValidator(Utf8String type, Utf8String label)
+    {
+    return [this, type, label](NavNodeCR n, HierarchyRequestParams const& requestParams)
+        {
+        VerifyCustomNode(n, type, label);
+        };
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+std::function<void(NavNodeCR, HierarchyRequestParams const&)> PresentationManagerIntegrationTests::CreateCustomNodeValidator(Utf8String type)
+    {
+    return [this, type](NavNodeCR n, HierarchyRequestParams const& requestParams)
+        {
+        VerifyCustomNode(n, type, nullptr);
+        };
     }
 
 /*---------------------------------------------------------------------------------**//**

--- a/iModelCore/ECPresentation/Tests/NonPublished/Integration/PresentationManagerIntegrationTests.h
+++ b/iModelCore/ECPresentation/Tests/NonPublished/Integration/PresentationManagerIntegrationTests.h
@@ -12,6 +12,23 @@ BEGIN_ECPRESENTATIONTESTS_NAMESPACE
 /*=================================================================================**//**
 * @bsiclass
 +===============+===============+===============+===============+===============+======*/
+template<typename TNode = NavNodeCPtr>
+struct HierarchyDef
+    {
+    TNode node;
+    bvector<HierarchyDef<TNode>> children;
+    HierarchyDef(TNode n)
+        : node(n)
+        {}
+    HierarchyDef(TNode n, bvector<HierarchyDef<TNode>> c)
+        : node(n), children(c)
+        {}
+    };
+typedef HierarchyDef<std::function<void(NavNodeCR, HierarchyRequestParams const&)>> ExpectedHierarchyDef;
+
+/*=================================================================================**//**
+* @bsiclass
++===============+===============+===============+===============+===============+======*/
 struct PresentationManagerIntegrationTests : ECPresentationTest
     {
     DECLARE_SCHEMA_REGISTRY(PresentationManagerIntegrationTests);
@@ -46,12 +63,22 @@ struct PresentationManagerIntegrationTests : ECPresentationTest
 
     Utf8String GetDefaultDisplayLabel(IECInstanceCR instance);
 
-    void VerifyNodeInstance(NavNodeCR node, IECInstanceCR instance) {VerifyNodeInstances(node, { &instance });}
+    void VerifyNodeInstance(NavNodeCR node, IECInstanceCR instance) { VerifyNodeInstances(node, { &instance }); }
     void VerifyNodeInstances(NavNodeCR node, bvector<RefCountedPtr<IECInstance const>> const& instances);
-    void VerifyPropertyGroupingNode(NavNodeCR node, bvector<RefCountedPtr<IECInstance const>> const& groupedInstances, bvector<ECValue> const& groupedValues, bool validateInstances = true);
-    void VerifyPropertyRangeGroupingNode(NavNodeCR node, bvector<RefCountedPtr<IECInstance const>> const& groupedInstances, bool validateInstances = true);
-    void VerifyClassGroupingNode(NavNodeCR node, bvector<RefCountedPtr<IECInstance const>> const& groupedInstances, ECClassCP groupingClass = nullptr, bool isPolymorphicGrouping = false, bool validateInstances = true);
-    void VerifyLabelGroupingNode(NavNodeCR node, bvector<RefCountedPtr<IECInstance const>> const& groupedInstances, bool validateInstances = true);
+    void VerifyPropertyGroupingNode(NavNodeCR node, bvector<RefCountedPtr<IECInstance const>> const& groupedInstances, bvector<ECValue> const& groupedValues);
+    void VerifyPropertyRangeGroupingNode(NavNodeCR node, bvector<RefCountedPtr<IECInstance const>> const& groupedInstances);
+    void VerifyClassGroupingNode(NavNodeCR node, bvector<RefCountedPtr<IECInstance const>> const& groupedInstances, ECClassCP groupingClass = nullptr, bool isPolymorphicGrouping = false);
+    void VerifyLabelGroupingNode(NavNodeCR node, bvector<RefCountedPtr<IECInstance const>> const& groupedInstances);
+    void VerifyCustomNode(NavNodeCR node, Utf8StringCR type, Nullable<Utf8String> const& label);
+
+    bvector<HierarchyDef<>> ValidateHierarchy(AsyncHierarchyRequestParams params, std::function<void(AsyncHierarchyRequestParams&)> const& configureParams, bvector<ExpectedHierarchyDef> const& expectedHierarchy);
+    bvector<HierarchyDef<>> ValidateHierarchy(AsyncHierarchyRequestParams const& params, bvector<ExpectedHierarchyDef> const& expectedHierarchy);
+    std::function<void(NavNodeCR, HierarchyRequestParams const&)> CreateInstanceNodeValidator(bvector<RefCountedPtr<IECInstance const>> const& expectedInstances);
+    std::function<void(NavNodeCR, HierarchyRequestParams const&)> CreateClassGroupingNodeValidator(ECClassCR ecClass, bool isPolymorphic, bvector<RefCountedPtr<IECInstance const>> const& expectedInstances);
+    std::function<void(NavNodeCR, HierarchyRequestParams const&)> CreateLabelGroupingNodeValidator(Utf8StringCR label, bvector<RefCountedPtr<IECInstance const>> const& expectedInstances);
+    std::function<void(NavNodeCR, HierarchyRequestParams const&)> CreatePropertyGroupingNodeValidator(bvector<RefCountedPtr<IECInstance const>> const& expectedInstances, ValueList const& groupedValues);
+    std::function<void(NavNodeCR, HierarchyRequestParams const&)> CreateCustomNodeValidator(Utf8String type, Utf8String label);
+    std::function<void(NavNodeCR, HierarchyRequestParams const&)> CreateCustomNodeValidator(Utf8String type);
     };
 
 /*=================================================================================**//**


### PR DESCRIPTION
Add an API to conveniently validate produced hierarchies in our integration tests. I only refactored ruleset variables - related integration tests for now.