### PR TITLE
CloudSQLite: add support for httptimeout being configurable

### DIFF
--- a/iModelCore/BeSQLite/CloudSqlite.cpp
+++ b/iModelCore/BeSQLite/CloudSqlite.cpp
@@ -15,6 +15,7 @@ USING_NAMESPACE_BENTLEY_SQLITE
 
 // default for "nRequests" to SQLite apis (number of simultaneous HTTP connections). 6 is the maximum from Chrome.
 static const int DEFAULT_MAX_HTTP_CONNECTIONS = 6;
+static const int DEFAULT_HTTP_TIMEOUT = 60; // 60 seconds 
 
 Utf8String Db::OpenParams::SetFromContainer(Utf8CP dbName, CloudContainerP container) {
     if (nullptr == container)
@@ -103,7 +104,7 @@ void CloudCache::ReadGuid() {
  * @param name the name of this vfs
  * @param rootDir the directory to use for caching cloud containers
  */
-CloudResult CloudCache::InitCache(Utf8StringCR name, Utf8StringCR rootDir, int64_t cacheSize, int64_t nRequest, bool curlDiagnostics) {
+CloudResult CloudCache::InitCache(Utf8StringCR name, Utf8StringCR rootDir, int64_t cacheSize, int64_t nRequest, int64_t httpTimeout, bool curlDiagnostics) {
     m_name = name;
     m_rootDir = rootDir;
     auto stat = CallSqliteFn([&](Utf8P* msg) { return sqlite3_bcvfs_create(m_rootDir.c_str(), m_name.c_str(), &m_vfs, msg); }, "create CloudCache");
@@ -123,6 +124,9 @@ CloudResult CloudCache::InitCache(Utf8StringCR name, Utf8StringCR rootDir, int64
         if (nRequest <= 0)
             nRequest = DEFAULT_MAX_HTTP_CONNECTIONS;
         sqlite3_bcvfs_config(m_vfs, SQLITE_BCV_NREQUEST, nRequest);
+        if (httpTimeout <= 0)
+            httpTimeout = DEFAULT_HTTP_TIMEOUT;
+        sqlite3_bcvfs_config(m_vfs, SQLITE_BCV_HTTPTIMEOUT, httpTimeout);
 
         ReadGuid(); // sets the m_guid member to either a new GUID or one from the localstore for write locks
     }
@@ -393,8 +397,9 @@ CloudPrefetch::PrefetchStatus CloudPrefetch::Run(int nRequest, int timeout) {
  * Initialize a CloudUtil object for a container. Opens a "handle" from SQLite to connect to the container.
  * @param container the container for the connection
  * @param nRequest if >0, the number of simultaneous http requests to make. Default is 6.
+ * @param httpTimeout if >0, the number of seconds to wait before considering an http request as timed out. Timed out requests will be tried. Default is 60 seconds.
  */
-CloudResult CloudUtil::Init(CloudContainer const& container, int logLevel, int nRequest) {
+CloudResult CloudUtil::Init(CloudContainer const& container, int logLevel, int nRequest, int httpTimeout) {
     int stat = sqlite3_bcv_open(container.m_storageType.c_str(), container.m_accessName.c_str(), container.m_accessToken.c_str(), container.m_containerId.c_str(), &m_handle);
     if (SQLITE_OK != stat)
         return CloudResult(stat,  Utf8PrintfString("cannot open CloudContainer: %s", sqlite3_bcv_errmsg(m_handle)).c_str());
@@ -405,6 +410,9 @@ CloudResult CloudUtil::Init(CloudContainer const& container, int logLevel, int n
     if (nRequest <= 0)
         nRequest = DEFAULT_MAX_HTTP_CONNECTIONS;
     sqlite3_bcv_config(m_handle, SQLITE_BCVCONFIG_NREQUEST, nRequest);
+    if (httpTimeout <= 0) 
+        httpTimeout = DEFAULT_HTTP_TIMEOUT;
+    sqlite3_bcv_config(m_handle, SQLITE_BCVCONFIG_HTTPTIMEOUT, httpTimeout);
     return CloudResult();
 }
 

--- a/iModelCore/BeSQLite/CloudSqlite.cpp
+++ b/iModelCore/BeSQLite/CloudSqlite.cpp
@@ -15,7 +15,8 @@ USING_NAMESPACE_BENTLEY_SQLITE
 
 // default for "nRequests" to SQLite apis (number of simultaneous HTTP connections). 6 is the maximum from Chrome.
 static const int DEFAULT_MAX_HTTP_CONNECTIONS = 6;
-static const int DEFAULT_HTTP_TIMEOUT = 60; // 60 seconds 
+// default for "httpTimeout" to SQLite apis (time in seconds to wait without a response before considering an http request as timed out).
+static const int DEFAULT_HTTP_TIMEOUT = 60; 
 
 Utf8String Db::OpenParams::SetFromContainer(Utf8CP dbName, CloudContainerP container) {
     if (nullptr == container)

--- a/iModelCore/BeSQLite/CloudSqlite.cpp
+++ b/iModelCore/BeSQLite/CloudSqlite.cpp
@@ -105,7 +105,7 @@ void CloudCache::ReadGuid() {
  * @param name the name of this vfs
  * @param rootDir the directory to use for caching cloud containers
  */
-CloudResult CloudCache::InitCache(Utf8StringCR name, Utf8StringCR rootDir, int64_t cacheSize, int64_t nRequest, int64_t httpTimeout, bool curlDiagnostics) {
+CloudResult CloudCache::InitCache(Utf8StringCR name, Utf8StringCR rootDir, int64_t cacheSize, int nRequest, int httpTimeout, bool curlDiagnostics) {
     m_name = name;
     m_rootDir = rootDir;
     auto stat = CallSqliteFn([&](Utf8P* msg) { return sqlite3_bcvfs_create(m_rootDir.c_str(), m_name.c_str(), &m_vfs, msg); }, "create CloudCache");

--- a/iModelCore/BeSQLite/PublicAPI/BeSQLite/CloudSqlite.h
+++ b/iModelCore/BeSQLite/PublicAPI/BeSQLite/CloudSqlite.h
@@ -51,7 +51,7 @@ struct CloudCache {
     Utf8String m_name;
     std::vector<CloudContainer*> m_containers;
 
-    BE_SQLITE_EXPORT CloudResult InitCache(Utf8StringCR name, Utf8StringCR rootDir, int64_t cacheSize = 0, int64_t nRequest = 0, bool verboseCurlLog = false);
+    BE_SQLITE_EXPORT CloudResult InitCache(Utf8StringCR name, Utf8StringCR rootDir, int64_t cacheSize = 0, int64_t nRequest = 0, int64_t httpTimeout = 0, bool verboseCurlLog = false);
     BE_SQLITE_EXPORT void SetLogMask(int logMask);
     BE_SQLITE_EXPORT Utf8String GetDatabaseHash(CloudContainer& container, Utf8StringCR dbName);
     BE_SQLITE_EXPORT int GetNumCleanupBlocks(CloudContainer& container);
@@ -147,7 +147,7 @@ public:
 
     virtual ~CloudUtil() { Close(); }
     BE_SQLITE_EXPORT void Close();
-    BE_SQLITE_EXPORT CloudResult Init(CloudContainer const& container, int logLevel = 0, int nRequests = 0);
+    BE_SQLITE_EXPORT CloudResult Init(CloudContainer const& container, int logLevel = 0, int nRequests = 0, int httpTimeout = 0);
     BE_SQLITE_EXPORT CloudResult InitializeContainer(int nameSize = 0, int blockSize = 0);
     BE_SQLITE_EXPORT CloudResult CleanDeletedBlocks(int deleteTime = 0);
     BE_SQLITE_EXPORT CloudResult UploadDatabase(Utf8StringCR localFileName, Utf8StringCR dbName);

--- a/iModelCore/BeSQLite/PublicAPI/BeSQLite/CloudSqlite.h
+++ b/iModelCore/BeSQLite/PublicAPI/BeSQLite/CloudSqlite.h
@@ -51,7 +51,7 @@ struct CloudCache {
     Utf8String m_name;
     std::vector<CloudContainer*> m_containers;
 
-    BE_SQLITE_EXPORT CloudResult InitCache(Utf8StringCR name, Utf8StringCR rootDir, int64_t cacheSize = 0, int64_t nRequest = 0, int64_t httpTimeout = 0, bool verboseCurlLog = false);
+    BE_SQLITE_EXPORT CloudResult InitCache(Utf8StringCR name, Utf8StringCR rootDir, int64_t cacheSize = 0, int nRequest = 0, int httpTimeout = 0, bool verboseCurlLog = false);
     BE_SQLITE_EXPORT void SetLogMask(int logMask);
     BE_SQLITE_EXPORT Utf8String GetDatabaseHash(CloudContainer& container, Utf8StringCR dbName);
     BE_SQLITE_EXPORT int GetNumCleanupBlocks(CloudContainer& container);

--- a/iModelJsNodeAddon/IModelJsNative.h
+++ b/iModelJsNodeAddon/IModelJsNative.h
@@ -395,6 +395,7 @@ struct JsInterop {
     BE_JSON_NAME(forceUseId)
     BE_JSON_NAME(globalOrigin)
     BE_JSON_NAME(guid)
+    BE_JSON_NAME(httpTimeout)
     BE_JSON_NAME(id)
     BE_JSON_NAME(index)
     BE_JSON_NAME(localFileName)

--- a/iModelJsNodeAddon/JsCloudSqlite.cpp
+++ b/iModelJsNodeAddon/JsCloudSqlite.cpp
@@ -67,7 +67,7 @@ struct JsCloudCache : CloudCache, Napi::ObjectWrap<JsCloudCache> {
                 BeNapi::ThrowJsException(info.Env(), "illegal cache size");
         }
         bool curlDiagnostics = boolMember(args, JSON_NAME(curlDiagnostics), false);
-        auto stat = InitCache(name, rootDir, cacheSize, intMember(args, JSON_NAME(nRequests), 0), curlDiagnostics);
+        auto stat = InitCache(name, rootDir, cacheSize, intMember(args, JSON_NAME(nRequests), 0), intMember(args, JSON_NAME(httpTimeout), 0), curlDiagnostics);
         if (!stat.IsSuccess()) {
             if (stat.m_status == BE_SQLITE_CANTOPEN)
                 stat.m_error = "Cannot create CloudCache: invalid cache directory or directory does not exist";
@@ -613,7 +613,7 @@ struct CloudDbTransfer : Napi::ObjectWrap<CloudDbTransfer> {
             m_direction = direction;
             m_localFile = requireString(args, JSON_NAME(localFileName));
             m_dbName = requireString(args, JSON_NAME(dbName));
-            auto stat = m_job.Init(container, 0, intMember(args, JSON_NAME(nRequests), 0));
+            auto stat = m_job.Init(container, 0, intMember(args, JSON_NAME(nRequests), 0), intMember(args, JSON_NAME(httpTimeout), 0));
             if (!stat.IsSuccess())
                 BeNapi::ThrowJsException(Env(), stat.m_error.c_str(), stat.m_status);
         }

--- a/iModelJsNodeAddon/api_package/ts/src/NativeCloudSqlite.ts
+++ b/iModelJsNodeAddon/api_package/ts/src/NativeCloudSqlite.ts
@@ -90,6 +90,8 @@ export namespace NativeCloudSqlite {
   export interface CloudHttpProps {
     /** The number of simultaneous HTTP requests.  Default is 6. */
     nRequests?: number;
+    /** The time in seconds to wait without a response before considering a http request as timed out. Default is 60 seconds. */
+    httpTimeout?: number;
   }
 
   export interface PrefetchProps extends CloudHttpProps {


### PR DESCRIPTION
The current default in SQLite code is 600 seconds. 

This will improve performance in cases where we do timeout when receiving blocks. There are some examples in the v2 checkpoint agent, which show upwards of 10 minutes wasted on a single request. These requests will get retried more quickly if we hit our timeout faster.

I opted for 60 seconds as the default, but lower may be even more beneficial especially in write cases. As a faster http timeout could mean a client releases the write lock faster.