### PR TITLE
Presentation: Evaluate node artifacts when taking node from cache

### DIFF
--- a/iModelCore/ECPresentation/Source/Hierarchies/NavNodeProviders.cpp
+++ b/iModelCore/ECPresentation/Source/Hierarchies/NavNodeProviders.cpp
@@ -230,7 +230,7 @@ void NavNodesProviderContext::Init()
     m_childNodeRule = nullptr;
     m_usedClassesListener = nullptr;
     m_pageOptions = nullptr;
-    m_mayHaveArtifacts = false;
+    m_mayHaveArtifacts = true;
     }
 
 /*---------------------------------------------------------------------------------**//**

--- a/iModelCore/ECPresentation/Tests/NonPublished/Integration/Hierarchies/HierarchyIntegrationTests.cpp
+++ b/iModelCore/ECPresentation/Tests/NonPublished/Integration/Hierarchies/HierarchyIntegrationTests.cpp
@@ -13953,7 +13953,6 @@ TEST_F(RulesDrivenECPresentationManagerNavigationTests, CreateChildGroupingNodeW
         [&](){return m_manager->GetNodesCount(AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables(), groupingNodesA2[0].get())).get(); }
     );
     ASSERT_EQ(0, noInstanceNodesA.GetSize());
-
     }
 
 /*---------------------------------------------------------------------------------**//**
@@ -14085,4 +14084,61 @@ TEST_F(RulesDrivenECPresentationManagerNavigationTests, OrdersMultipleNodesWithN
     VerifyNodeInstances(*rootNodes[1], { a3 });
     VerifyNodeInstances(*rootNodes[2], { a4 });
     VerifyNodeInstances(*rootNodes[3], { a2 });
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* @bsitest
++---------------+---------------+---------------+---------------+---------------+------*/
+DEFINE_SCHEMA(CorrectlyHandlesChildrenArtifactsInChildLevelHideExpression, R"*(
+    <ECEntityClass typeName="A"/>
+    <ECEntityClass typeName="B"/>
+    <ECEntityClass typeName="C"/>
+)*");
+TEST_F(RulesDrivenECPresentationManagerNavigationTests, CorrectlyHandlesChildrenArtifactsInChildLevelHideExpression)
+    {
+    ECClassCP classA = GetClass("A");
+    ECClassCP classB = GetClass("B");
+    ECClassCP classC = GetClass("C");
+
+    //expected returned instances
+    IECInstancePtr a = RulesEngineTestHelpers::InsertInstance(s_project->GetECDb(), *classA);
+    IECInstancePtr b = RulesEngineTestHelpers::InsertInstance(s_project->GetECDb(), *classB);
+    IECInstancePtr c = RulesEngineTestHelpers::InsertInstance(s_project->GetECDb(), *classC);
+
+    // create the rule set
+    PresentationRuleSetPtr rules = PresentationRuleSet::CreateInstance(BeTest::GetNameOfCurrentTest());
+    m_locater->AddRuleSet(*rules);
+
+    auto rootRule = new RootNodeRule();
+    rules->AddPresentationRule(*rootRule);
+    auto rootSpec = new InstanceNodesOfSpecificClassesSpecification(1, ChildrenHint::Unknown, false, false, false, false, "", classA->GetFullName(), true);
+    rootRule->AddSpecification(*rootSpec);
+
+    auto childRule = new ChildNodeRule(Utf8PrintfString("ParentNode.IsOfClass(\"%s\", \"%s\")", classA->GetName().c_str(), classA->GetSchema().GetName().c_str()), 1, false);
+    rules->AddPresentationRule(*childRule);
+    auto childSpec = new InstanceNodesOfSpecificClassesSpecification(1, ChildrenHint::Unknown, false, false, false, false, "", classB->GetFullName(), true);
+    childSpec->SetHideExpression("NOT ThisNode.ChildrenArtifacts.AnyMatches(x => x.isVisibleChild)");
+    childRule->AddSpecification(*childSpec);
+
+    auto grandChildRule = new ChildNodeRule(Utf8PrintfString("ParentNode.IsOfClass(\"%s\", \"%s\")", classB->GetName().c_str(), classB->GetSchema().GetName().c_str()), 1, false);
+    rules->AddPresentationRule(*grandChildRule);
+    auto grandChildSpec = new InstanceNodesOfSpecificClassesSpecification(1, ChildrenHint::Unknown, false, false, false, false, "", classC->GetFullName(), true);
+    grandChildRule->AddSpecification(*grandChildSpec);
+
+    bmap<Utf8String, Utf8String> artifactDefinitions;
+    artifactDefinitions.Insert("isVisibleChild", "TRUE");
+    grandChildRule->AddCustomizationRule(*new NodeArtifactsRule("", artifactDefinitions));
+
+    // verify
+    auto params = AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables());
+    ValidateHierarchy(params,
+        {
+        ExpectedHierarchyDef(CreateInstanceNodeValidator({ a }),
+            {
+            ExpectedHierarchyDef(CreateInstanceNodeValidator({ b }),
+                {
+                CreateInstanceNodeValidator({ c })
+                }),
+            }),
+        });
     }


### PR DESCRIPTION
After changes to not cache transient node data we now need to evaluate node artifacts when loading nodes from cache. Previously artifacts were evaluated only when querying nodes based on specification. This change inverts this logic to always try to load artifacts unless we now that there are no artifact rules for specification used to query nodes.