### PR TITLE
cherry-pick: fix out-of-bounds array deref caught by asan

### DIFF
--- a/iModelCore/GeomLibs/geom/src/funcs/ConvexHull.cpp
+++ b/iModelCore/GeomLibs/geom/src/funcs/ConvexHull.cpp
@@ -205,7 +205,7 @@ bool includeClosurePoint
                 }
             if (includeClosurePoint && hullPoints.size() > 1)
                 {
-                DPoint3d xyz = hullPoints.back ();
+                DPoint3d xyz = hullPoints.front();
                 hullPoints.push_back (xyz);
                 }
             }

--- a/iModelCore/GeomLibs/geom/src/regions/rg_gaps.cpp
+++ b/iModelCore/GeomLibs/geom/src/regions/rg_gaps.cpp
@@ -322,7 +322,8 @@ double          maxDiagBoxFraction
                         size_t num1 = xyz1.size ();
                         if (num1 > 2)
                             {
-                            xyz1.push_back(xyz1[0]);
+                            xyzA = xyz1[0];
+                            xyz1.push_back(xyzA);
                             ++num1;
                             }
                         for (j = 1; j < num1; j++)

--- a/iModelCore/GeomLibs/geom/src/regions/rg_gaps.cpp
+++ b/iModelCore/GeomLibs/geom/src/regions/rg_gaps.cpp
@@ -322,7 +322,8 @@ double          maxDiagBoxFraction
                         size_t num1 = xyz1.size ();
                         if (num1 > 2)
                             {
-                            xyz1[num1++] = xyz1[0];
+                            xyz1.push_back(xyz1[0]);
+                            ++num1;
                             }
                         for (j = 1; j < num1; j++)
                             {

--- a/iModelCore/GeomLibs/geom/test/CurvePrimitiveTest/t_frustum.cpp
+++ b/iModelCore/GeomLibs/geom/test/CurvePrimitiveTest/t_frustum.cpp
@@ -295,3 +295,30 @@ TEST(ConvexHull, GridTest)
         }
     Check::ClearGeometry("ConvexHull.GridTest");
     }
+
+static bool testPushBackWithRealloc(bvector<DPoint3d>& v)
+    {
+    if (v.size() != v.capacity())
+        return false;   // no realloc, don't care
+
+    // push_back will reallocate. Does it safely access v[0] before it is freed? VS2010 did not! 
+    v.push_back(v[0]);
+    Check::Exact(v.front(), v.back(), "push_back of first element with reallocate");
+    return true;
+    }
+
+TEST(ConvexHull, VectorPushBackTest)
+    {
+    bvector<DPoint3d> v({DPoint3d::From(41,37,59)});
+    if (!testPushBackWithRealloc(v))
+        {
+        // try shrinkwrap suggestion
+        v.shrink_to_fit();
+        if (!testPushBackWithRealloc(v))
+            {
+            // try the "swap trick" from Item 17 of "Effective STL" by Scott Meyers
+            bvector<DPoint3d>(v).swap(v);
+            testPushBackWithRealloc(v);
+            }
+        }
+    }

--- a/iModelCore/GeomLibs/geom/test/CurvePrimitiveTest/t_frustum.cpp
+++ b/iModelCore/GeomLibs/geom/test/CurvePrimitiveTest/t_frustum.cpp
@@ -283,7 +283,11 @@ TEST(ConvexHull, GridTest)
                 xyz.pop_back();
             for (auto &xyz1 : xyz)
                 Check::SaveTransformedMarker(xyz1, 0.02);
-            DPoint3dOps::ConvexHullXY (xyz, xyzHull);
+            DPoint3dOps::ConvexHullXY (xyz, xyzHull, true);
+
+            if (xyzHull.size() > 1 && Check::Exact(xyzHull.front(), xyzHull.back(), "ConvexHullXY closure point"))
+                xyzHull.pop_back(); // rest of test assumes no closure point
+
             CheckHull(xyzHull, xyz);
             Check::SaveTransformed(xyzHull);
             Check::Shift(4 * gridCount, 0);


### PR DESCRIPTION
Cherry-pick of #92 

Details:
* Longstanding oob error caused by incomplete buffer -> bvector conversion
* ConvexHullXY closure point logic appended last point instead of first