### PR TITLE
stable Frenet frame logic for line strings

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,7 +24,7 @@
 /iModelCore/ecobjects/                       @calebmshafer @ColinKerr @c-macdonald @rschili
 /iModelCore/ECPresentation/                  @iTwin/itwinjs-core-presentation
 /iModelCore/GeoCoord/                        @kabentley @AlainRobertAtBentley
-/iModelCore/GeomLibs/                        @EarlinLutz @bbastings @kabentley @dassaf4
+/iModelCore/GeomLibs/                        @saeeedtorabi @bbastings @kabentley @dassaf4
 /iModelCore/iModelPlatform/                  @pmconne @swwilson-bsi @kabentley @bbastings
 /iModelCore/Units/                           @calebmshafer @ColinKerr @bbastings @rschili
 /iModelCore/iModelPlatform/**/*Tile*.*       @pmconne @markschlosseratbentley

--- a/iModelCore/GeomLibs/geom/test/CurvePrimitiveTest/t_CurvePrimitive.cpp
+++ b/iModelCore/GeomLibs/geom/test/CurvePrimitiveTest/t_CurvePrimitive.cpp
@@ -1444,7 +1444,35 @@ TEST(CurvePrimitive,ParallelLinesFrenetFrame)
         {
         }    
     }    
-        
+
+/*---------------------------------------------------------------------------------**//**
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+TEST(CurvePrimitive,LineStringFrenetFrame)
+    {
+    double eps = 1.0e-8;
+    bvector<DPoint3d> pts;
+    pts.push_back(DPoint3d::From(0,0));
+    pts.push_back(DPoint3d::From(1,0));
+    pts.push_back(DPoint3d::From(2,0));
+    pts.push_back(DPoint3d::From(3,0));
+    pts.push_back(DPoint3d::From(4,-eps));
+    pts.push_back(DPoint3d::From(5,0));
+    pts.push_back(DPoint3d::From(6,0));
+    ICurvePrimitivePtr lineString = ICurvePrimitive::CreateLineString(pts);
+    CurveVectorPtr collection = CurveVector::Create (CurveVector::BOUNDARY_TYPE_None);
+    collection->push_back (lineString);
+
+    Transform frame;
+    if (Check::True (collection->GetAnyFrenetFrame (frame), "Frenet frame on line string with front-loaded colinear vertices."))
+        {
+        Transform expected = Transform::From(pts[3]);
+        expected.SetMatrixByRowAndColumn(0, 1, eps);
+        expected.SetMatrixByRowAndColumn(1, 0, -eps);
+        Check::Near(frame, expected);
+        }
+    }
+
 /*---------------------------------------------------------------------------------**//**
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/


### PR DESCRIPTION
Enhance `CurveVector::GetAnyFrenetFrame` with line string logic that seeks an optimal frame among the points, preferring the first frame if it is good enough.

Details:
* This is a backport from PowerPlatform, as requested by @swwilson-bsi.
* I also updated geomlibs owners.