### PR TITLE
Relying on installed/pipeline node rather than repo

### DIFF
--- a/iModelCore/ecobjects/src/ExpressionHandler.cpp
+++ b/iModelCore/ecobjects/src/ExpressionHandler.cpp
@@ -1,10 +1,7 @@
-/*--------------------------------------------------------------------------------------+
-|
-|     $Source: src/ExpressionHandler.cpp $
-|
-|  $Copyright: (c) 2017 Bentley Systems, Incorporated. All rights reserved. $
-|
-+--------------------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the repository root for full copyright notice.
+*--------------------------------------------------------------------------------------------*/
 
 #include "ECObjectsPch.h"
 

--- a/iModelCore/libsrc/compress/lzma/lzma.mke
+++ b/iModelCore/libsrc/compress/lzma/lzma.mke
@@ -1,10 +1,7 @@
-#--------------------------------------------------------------------------------------
-#
-#     $Source: lzma/lzma.mke $
-#
-#  $Copyright: (c) 2016 Bentley Systems, Incorporated. All rights reserved. $
-#
-#--------------------------------------------------------------------------------------
+#---------------------------------------------------------------------------------------------
+#  Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+#  See LICENSE.md in the repository root for full copyright notice.
+#---------------------------------------------------------------------------------------------
 # Export/make visible all functions in JsonCpp
 GCC_DEFAULT_VISIBILITY=default
 

--- a/iModelCore/libsrc/compress/lzma19/lzma.mke
+++ b/iModelCore/libsrc/compress/lzma19/lzma.mke
@@ -1,10 +1,7 @@
-#--------------------------------------------------------------------------------------
-#
-#     $Source: lzma19/lzma.mke $
-#
-#  $Copyright: (c) 2020 Bentley Systems, Incorporated. All rights reserved. $
-#
-#--------------------------------------------------------------------------------------
+#---------------------------------------------------------------------------------------------
+#  Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+#  See LICENSE.md in the repository root for full copyright notice.
+#---------------------------------------------------------------------------------------------
 # Export/make visible all functions in JsonCpp
 GCC_DEFAULT_VISIBILITY=default
 

--- a/iModelCore/libsrc/compress/prewire.mke
+++ b/iModelCore/libsrc/compress/prewire.mke
@@ -1,10 +1,7 @@
-#--------------------------------------------------------------------------------------
-#
-#     $Source: prewire.mke $
-#
-#  $Copyright: (c) 2015 Bentley Systems, Incorporated. All rights reserved. $
-#
-#--------------------------------------------------------------------------------------
+#---------------------------------------------------------------------------------------------
+#  Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+#  See LICENSE.md in the repository root for full copyright notice.
+#---------------------------------------------------------------------------------------------
 %include mdl.mki
 
 baseDir       = $(_MakeFilePath)

--- a/iModelCore/libsrc/compress/snappy/snappy.mke
+++ b/iModelCore/libsrc/compress/snappy/snappy.mke
@@ -1,10 +1,7 @@
-#--------------------------------------------------------------------------------------
-#
-#     $Source: snappy/snappy.mke $
-#
-#  $Copyright: (c) 2016 Bentley Systems, Incorporated. All rights reserved. $
-#
-#--------------------------------------------------------------------------------------
+#---------------------------------------------------------------------------------------------
+#  Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+#  See LICENSE.md in the repository root for full copyright notice.
+#---------------------------------------------------------------------------------------------
 # Export/make visible all functions in JsonCpp
 GCC_DEFAULT_VISIBILITY=default
 

--- a/iModelCore/libsrc/compress/zlib/Zlib.mke
+++ b/iModelCore/libsrc/compress/zlib/Zlib.mke
@@ -1,10 +1,7 @@
-#--------------------------------------------------------------------------------------
-#
-#     $Source: zlib/Zlib.mke $
-#
-#  $Copyright: (c) 2016 Bentley Systems, Incorporated. All rights reserved. $
-#
-#--------------------------------------------------------------------------------------
+#---------------------------------------------------------------------------------------------
+#  Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+#  See LICENSE.md in the repository root for full copyright notice.
+#---------------------------------------------------------------------------------------------
 GCC_DEFAULT_VISIBILITY              = default
 HAVE_PERMISSION_TO_COMPILE_AT_W3    = 1
 IS_THIRD_PARTY_LIBRARY = 1

--- a/iModelJsNodeAddon/api_package/ts/makeTs.mke
+++ b/iModelJsNodeAddon/api_package/ts/makeTs.mke
@@ -13,9 +13,9 @@ outDir = $(_MakeFilePath)lib/
 always:
     ~chdir $(srcDir)
 %if defined(BMAKE_DELETE_ALL_TARGETS)
-    -$(BBPYTHONCMD) $(SrcRoot)thirdparty/nodejs_14_16_0/bentley/npm.py run clean
+    npm run clean
 %endif
-    -$(BBPYTHONCMD) $(SrcRoot)thirdparty/nodejs_14_16_0/bentley/npm.py run build
+    npm run build
 
 $(BuildContext)Delivery/lib : $(outDir)
     $(LinkFirstDepToFirstTargetAsDirectory)

