### PR TITLE
Presentation: Fix multithreading issues (#98)

### DIFF
--- a/iModelCore/ECPresentation/Source/TaskScheduler.h
+++ b/iModelCore/ECPresentation/Source/TaskScheduler.h
@@ -267,7 +267,7 @@ protected:
     virtual folly::Future<folly::Unit> _GetCompletion() const override {return const_cast<folly::SharedPromise<folly::Unit>&>(m_completionPromise).getFuture();}
     virtual void _Complete() override {m_completionPromise.setValue();}
     virtual ICancelationTokenCP _GetCancelationToken() const override {return m_cancelationToken.get();}
-    virtual void _Cancel() override 
+    virtual void _Cancel() override
         {
         m_promise.getFuture().cancel();
         }
@@ -310,8 +310,8 @@ protected:
         catch (std::exception const& e)
             {
             return [this, e = folly::exception_wrapper{ std::current_exception(), e }](){Resolve(folly::Try<TResult>(e));};
-            } 
-        catch (...) 
+            }
+        catch (...)
             {
             return [this](){Resolve(folly::Try<TResult>(InternalError("Unexpected error occurred.")));};
             }
@@ -340,7 +340,7 @@ public:
         m_promiseResolved = std::make_shared<bool>(false);
         m_promise.setInterruptHandler([&, promiseResolved = m_promiseResolved](folly::exception_wrapper const& e)
             {
-            BeMutexHolder lock(m_mutex);
+            BeMutexHolder lock(mutex);
             if (*promiseResolved)
                 {
                 // the interrupt handler may outlive the task - the `promiseResolved` shared_ptr is used
@@ -370,7 +370,7 @@ public:
     void SetIsCancelable(bool isCancelable) {m_cancelationToken = isCancelable ? SimpleCancelationToken::Create() : nullptr;}
     void SetOtherTasksBlockingPredicate(IECPresentationTask::Predicate pred) {m_otherTasksBlockingPredicate = pred;}
     void SetThisTaskBlockingPredicate(std::function<bool()> pred) {m_blockPredicate = pred;}
-    void SetExecutor(folly::Executor* e) {m_futureExecutor = e;}
+    void SetFutureExecutor(folly::Executor* e) {m_futureExecutor = e;}
 };
 
 /*=================================================================================**//**
@@ -644,14 +644,14 @@ public:
     folly::Future<folly::Unit> CreateAndExecute(std::function<void(IECPresentationTaskR)> func, ECPresentationTaskParams const& params = {})
         {
         RefCountedPtr<ECPresentationTask> task = new ECPresentationTask(m_scheduler->GetMutex(), func);
-        task->SetExecutor(m_tasksExecutor.get());
+        task->SetFutureExecutor(&BeFolly::ThreadPool::GetCpuPool());
         params.Apply(*task);
         return Execute<folly::Unit>(*task);
         }
     template<typename TResult> folly::Future<TResult> CreateAndExecute(std::function<TResult(IECPresentationTaskWithResult<TResult>&)> func, ECPresentationTaskParams const& params = {})
         {
         RefCountedPtr<ECPresentationTaskWithResult<TResult>> task = new ECPresentationTaskWithResult<TResult>(m_scheduler->GetMutex(), func);
-        task->SetExecutor(m_tasksExecutor.get());
+        task->SetFutureExecutor(&BeFolly::ThreadPool::GetCpuPool());
         params.Apply(*task);
         return Execute<TResult>(*task);
         }

--- a/iModelCore/ECPresentation/Tests/NonPublished/Unit/TasksSchedulerTests.cpp
+++ b/iModelCore/ECPresentation/Tests/NonPublished/Unit/TasksSchedulerTests.cpp
@@ -1120,7 +1120,7 @@ TEST_F(ECPresentationTaskTests, SupportsCancellationThroughChainedFuturesWhenUsi
         ASSERT_TRUE(t.GetCancelationToken()->IsCanceled());
         didExecute = true;
         });
-    task->SetExecutor(&executor);
+    task->SetFutureExecutor(&executor);
     task->SetIsCancelable(true);
     auto taskFuture = task->GetFuture();
 


### PR DESCRIPTION
Backport https://github.com/iTwin/imodel-native/pull/98 (the fixed issues have a decent chance of being reproduced in production code).

* Can't use our executor for chained tasks, because they may exceed the lifetime of the executor

* Can't use `m_mutex` in interrupt handler as the task may be destroyed. Using `mutex` is allowed, because it stays valid for the lifetime of all tasks.