### PR TITLE
Validate that CodeScope is the ElementId of an existing element

### DIFF
--- a/iModelCore/iModelPlatform/DgnCore/CodeSpec.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/CodeSpec.cpp
@@ -559,8 +559,6 @@ void DgnCode::ToJson(BeJsValue val) const {
 DgnCode DgnCode::FromJson(BeJsConst value, DgnDbCR db) {
     DgnCode val = CreateEmpty();
     val.m_value = value[json_value()].asString();
-    if (val.m_value.empty())
-        return val; // if the value is empty, don't use any of the other parameters
 
     auto specJson = value[json_spec()];
     val.m_specId = CodeSpecId(specJson.asUInt64());

--- a/iModelCore/iModelPlatform/DgnCore/DgnElement.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/DgnElement.cpp
@@ -1392,7 +1392,6 @@ void DgnElement::_FromJson(BeJsConst props) {
 DgnElement::CreateParams::CreateParams(DgnDbR db, BeJsConst val) : m_dgndb(db) {
     m_classId = ECJsonUtilities::GetClassIdFromClassNameJson(val[DgnElement::json_classFullName()], db.GetClassLocater());
     m_modelId.FromJson(val[DgnElement::json_model()]);
-    m_code = DgnCode::FromJson(val[DgnElement::json_code()], db);
     m_federationGuid.FromString(val[DgnElement::json_federationGuid()].asString().c_str());
     m_userLabel = val[DgnElement::json_userLabel()].asString();
 

--- a/iModelCore/iModelPlatform/DgnCore/DgnElement.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/DgnElement.cpp
@@ -1328,7 +1328,7 @@ void DgnElement::_FromJson(BeJsConst props) {
 
     auto code = props[json_code()];
     if (!code.isNull())
-        m_code = DgnCode::FromJson(code, m_dgndb);
+        m_code = DgnCode::FromJson(code, m_dgndb, true);
 
     // support partial update, only update m_federationGuid if props has member
     if (props.hasMember(json_federationGuid())) {
@@ -1348,7 +1348,7 @@ void DgnElement::_FromJson(BeJsConst props) {
             m_userLabel.clear(); // allow undefined to clear an existing value
     }
 
-         // support partial update, only update m_parent if props has member
+    // support partial update, only update m_parent if props has member
     if (props.hasMember(json_parent())) {
         auto parent = props[json_parent()];
         m_parent.FromJson(m_dgndb, parent); // RelatedElement::FromJson also clears for undefined

--- a/iModelCore/iModelPlatform/DgnCore/DgnElements.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/DgnElements.cpp
@@ -350,6 +350,13 @@ DgnElementCPtr DgnElements::QueryElementByFederationGuid(BeGuidCR federationGuid
     return (BE_SQLITE_ROW != statement->Step()) ? nullptr : GetElement(statement->GetValueId<DgnElementId>(0));
     }
 
+/** Return true if an element with the supplied Id exists */
+bool DgnElements::ElementExists(DgnElementId id) {
+    CachedStatementPtr statement = GetStatement("SELECT 1 FROM " BIS_TABLE(BIS_CLASS_Element) " WHERE Id=?");
+    statement->BindId(1, id);
+    return BE_SQLITE_ROW == statement->Step();
+}
+
 /*---------------------------------------------------------------------------------**//**
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/

--- a/iModelCore/iModelPlatform/DgnCore/DgnElements.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/DgnElements.cpp
@@ -352,6 +352,10 @@ DgnElementCPtr DgnElements::QueryElementByFederationGuid(BeGuidCR federationGuid
 
 /** Return true if an element with the supplied Id exists */
 bool DgnElements::ElementExists(DgnElementId id) {
+    // the root subject element always exists. Don't bother to check.
+    if (id == GetRootSubjectId())
+        return true;
+
     CachedStatementPtr statement = GetStatement("SELECT 1 FROM " BIS_TABLE(BIS_CLASS_Element) " WHERE Id=?");
     statement->BindId(1, id);
     return BE_SQLITE_ROW == statement->Step();

--- a/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/DgnDbTables.h
+++ b/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/DgnDbTables.h
@@ -314,7 +314,7 @@ public:
     BE_JSON_NAME(scope)
     BE_JSON_NAME(value)
     DGNPLATFORM_EXPORT void ToJson(BeJsValue) const;
-    DGNPLATFORM_EXPORT static DgnCode FromJson(BeJsConst value, DgnDbCR);
+    DGNPLATFORM_EXPORT static DgnCode FromJson(BeJsConst value, DgnDbCR, bool validateScope);
 };
 
 typedef bset<DgnCode> DgnCodeSet;

--- a/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/DgnDbTables.h
+++ b/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/DgnDbTables.h
@@ -251,8 +251,8 @@ public:
 //! The combination of the three must be unique across all elements within a DgnDb.
 //! The meaning of a DgnCode is determined by the CodeSpec.
 //!
-//! The CodeSpecId must be non-null and identify a valid CodeSpec.
-//! The scope must not be null and identifies the uniqueness scope for the value.
+//! The CodeSpecId must be the ElementId of a valid CodeSpec.
+//! The scope must be the ElementId of a valid element that defines the uniqueness scope.
 //! The value may be null if the element does not have a name. The value may not be an empty string.
 //!
 //! @see CodeSpec

--- a/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/DgnElement.h
+++ b/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/DgnElement.h
@@ -3852,7 +3852,6 @@ private:
 
     void Destroy();
     void AddToPool(DgnElementCR) const;
-    void FinishUpdate(DgnElementCR replacement, DgnElementCR original);
     DgnElementCPtr LoadElement(DgnElement::CreateParams const& params, Utf8CP jsonProps, bool makePersistent) const;
     DgnElementCPtr LoadElement(DgnElementId elementId, bool makePersistent) const;
     DgnElementCPtr PerformInsert(DgnElementR element, DgnDbStatus&);
@@ -3893,6 +3892,8 @@ public:
     DGNPLATFORM_EXPORT BeSQLite::CachedStatementPtr GetStatement(Utf8CP sql) const; //!< Get a statement from the element-specific statement cache for this DgnDb @private
     DGNPLATFORM_EXPORT void DropFromPool(DgnElementCR) const; //!< @private
     DGNPLATFORM_EXPORT DgnDbStatus LoadGeometryStream(GeometryStreamR geom, void const* blob, int blobSize); //!< @private
+
+    DGNPLATFORM_EXPORT bool ElementExists(DgnElementId);
 
     //! Look up an element in the pool of loaded elements for this DgnDb.
     //! @return A pointer to the element, or nullptr if the is not in the pool.

--- a/iModelCore/iModelPlatform/Tests/DgnProject/NonPublished/DgnElement_Test.cpp
+++ b/iModelCore/iModelPlatform/Tests/DgnProject/NonPublished/DgnElement_Test.cpp
@@ -2399,7 +2399,7 @@ TEST_F(DgnElementTests, AutoHandledGeometryJsonRoundTrip)
         Placement3d().ToJson(BeJsValue{placementJson});
         inPropsJson["placement"] = placementJson;
         inPropsJson["federationGuid"] = "00000000-0000-0000-0000-000000000000";
-        DgnCode().ToJson(inPropsJson["code"]);
+        DgnCode::CreateEmpty().ToJson(inPropsJson["code"]);
         Json::Value geomJson;
         ECN::ECJsonUtilities::IGeometryToJson(geomJson, *inGeom);
         inPropsJson["geomProp"] = geomJson;

--- a/iModelJsNodeAddon/JsInteropDgnDb.cpp
+++ b/iModelJsNodeAddon/JsInteropDgnDb.cpp
@@ -302,37 +302,33 @@ DgnDbStatus JsInterop::GetSchemaItem(BeJsValue mjson, DgnDbR dgndb, Utf8CP schem
 // @bsimethod
 //---------------------------------------------------------------------------------------
 DgnDbStatus JsInterop::GetElement(BeJsValue elementJson, DgnDbR dgndb, Napi::Object obj) {
-    try {
-        BeJsConst inOpts(obj);
-        DgnElementCPtr elem;
-        DgnElementId eid = inOpts[json_id()].GetId64<DgnElementId>();
+    BeJsConst inOpts(obj);
+    DgnElementCPtr elem;
+    DgnElementId eid = inOpts[json_id()].GetId64<DgnElementId>();
 
-        if (!eid.IsValid()) {
-            auto fedJson = inOpts[json_federationGuid()];
-            if (fedJson.isString()) {
-                BeGuid federationGuid;
-                federationGuid.FromString(fedJson.asCString());
-                elem = dgndb.Elements().QueryElementByFederationGuid(federationGuid);
-            } else {
-                eid = dgndb.Elements().QueryElementIdByCode(DgnCode::FromJson(inOpts[json_code()], dgndb));
-            }
+    if (!eid.IsValid()) {
+        auto fedJson = inOpts[json_federationGuid()];
+        if (fedJson.isString()) {
+            BeGuid federationGuid;
+            federationGuid.FromString(fedJson.asCString());
+            elem = dgndb.Elements().QueryElementByFederationGuid(federationGuid);
+        } else {
+            eid = dgndb.Elements().QueryElementIdByCode(DgnCode::FromJson(inOpts[json_code()], dgndb, false));
         }
-
-        if (!elem.IsValid())
-            elem = dgndb.Elements().GetElement(eid);
-
-        if (!elem.IsValid())
-            return DgnDbStatus::NotFound;
-
-        // if they only want base properties, don't bother calling virtual function
-        if (inOpts[json_onlyBaseProperties()].asBool())
-            elem->ToBaseJson(elementJson);
-        else
-            elem->ToJson(elementJson, inOpts);
-        return DgnDbStatus::Success;
-    } catch (std::logic_error const& err) {
-        BeNapi::ThrowJsException(Env(), err.what(), (int)DgnDbStatus::BadArg);
     }
+
+    if (!elem.IsValid())
+        elem = dgndb.Elements().GetElement(eid);
+
+    if (!elem.IsValid())
+        return DgnDbStatus::NotFound;
+
+    // if they only want base properties, don't bother calling virtual function
+    if (inOpts[json_onlyBaseProperties()].asBool())
+        elem->ToBaseJson(elementJson);
+    else
+        elem->ToJson(elementJson, inOpts);
+    return DgnDbStatus::Success;
 }
 
 struct SetNapiObjOnElement {
@@ -1029,27 +1025,23 @@ void JsInterop::DeleteModel(DgnDbR dgndb, Utf8StringCR midStr) {
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/
 DgnDbStatus JsInterop::GetModel(Napi::Object modelObj, DgnDbR dgndb, BeJsConst inOpts) {
-    try {
-        DgnModelId modelId = inOpts[json_id()].GetId64<DgnModelId>();
-        if (!modelId.IsValid()) {
-            auto codeVal = inOpts[json_code()];
-            if (codeVal.isNull())
-                return DgnDbStatus::NotFound;
-
-            modelId = dgndb.Models().QuerySubModelId(DgnCode::FromJson(codeVal, dgndb));
-        }
-
-        //  Look up the model
-        auto model = dgndb.Models().GetModel(modelId);
-        if (!model.IsValid())
+    DgnModelId modelId = inOpts[json_id()].GetId64<DgnModelId>();
+    if (!modelId.IsValid()) {
+        auto codeVal = inOpts[json_code()];
+        if (codeVal.isNull())
             return DgnDbStatus::NotFound;
 
-        model->ToJson(modelObj, inOpts);
-        // Note: there are no auto-handled properties on DgnModels. Any such data goes on the modeled element.
-        return DgnDbStatus::Success;
-    } catch (std::logic_error const& err) {
-        BeNapi::ThrowJsException(Env(), err.what(), (int)DgnDbStatus::BadArg);
+        modelId = dgndb.Models().QuerySubModelId(DgnCode::FromJson(codeVal, dgndb, false));
     }
+
+    //  Look up the model
+    auto model = dgndb.Models().GetModel(modelId);
+    if (!model.IsValid())
+        return DgnDbStatus::NotFound;
+
+    model->ToJson(modelObj, inOpts);
+    // Note: there are no auto-handled properties on DgnModels. Any such data goes on the modeled element.
+    return DgnDbStatus::Success;
 }
 
 //---------------------------------------------------------------------------------------

--- a/iModelJsNodeAddon/JsInteropDgnDb.cpp
+++ b/iModelJsNodeAddon/JsInteropDgnDb.cpp
@@ -296,40 +296,43 @@ DgnDbStatus JsInterop::GetSchemaItem(BeJsValue mjson, DgnDbR dgndb, Utf8CP schem
         }
 
     return DgnDbStatus::NotFound;    // This is not an exception. It just returns an empty result.
-    }
+}
 
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //---------------------------------------------------------------------------------------
 DgnDbStatus JsInterop::GetElement(BeJsValue elementJson, DgnDbR dgndb, Napi::Object obj) {
-    BeJsConst inOpts(obj);
+    try {
+        BeJsConst inOpts(obj);
+        DgnElementCPtr elem;
+        DgnElementId eid = inOpts[json_id()].GetId64<DgnElementId>();
 
-    DgnElementCPtr elem;
-    DgnElementId eid = inOpts[json_id()].GetId64<DgnElementId>();
-
-    if (!eid.IsValid()) {
-        auto fedJson = inOpts[json_federationGuid()];
-        if (fedJson.isString()) {
-            BeGuid federationGuid;
-            federationGuid.FromString(fedJson.asCString());
-            elem = dgndb.Elements().QueryElementByFederationGuid(federationGuid);
-        } else {
-            eid = dgndb.Elements().QueryElementIdByCode(DgnCode::FromJson(inOpts[json_code()], dgndb));
+        if (!eid.IsValid()) {
+            auto fedJson = inOpts[json_federationGuid()];
+            if (fedJson.isString()) {
+                BeGuid federationGuid;
+                federationGuid.FromString(fedJson.asCString());
+                elem = dgndb.Elements().QueryElementByFederationGuid(federationGuid);
+            } else {
+                eid = dgndb.Elements().QueryElementIdByCode(DgnCode::FromJson(inOpts[json_code()], dgndb));
+            }
         }
+
+        if (!elem.IsValid())
+            elem = dgndb.Elements().GetElement(eid);
+
+        if (!elem.IsValid())
+            return DgnDbStatus::NotFound;
+
+        // if they only want base properties, don't bother calling virtual function
+        if (inOpts[json_onlyBaseProperties()].asBool())
+            elem->ToBaseJson(elementJson);
+        else
+            elem->ToJson(elementJson, inOpts);
+        return DgnDbStatus::Success;
+    } catch (std::logic_error const& err) {
+        BeNapi::ThrowJsException(Env(), err.what(), (int)DgnDbStatus::BadArg);
     }
-
-    if (!elem.IsValid())
-        elem = dgndb.Elements().GetElement(eid);
-
-    if (!elem.IsValid())
-        return DgnDbStatus::NotFound;
-
-    // if they only want base properties, don't bother calling virtual function
-    if (inOpts[json_onlyBaseProperties()].asBool())
-        elem->ToBaseJson(elementJson);
-    else
-        elem->ToJson(elementJson, inOpts);
-    return DgnDbStatus::Success;
 }
 
 struct SetNapiObjOnElement {
@@ -1026,23 +1029,27 @@ void JsInterop::DeleteModel(DgnDbR dgndb, Utf8StringCR midStr) {
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/
 DgnDbStatus JsInterop::GetModel(Napi::Object modelObj, DgnDbR dgndb, BeJsConst inOpts) {
-    DgnModelId modelId = inOpts[json_id()].GetId64<DgnModelId>();
-    if (!modelId.IsValid()) {
-        auto codeVal = inOpts[json_code()];
-        if (codeVal.isNull())
+    try {
+        DgnModelId modelId = inOpts[json_id()].GetId64<DgnModelId>();
+        if (!modelId.IsValid()) {
+            auto codeVal = inOpts[json_code()];
+            if (codeVal.isNull())
+                return DgnDbStatus::NotFound;
+
+            modelId = dgndb.Models().QuerySubModelId(DgnCode::FromJson(codeVal, dgndb));
+        }
+
+        //  Look up the model
+        auto model = dgndb.Models().GetModel(modelId);
+        if (!model.IsValid())
             return DgnDbStatus::NotFound;
 
-        modelId = dgndb.Models().QuerySubModelId(DgnCode::FromJson(codeVal, dgndb));
+        model->ToJson(modelObj, inOpts);
+        // Note: there are no auto-handled properties on DgnModels. Any such data goes on the modeled element.
+        return DgnDbStatus::Success;
+    } catch (std::logic_error const& err) {
+        BeNapi::ThrowJsException(Env(), err.what(), (int)DgnDbStatus::BadArg);
     }
-
-    //  Look up the model
-    auto model = dgndb.Models().GetModel(modelId);
-    if (!model.IsValid())
-        return DgnDbStatus::NotFound;
-
-    model->ToJson(modelObj, inOpts);
-    // Note: there are no auto-handled properties on DgnModels. Any such data goes on the modeled element.
-    return DgnDbStatus::Success;
 }
 
 //---------------------------------------------------------------------------------------


### PR DESCRIPTION
The value of `CodeScope` *must* be a valid ElementId, but we did not enforce that. Throw an exception if the supplied value is illegal.

On insert and update, the value supplied from JavaScript may be a `FederationgGuid`. If so, look up the element and use its ElementId.