--- a/iModelJsNodeAddon/api_package/ts/runTests.mke
+++ b/iModelJsNodeAddon/api_package/ts/runTests.mke
@@ -5,7 +5,7 @@
 %include mdl.mki
 
 baseDir = $(_MakeFilePath)
-npmCmd = $(BBPYTHONCMD) $(SrcRoot)thirdparty/nodejs_14_16_0/bentley/npm.py
+npmCmd = npm
 npmArg =
 
 # On MacOSARM64, we must use an arm64 version of node which nodejs_14_16_0 does not support, so use a newer one.
@@ -16,7 +16,7 @@ npmArg =
         %warn *** Skipping tests as we're not running on an Apple Silicon processor ***
         %return
     %else
-        npmCmd = $(SrcRoot)thirdparty/nodejs_16_15_0/bentley/npm.sh
+        npmCmd = npm
         npmArg = --forceArm64
     %endif
 %endif

--- a/iModelJsNodeAddon/api_package/ts/runTests.mke
+++ b/iModelJsNodeAddon/api_package/ts/runTests.mke
@@ -6,21 +6,16 @@
 
 baseDir = $(_MakeFilePath)
 npmCmd = npm
-npmArg =
 
 # On MacOSARM64, we must use an arm64 version of node which nodejs_14_16_0 does not support, so use a newer one.
-# NOTE: running npm.sh directly and forcing the arm64 version rather than npm.py as that might result in the wrong arch if python isn't an arm64 build.
 %if $(TARGET_PROCESSOR_ARCHITECTURE) == "MacOSARM64"
     # Only run tests if we're compiling with an Apple processor
     %if " " == $[@findstring Apple, $[@readstdout "sysctl -n machdep.cpu.brand_string"]]
         %warn *** Skipping tests as we're not running on an Apple Silicon processor ***
         %return
-    %else
-        npmCmd = npm
-        npmArg = --forceArm64
     %endif
 %endif
 
 always:
     ~chdir $(baseDir)
-    $(npmCmd) $(npmArg) run test
+    $(npmCmd) run test

--- a/schemas/BisSchemas/findSchemaPath.mki
+++ b/schemas/BisSchemas/findSchemaPath.mki
@@ -1,10 +1,7 @@
-#-------------------------------------------------------------------------------------------------+
-#
-#  $Source: findSchemaPath.mki $
-#
-#  $Copyright (c) Bentley Systems, Incorporated. All rights reserved.  $
-#  $See LICENSE.md in the project root for license terms and full copyright notice.  $
-#
+#---------------------------------------------------------------------------------------------
+#  Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+#  See LICENSE.md in the repository root for full copyright notice.
+#---------------------------------------------------------------------------------------------
 #-------------------------------------------------------------------------------------------------+
 # Inputs:
 #       SYMLINK_OUT - It is the absolute path of symlinked file at out. 

--- a/schemas/ECStandards/StandardSchemas.delivery.mki
+++ b/schemas/ECStandards/StandardSchemas.delivery.mki
@@ -1,10 +1,7 @@
-#--------------------------------------------------------------------------------------
-#
-#     $Source: StandardSchemas.delivery.mki $
-#
-#  $Copyright: (c) 2019 Bentley Systems, Incorporated. All rights reserved. $
-#
-#--------------------------------------------------------------------------------------
+#---------------------------------------------------------------------------------------------
+#  Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+#  See LICENSE.md in the repository root for full copyright notice.
+#---------------------------------------------------------------------------------------------
 
 # Specify the exact name of each schema that is delivered.  This allows makefiles to use this information instead of hardcoding in a version number
 

--- a/schemas/ECStandards/StandardSchemas.prewire.mke
+++ b/schemas/ECStandards/StandardSchemas.prewire.mke
@@ -1,10 +1,7 @@
-#--------------------------------------------------------------------------------------
-#
-#     $Source: StandardSchemas.prewire.mke $
-#
-#  $Copyright: (c) 2016 Bentley Systems, Incorporated. All rights reserved. $
-#
-#--------------------------------------------------------------------------------------
+#---------------------------------------------------------------------------------------------
+#  Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+#  See LICENSE.md in the repository root for full copyright notice.
+#---------------------------------------------------------------------------------------------
 PolicyFile = $(InternalSystemPolicy)
 
 %include    mdl.mki

--- a/schemas/ECStandards/V3ConversionSchemas.prewire.mke
+++ b/schemas/ECStandards/V3ConversionSchemas.prewire.mke
@@ -1,10 +1,7 @@
-#--------------------------------------------------------------------------------------
-#
-#     $Source: V3ConversionSchemas.prewire.mke $
-#
-#  $Copyright: (c) 2019 Bentley Systems, Incorporated. All rights reserved. $
-#
-#--------------------------------------------------------------------------------------
+#---------------------------------------------------------------------------------------------
+#  Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+#  See LICENSE.md in the repository root for full copyright notice.
+#---------------------------------------------------------------------------------------------
 PolicyFile = $(InternalSystemPolicy)
 
 %include    mdl.mki


### PR DESCRIPTION
This is the next step to removing dependence on node committed to repositories. Run the installed npm rather than the one in the repository. This only affects the building and running of the tests imodeljsnodeaddon. Also cleaned up some copyright headers.