### PR TITLE
Presentation: Fix unnecessary data source association with ruleset vars

### DIFF
--- a/iModelCore/ECPresentation/Source/Content/ContentProviders.cpp
+++ b/iModelCore/ECPresentation/Source/Content/ContentProviders.cpp
@@ -31,7 +31,6 @@ ContentProviderContext::ContentProviderContext(ContentProviderContextCR other)
     m_categorySupplier(other.m_categorySupplier), m_inputNodeKeys(other.m_inputNodeKeys), m_contentFlags(other.m_contentFlags)
     {
     Init();
-    SetUsedVariablesListener(other, false);
 
     if (other.IsSelectionContext())
         SetSelectionInfo(other);

--- a/iModelCore/ECPresentation/Source/Shared/RulesDrivenProviderContext.cpp
+++ b/iModelCore/ECPresentation/Source/Shared/RulesDrivenProviderContext.cpp
@@ -28,8 +28,7 @@ protected:
             m_parent->OnVariableUsed(variableId);
         }
 public:
-    UsedRulesetVariablesListener() : m_parent(nullptr) {}
-    UsedRulesetVariablesListener(UsedRulesetVariablesListener const& other) : m_variableIds(other.m_variableIds), m_parent(nullptr) {}
+    UsedRulesetVariablesListener(bset<Utf8String> variableIds = {}) : m_parent(nullptr), m_variableIds(variableIds) {}
     bset<Utf8String> const& GetVariableIds() const {BeMutexHolder lock(m_mutex); return m_variableIds;}
     void SetParent(IUsedRulesetVariablesListener* parent) {m_parent = parent;}
 };
