### PR TITLE
Changed getOriginPropertyName signature to improve usability

### DIFF
--- a/iModelJsNodeAddon/IModelJsNative.cpp
+++ b/iModelJsNodeAddon/IModelJsNative.cpp
@@ -3169,7 +3169,6 @@ struct NativeECSqlColumnInfo : BeObjectWrap<NativeECSqlColumnInfo>
             InstanceMethod("getType", &NativeECSqlColumnInfo::GetType),
             InstanceMethod("getPropertyName", &NativeECSqlColumnInfo::GetPropertyName),
             InstanceMethod("getOriginPropertyName", &NativeECSqlColumnInfo::GetOriginPropertyName),
-            InstanceMethod("hasOriginProperty", &NativeECSqlColumnInfo::HasOriginProperty),
             InstanceMethod("getAccessString", &NativeECSqlColumnInfo::GetAccessString),
             InstanceMethod("isSystemProperty", &NativeECSqlColumnInfo::IsSystemProperty),
             InstanceMethod("isGeneratedProperty", &NativeECSqlColumnInfo::IsGeneratedProperty),
@@ -3299,18 +3298,9 @@ struct NativeECSqlColumnInfo : BeObjectWrap<NativeECSqlColumnInfo>
 
             ECPropertyCP prop = m_colInfo->GetOriginProperty();
             if (prop == nullptr)
-                THROW_JS_EXCEPTION("ECSqlColumnInfo does not have an origin property.");
+                return Env().Undefined();
 
             return toJsString(Env(), prop->GetName());
-            }
-
-        Napi::Value HasOriginProperty(Napi::CallbackInfo const& info)
-            {
-            if (m_colInfo == nullptr)
-                THROW_JS_EXCEPTION("ECSqlColumnInfo is not initialized.");
-
-            ECPropertyCP prop = m_colInfo->GetOriginProperty();
-            return Napi::Boolean::New(Env(), prop != nullptr);
             }
 
         Napi::Value GetAccessString(Napi::CallbackInfo const& info)

--- a/iModelJsNodeAddon/api_package/ts/src/NativeLibrary.ts
+++ b/iModelJsNodeAddon/api_package/ts/src/NativeLibrary.ts
@@ -677,7 +677,7 @@ export declare namespace IModelJsNative {
     constructor();
     public getAccessString(): string;
     public getPropertyName(): string;
-    public getOriginPropertyName(): string;
+    public getOriginPropertyName(): string | undefined;
     public getRootClassAlias(): string;
     public getRootClassName(): string;
     public getRootClassTableSpace(): string;
@@ -685,7 +685,6 @@ export declare namespace IModelJsNative {
     public isEnum(): boolean;
     public isGeneratedProperty(): boolean;
     public isSystemProperty(): boolean;
-    public hasOriginProperty(): boolean;
   }
 
   class ECSqlValue {

--- a/iModelJsNodeAddon/api_package/ts/src/test/SqlStatement.test.ts
+++ b/iModelJsNodeAddon/api_package/ts/src/test/SqlStatement.test.ts
@@ -32,8 +32,7 @@ describe("SQLite statements", () => {
       const colInfo = value.getColumnInfo();
 
       expect(colInfo.getPropertyName()).eq("foo");
-      expect(colInfo.hasOriginProperty()).to.be.false;
-      expect(() => colInfo.getOriginPropertyName()).to.throw("ECSqlColumnInfo does not have an origin property.");
+      expect(colInfo.getOriginPropertyName()).to.be.undefined;
     } finally {
       stmt.dispose();
     }
@@ -49,8 +48,7 @@ describe("SQLite statements", () => {
       const colInfo = value.getColumnInfo();
 
       expect(colInfo.getPropertyName()).to.exist; //we generate a pseudo name automatically
-      expect(colInfo.hasOriginProperty()).to.be.false;
-      expect(() => colInfo.getOriginPropertyName()).to.throw("ECSqlColumnInfo does not have an origin property.");
+      expect(colInfo.getOriginPropertyName()).to.be.undefined;
     } finally {
       stmt.dispose();
     }
@@ -66,8 +64,7 @@ describe("SQLite statements", () => {
       const colInfo = value.getColumnInfo();
 
       expect(colInfo.getPropertyName()).to.exist;
-      expect(colInfo.hasOriginProperty()).to.be.false;
-      expect(() => colInfo.getOriginPropertyName()).to.throw("ECSqlColumnInfo does not have an origin property.");
+      expect(colInfo.getOriginPropertyName()).to.be.undefined;
     } finally {
       stmt.dispose();
     }
@@ -84,8 +81,7 @@ describe("SQLite statements", () => {
       const colInfo = value.getColumnInfo();
 
       expect(colInfo.getPropertyName()).to.exist;
-      expect(colInfo.hasOriginProperty()).to.be.false;
-      expect(() => colInfo.getOriginPropertyName()).to.throw("ECSqlColumnInfo does not have an origin property.");
+      expect(colInfo.getOriginPropertyName()).to.be.undefined;
     } finally {
       stmt.dispose();
     }
@@ -101,7 +97,6 @@ describe("SQLite statements", () => {
       const colInfo = value.getColumnInfo();
 
       expect(colInfo.getPropertyName()).eq("SchemaName");
-      expect(colInfo.hasOriginProperty()).to.be.true;
       expect(colInfo.getOriginPropertyName()).eq("Name");
     } finally {
       stmt.dispose();


### PR DESCRIPTION
Instead of 2 methods there is now only one which returns undefined if no origin property is available