@@ -152,7 +151,8 @@ RulesDrivenProviderContext::RulesDrivenProviderContext(PresentationRuleSetCR rul
 +---------------+---------------+---------------+---------------+---------------+------*/
 RulesDrivenProviderContext::RulesDrivenProviderContext(RulesDrivenProviderContextCR other)
     : m_ruleset(other.m_ruleset), m_rulesetVariables(std::make_unique<RulesetVariables>(*other.m_rulesetVariables)), m_relatedPathsCache(other.m_relatedPathsCache),
-    m_ecexpressionsCache(other.m_ecexpressionsCache), m_nodesFactory(other.m_nodesFactory), m_localState(other.m_localState), m_cancelationToken(other.m_cancelationToken)
+    m_ecexpressionsCache(other.m_ecexpressionsCache), m_nodesFactory(other.m_nodesFactory), m_localState(other.m_localState), m_cancelationToken(other.m_cancelationToken),
+    m_usedVariablesListener(other.m_usedVariablesListener)
     {
     Init();
 
@@ -234,25 +234,22 @@ IUsedRulesetVariablesListener& RulesDrivenProviderContext::GetUsedVariablesListe
 /*---------------------------------------------------------------------------------**//**
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/
-void RulesDrivenProviderContext::SetUsedVariablesListener(RulesDrivenProviderContextCR other, bool makeCopy)
+void RulesDrivenProviderContext::InitUsedVariablesListener(bset<Utf8String> const& parentVariables, IUsedRulesetVariablesListener* parentListener)
     {
-    if (makeCopy && other.m_usedVariablesListener.IsValid())
-        {
-        m_usedVariablesListener = new UsedRulesetVariablesListener(*other.m_usedVariablesListener);
-        m_usedVariablesListener->SetParent(other.m_usedVariablesListener.get());
-        return;
-        }
-
-    m_usedVariablesListener = other.m_usedVariablesListener;
+    m_usedVariablesListener = new UsedRulesetVariablesListener(parentVariables);
+    m_usedVariablesListener->SetParent(parentListener);
     }
 
 /*---------------------------------------------------------------------------------**//**
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/
-bset<Utf8String> RulesDrivenProviderContext::GetRelatedVariablesIds() const
+bset<Utf8String> const& RulesDrivenProviderContext::GetRelatedVariablesIds() const
     {
     if (m_usedVariablesListener.IsNull())
-        return bset<Utf8String>();
+        {
+        static bset<Utf8String> const s_empty;
+        return s_empty;
+        }
     return m_usedVariablesListener->GetVariableIds();
     }
 

--- a/iModelCore/ECPresentation/Source/Shared/RulesDrivenProviderContext.h
+++ b/iModelCore/ECPresentation/Source/Shared/RulesDrivenProviderContext.h
@@ -78,8 +78,8 @@ public:
     NavNodesFactory const& GetNodesFactory() const {return m_nodesFactory;}
     RulesetVariables const& GetRulesetVariables() const {return *m_rulesetVariables;}
     ECPRESENTATION_EXPORT IUsedRulesetVariablesListener& GetUsedVariablesListener() const;
-    ECPRESENTATION_EXPORT void SetUsedVariablesListener(RulesDrivenProviderContextCR other, bool makeCopy);
-    bset<Utf8String> GetRelatedVariablesIds() const;
+    ECPRESENTATION_EXPORT void InitUsedVariablesListener(bset<Utf8String> const& parentVariables, IUsedRulesetVariablesListener* parentListener);
+    bset<Utf8String> const& GetRelatedVariablesIds() const;
     ECExpressionsCache& GetECExpressionsCache() const {return m_ecexpressionsCache;}
     IJsonLocalState const* GetLocalState() const {return m_localState;}
     ECPRESENTATION_EXPORT IRulesPreprocessorR GetRulesPreprocessor() const;

--- a/iModelCore/ECPresentation/Tests/NonPublished/Unit/Hierarchies/MultiSpecificationNodesProviderTests.cpp
+++ b/iModelCore/ECPresentation/Tests/NonPublished/Unit/Hierarchies/MultiSpecificationNodesProviderTests.cpp
@@ -161,3 +161,30 @@ TEST_F(MultiSpecificationNodesProviderTests, EvaluatesChildrenArtifactsWhenCheck
 
     EXPECT_EQ(1, captureArtifacts->GetArtifacts().size());
     }
+
+/*---------------------------------------------------------------------------------**//**
+* @bsitest
++---------------+---------------+---------------+---------------+---------------+------*/
+TEST_F(MultiSpecificationNodesProviderTests, AssociatesIndividualProvidersWithTheirRulesetVariables)
+    {
+    m_context->GetUsedVariablesListener().OnVariableUsed("x");
+
+    RootNodeRule rule;
+    InstanceNodesOfSpecificClassesSpecification spec1(1, ChildrenHint::Unknown, false, false, false, false, "HasVariable(\"a\")",
+        { new MultiSchemaClass("ECDbMeta", false, { "ECClassDef" }) }, {});
+    CustomNodeSpecification spec2(1, false, "type2", "label2", "", "imageId");
+    InstanceNodesOfSpecificClassesSpecification spec3(1, ChildrenHint::Unknown, false, false, false, false, "HasVariable(\"b\")",
+        { new MultiSchemaClass("ECDbMeta", false, { "ECSchemaDef" }) }, {});
+
+    RootNodeRuleSpecificationsList specs;
+    specs.push_back(RootNodeRuleSpecification(spec1, rule));
+    specs.push_back(RootNodeRuleSpecification(spec2, rule));
+    specs.push_back(RootNodeRuleSpecification(spec3, rule));
+
+    auto provider = MultiSpecificationNodesProvider::Create(*m_context, specs);
+
+    EXPECT_EQ((bvector<Utf8String>{"a", "b", "x"}), provider->GetRelatedRulesetVariables().GetVariableNames());
+    EXPECT_EQ((bvector<Utf8String>{"a", "x"}), provider->GetNodeProviders()[0]->GetRelatedRulesetVariables().GetVariableNames());
+    EXPECT_EQ((bvector<Utf8String>{"x"}), provider->GetNodeProviders()[1]->GetRelatedRulesetVariables().GetVariableNames());
+    EXPECT_EQ((bvector<Utf8String>{"b", "x"}), provider->GetNodeProviders()[2]->GetRelatedRulesetVariables().GetVariableNames());
+    }


### PR DESCRIPTION
The problem showed up when we had multiple data sources under the same hierarchy level in that case every subsequent data source was associated with variables of all previous data sources.