### PR TITLE
geomlibs: replace sprintf, remove unused-but-set vars

### DIFF
--- a/iModelCore/GeomLibs/common/test/printfuncs.cpp
+++ b/iModelCore/GeomLibs/common/test/printfuncs.cpp
@@ -307,9 +307,7 @@ const double a0,
 Tag *pParent
 )
     {
-    char stringVal[1024];
-    sprintf (stringVal, "%lg", a0);
-    printDatum ("double", pName, stringVal, pParent);
+    printDatum ("double", pName, Utf8PrintfString("%lg", a0).c_str(), pParent);
     }
 
 /*---------------------------------------------------------------------*//**
@@ -323,9 +321,7 @@ const int a0,
 Tag *pParent
 )
     {
-    char stringVal[1024];
-    sprintf (stringVal, "%d", a0);
-    printDatum ("int", pName, stringVal, pParent);
+    printDatum ("int", pName, Utf8PrintfString("%d", a0).c_str(), pParent);
     }
 
 /*---------------------------------------------------------------------*//**
@@ -339,9 +335,7 @@ const int a0,
 Tag *pParent
 )
     {
-    char stringVal[1024];
-    sprintf (stringVal, "0x%x", a0);
-    printDatum ("hex", pName, stringVal, pParent);
+    printDatum ("hex", pName, Utf8PrintfString("0x%x", a0).c_str(), pParent);
     }
 
 
@@ -370,9 +364,7 @@ const DVec3d *pVec,
 Tag *pParent
 )
     {
-    char stringVal[1024];
-    sprintf (stringVal, "%lg,%lg,%lg", pVec->x, pVec->y, pVec->z);
-    printDatum ("DVec3d", pName, stringVal, pParent);
+    printDatum ("DVec3d", pName, Utf8PrintfString("%lg,%lg,%lg", pVec->x, pVec->y, pVec->z).c_str(), pParent);
     }
 
 /*---------------------------------------------------------------------*//**
@@ -386,9 +378,7 @@ const DVec2d *pVec,
 Tag *pParent
 )
     {
-    char stringVal[1024];
-    sprintf (stringVal, "%lg,%lg", pVec->x, pVec->y);
-    printDatum ("DVec2d", pName, stringVal, pParent);
+    printDatum ("DVec2d", pName, Utf8PrintfString("%lg,%lg", pVec->x, pVec->y).c_str(), pParent);
     }
 
 /*---------------------------------------------------------------------*//**
@@ -402,9 +392,7 @@ const DPoint3d *pVec,
 Tag *pParent
 )
     {
-    char stringVal[1024];
-    sprintf (stringVal, "%lg,%lg,%lg", pVec->x, pVec->y, pVec->z);
-    printDatum ("DPoint3d", pName, stringVal, pParent);
+    printDatum ("DPoint3d", pName, Utf8PrintfString("%lg,%lg,%lg", pVec->x, pVec->y, pVec->z).c_str(), pParent);
     }
 
 /*---------------------------------------------------------------------*//**
@@ -418,9 +406,7 @@ const DPoint4d *pVec,
 Tag *pParent
 )
     {
-    char stringVal[1024];
-    sprintf (stringVal, "%lg,%lg,%lg,%lg", pVec->x, pVec->y, pVec->z, pVec->w);
-    printDatum ("DPoint4d", pName, stringVal, pParent);
+    printDatum ("DPoint4d", pName, Utf8PrintfString("%lg,%lg,%lg,%lg", pVec->x, pVec->y, pVec->z, pVec->w).c_str(), pParent);
     }
 
 
@@ -601,11 +587,8 @@ const DPlane3d *pPlane1,
 const char *pDescr
 )
     {
-    char descr[2048];
-    sprintf (descr, "(DPlane3d.origin)%s", pDescr);
-    checkDPoint3d (&pPlane0->origin, &pPlane1->origin, descr);
-    sprintf (descr, "(DPlane3d.normal)%s", pDescr);
-    checkDVec3d (&pPlane0->normal, &pPlane1->normal, descr);
+    checkDPoint3d (&pPlane0->origin, &pPlane1->origin, Utf8PrintfString("(DPlane3d.origin)%s", pDescr).c_str());
+    checkDVec3d (&pPlane0->normal, &pPlane1->normal, Utf8PrintfString("(DPlane3d.normal)%s", pDescr).c_str());
     }
 
 /*---------------------------------------------------------------------*//**
@@ -657,13 +640,9 @@ const RotMatrix *pM,
 Tag *pParent
 )
     {
-    char stringVal[1024];
-    sprintf (stringVal, "%lg,%lg,%lg", pM->form3d[0][0], pM->form3d[0][1], pM->form3d[0][2]);
-    printDatum ("row0", pName, stringVal, pParent);
-    sprintf (stringVal, "%lg,%lg,%lg", pM->form3d[1][0], pM->form3d[1][1], pM->form3d[1][2]);
-    printDatum ("row1", pName, stringVal, pParent);
-    sprintf (stringVal, "%lg,%lg,%lg]", pM->form3d[2][0], pM->form3d[2][1], pM->form3d[2][2]);
-    printDatum ("row2", pName, stringVal, pParent);
+    printDatum ("row0", pName, Utf8PrintfString("%lg,%lg,%lg", pM->form3d[0][0], pM->form3d[0][1], pM->form3d[0][2]).c_str(), pParent);
+    printDatum ("row1", pName, Utf8PrintfString("%lg,%lg,%lg", pM->form3d[1][0], pM->form3d[1][1], pM->form3d[1][2]).c_str(), pParent);
+    printDatum ("row2", pName, Utf8PrintfString("%lg,%lg,%lg]", pM->form3d[2][0], pM->form3d[2][1], pM->form3d[2][2]).c_str(), pParent);
     }
 
 /*---------------------------------------------------------------------*//**
@@ -811,9 +790,7 @@ double messageValue
     {
     if (messageValue != DBL_MAX)
         {
-        char message[2048];
-        sprintf (message, pDescr, messageValue);
-        checkDoubleLessThan (a0, a1, message);
+        checkDoubleLessThan (a0, a1, Utf8PrintfString(pDescr, messageValue).c_str());
         return;
         }
     double diff = fabs (a0 - a1);
@@ -850,9 +827,7 @@ double messageValue
     {
     if (messageValue != DBL_MAX)
         {
-        char message[2048];
-        sprintf (message, pDescr, messageValue);
-        checkDouble (a0, a1, message);
+        checkDouble (a0, a1, Utf8PrintfString(pDescr, messageValue).c_str());
         return;
         }
     double diff = fabs (a0 - a1);
@@ -943,9 +918,7 @@ double messageValue
     {
     if (messageValue != DBL_MAX)
         {
-        char message[2048];
-        sprintf (message, pDescr, messageValue);
-        checkTrue (a0, message);
+        checkTrue (a0, Utf8PrintfString(pDescr, messageValue).c_str());
         return;
         }
     if (a0)
@@ -975,9 +948,7 @@ double messageValue
     {
     if (messageValue != DBL_MAX)
         {
-        char message[2048];
-        sprintf (message, pDescr, messageValue);
-        checkFalse (a0, message);
+        checkFalse (a0, Utf8PrintfString(pDescr, messageValue).c_str());
         return;
         }
     if (!a0)

--- a/iModelCore/GeomLibs/common/test/printfuncs.h
+++ b/iModelCore/GeomLibs/common/test/printfuncs.h
@@ -808,14 +808,14 @@ void Content (char const *pName, DPoint2d const *pData)
 
 void Content (char const *pName, RotMatrix const *pM)
     {
-    EmitCompleteTag ("row0", pName, Utf8PrintfString("%lg,%lg,%lg", pM->form3d[0][0], pM->form3d[0][1], pM->form3d[0][2]).c_str());
+    EmitCompleteTag ("row0", pName, Utf8PrintfString("[%lg,%lg,%lg", pM->form3d[0][0], pM->form3d[0][1], pM->form3d[0][2]).c_str());
     EmitCompleteTag ("row1", pName, Utf8PrintfString("%lg,%lg,%lg", pM->form3d[1][0], pM->form3d[1][1], pM->form3d[1][2]).c_str());
     EmitCompleteTag ("row2", pName, Utf8PrintfString("%lg,%lg,%lg]", pM->form3d[2][0], pM->form3d[2][1], pM->form3d[2][2]).c_str());
     }
 
 void Content (char const *pName, DPoint4d const *pPoint)
     {
-    EmitCompleteTag("DPoint4d", pName, Utf8PrintfString("%lg,%lg,%lg", pPoint->x, pPoint->y, pPoint->z, pPoint->w).c_str());
+    EmitCompleteTag("DPoint4d", pName, Utf8PrintfString("%lg,%lg,%lg,%lg", pPoint->x, pPoint->y, pPoint->z, pPoint->w).c_str());
     }
 
 void Content (char const *pName, GraphicsPoint const *pGP)

--- a/iModelCore/GeomLibs/common/test/printfuncs.h
+++ b/iModelCore/GeomLibs/common/test/printfuncs.h
@@ -793,41 +793,29 @@ void EmitCompleteTag (char const * pTagName, char const *pNameString, char const
 
 void Content (char const *pName, DPoint3d const *pPoint)
     {
-    char stringVal[1024];
-    sprintf (stringVal, "%lg,%lg,%lg", pPoint->x, pPoint->y, pPoint->z);
-    EmitCompleteTag("DPoint3d", pName, stringVal);
+    EmitCompleteTag("DPoint3d", pName, Utf8PrintfString("%lg,%lg,%lg", pPoint->x, pPoint->y, pPoint->z).c_str());
     }
 
 void Content (char const *pName, DVec3d const *pVec)
     {
-    char stringVal[1024];
-    sprintf (stringVal, "%lg,%lg,%lg", pVec->x, pVec->y, pVec->z);
-    EmitCompleteTag("DVec3d", pName, stringVal);
+    EmitCompleteTag("DVec3d", pName, Utf8PrintfString("%lg,%lg,%lg", pVec->x, pVec->y, pVec->z).c_str());
     }
 
 void Content (char const *pName, DPoint2d const *pData)
     {
-    char stringVal[1024];
-    sprintf (stringVal, "%lg,%lg", pData->x, pData->y);
-    EmitCompleteTag("DPoint2d", pName, stringVal);
+    EmitCompleteTag("DPoint2d", pName, Utf8PrintfString("%lg,%lg", pData->x, pData->y).c_str());
     }
 
 void Content (char const *pName, RotMatrix const *pM)
     {
-    char stringVal[1024];
-    sprintf (stringVal, "%lg,%lg,%lg", pM->form3d[0][0], pM->form3d[0][1], pM->form3d[0][2]);
-    EmitCompleteTag ("row0", pName, stringVal);
-    sprintf (stringVal, "%lg,%lg,%lg", pM->form3d[1][0], pM->form3d[1][1], pM->form3d[1][2]);
-    EmitCompleteTag ("row1", pName, stringVal);
-    sprintf (stringVal, "%lg,%lg,%lg]", pM->form3d[2][0], pM->form3d[2][1], pM->form3d[2][2]);
-    EmitCompleteTag ("row2", pName, stringVal);
+    EmitCompleteTag ("row0", pName, Utf8PrintfString("%lg,%lg,%lg", pM->form3d[0][0], pM->form3d[0][1], pM->form3d[0][2]).c_str());
+    EmitCompleteTag ("row1", pName, Utf8PrintfString("%lg,%lg,%lg", pM->form3d[1][0], pM->form3d[1][1], pM->form3d[1][2]).c_str());
+    EmitCompleteTag ("row2", pName, Utf8PrintfString("%lg,%lg,%lg]", pM->form3d[2][0], pM->form3d[2][1], pM->form3d[2][2]).c_str());
     }
 
 void Content (char const *pName, DPoint4d const *pPoint)
     {
-    char stringVal[1024];
-    sprintf (stringVal, "%lg,%lg,%lg", pPoint->x, pPoint->y, pPoint->z, pPoint->w);
-    EmitCompleteTag("DPoint4d", pName, stringVal);
+    EmitCompleteTag("DPoint4d", pName, Utf8PrintfString("%lg,%lg,%lg", pPoint->x, pPoint->y, pPoint->z, pPoint->w).c_str());
     }
 
 void Content (char const *pName, GraphicsPoint const *pGP)
@@ -895,16 +883,12 @@ void Content (double a)
 
 void ContentHex (char const *pName, int a)
     {
-    char stringVal[1024];
-    sprintf (stringVal, "0x%x", a);
-    EmitCompleteTag ("hex", pName, stringVal);
+    EmitCompleteTag ("hex", pName, Utf8PrintfString("0x%x", a).c_str());
     }
 
 void Content (char const *pName, double a)
     {
-    char stringVal[1024];
-    sprintf (stringVal, "%20.15lg", a);
-    EmitCompleteTag ("double", pName, stringVal);
+    EmitCompleteTag ("double", pName, Utf8PrintfString("%20.15lg", a).c_str());
     }
 
 void Content (DPoint3d const *pPoint)
@@ -914,16 +898,12 @@ void Content (DPoint3d const *pPoint)
 
 void Content (char const *pName, int a)
     {
-    char stringVal[1024];
-    sprintf (stringVal, "%d", a);
-    EmitCompleteTag ("int", pName, stringVal);
+    EmitCompleteTag ("int", pName, Utf8PrintfString("%d", a).c_str());
     }
 
 void Content (char const *pName, bool a)
     {
-    char stringVal[1024];
-    sprintf (stringVal, "%s", a ? "true" : "false");
-    EmitCompleteTag ("bool", pName, stringVal);
+    EmitCompleteTag ("bool", pName, Utf8PrintfString("%s", a ? "true" : "false").c_str());
     }
 
 void Content (int a)

--- a/iModelCore/GeomLibs/geom/build/BentleyGeom/BentleyGeom.mke
+++ b/iModelCore/GeomLibs/geom/build/BentleyGeom/BentleyGeom.mke
@@ -38,17 +38,6 @@ nameToDefine = MinimalRefMethods
 CCompOpts + -we4238 
 %endif
 
-# This was recently introduced to clang.
-# Ignore unused but set variables for GeomLibs. Other compilers (gcc) already are ignoring this warning
-%if defined (BSI)
-    IsClang13_0_0_OrGreater = $[@readstdout "$(BBPYTHONCMD) $(SrcRoot)bsicommon/build/DetectClangVersion.py 1300.0.00.0"]
-%else
-    IsClang13_0_0_OrGreater = $[@readstdout "$(BBPYTHONCMD) $(_CurrentFilePath)/../../../../../build/PublicSDK/DetectClangVersion.py 1300.0.00.0"]
-%endif
-%if $(IsClang13_0_0_OrGreater) == "YES"
-    LLVMCommonCompOpts + -Wno-unused-but-set-variable
-%endif
-
 #--------------------------------------------------------------------------------
 #  Bring our precompiled header up-to-date.  After including PreCompileHeader.mki
 #  $(UsePrecompiledHeaderOptions) will contain the /Yu and /Fp options that we

--- a/iModelCore/GeomLibs/geom/src/CurvePrimitive/cp_spiralConstruction.cpp
+++ b/iModelCore/GeomLibs/geom/src/CurvePrimitive/cp_spiralConstruction.cpp
@@ -85,7 +85,7 @@ ICurvePrimitivePtr CreateBasePartialSpiralWithPreciseBearingCurvatureLengthCurva
     double distanceTolBig = 1.0e-7 * targetPartialLength;
     double distanceTolSmall = 1.0e-12 * targetPartialLength;
     double maxLocalFraction = 2.0;      // when extrapolating from prior iterates, allow modest amount of out-of-interval step.   (default to length ratio if this fails)
-    double curvature1, radius1, length1, fraction0;
+    double curvature1, radius1, length1;
     double bearing0 = 0.0;
     // (fraction0) is the approximate fraction for curvatureA
     // (fraction1, radius1, length1) are the construction parameters for the full spiral
@@ -93,14 +93,12 @@ ICurvePrimitivePtr CreateBasePartialSpiralWithPreciseBearingCurvatureLengthCurva
     // The actual fractions for the partial spiral are determined by search for precise requested curvatures.
     if (fabs (curvatureA) > fabs (curvatureB))
         {
-        fraction0 = curvatureB / curvatureA;
         curvature1 = curvatureA;
         radius1    = 1.0 / curvatureA;
         length1    = targetPartialLength * curvatureA / (curvatureA - curvatureB);
         }
     else
         {
-        fraction0 = curvatureA / curvatureB;
         curvature1 = curvatureB;
         radius1    = 1.0 / curvatureB;
         length1    = targetPartialLength * curvatureB / (curvatureB - curvatureA);

--- a/iModelCore/GeomLibs/geom/src/CurvePrimitive/cv_areaBooleans.cpp
+++ b/iModelCore/GeomLibs/geom/src/CurvePrimitive/cv_areaBooleans.cpp
@@ -284,15 +284,16 @@ MTGNodeId     nodeId
     bool myStat = false;
     int curveIndex;
     DPoint3d point[2];
-    //int parentId;
-    /* MSBsplineCurve curve; */
     DEllipse3d ellipse;
     MSBsplineCurve curve;
+
+#ifdef DEBUG_EXTRACT_EDGE
     static int s_numChords = 0; // to trigger length debug.
     double quickLength = 0.0;
     double realLength = 0.0;
     if (s_numChords > 0)
         quickLength = jmdlRG_quickChordLength (m_rgContext, nodeId, s_numChords);
+#endif
 
     if (   jmdlRG_getCurveData
 	    (m_rgContext, &curveIndex, &isReversed, &point[0], &point[1], nodeId)
@@ -317,8 +318,10 @@ MTGNodeId     nodeId
 	          }
         else if (jmdlRIMSBS_getDEllipse3d (m_rimsbsCurves, &ellipse, curveIndex, isReversed))
 	          {
+#ifdef DEBUG_EXTRACT_EDGE
 	          if (s_numChords > 0)
 	              realLength = ellipse.ArcLength ();
+#endif
             lineString.Flush (*this, dest);
             dest.push_back (ICurvePrimitive::CreateArc (ellipse));
             RecordNewCurve (dest.back (), callerCurveIndex);
@@ -629,7 +632,6 @@ const char * name = "op"
     
     CurveVectorPtr result;
     bvector<int> faceNodeIdArray;
-    bool myStat = false;
     MTGGraph * pGraph = context.GetGraph ();
 
     context.SetNextGroupId (0);
@@ -657,7 +659,7 @@ const char * name = "op"
         bvector<int> nodeIdToDepthArray;
         jmdlRG_collectAndNumberExtendedFaceLoops (context.m_rgContext, &startArray, &sequenceArray, &faceSet);
         jmdlRG_setMarksetDepthByInwardSearch (context.m_rgContext, &nodeIdToDepthArray, &faceSet);
-        myStat = context.TryAssembleComponents (sequenceArray, nodeIdToDepthArray, result);
+        context.TryAssembleComponents (sequenceArray, nodeIdToDepthArray, result);
 	}
 
     return result;
@@ -677,7 +679,6 @@ const char * name = "op"
     
     CurveVectorPtr result;
     bvector<int> faceNodeIdArray;
-    bool myStat = false;
     context.SetNextGroupId (0);
     context.Load (regionA);
     int numGroup = context.GetNextGroupId ();
@@ -697,7 +698,7 @@ const char * name = "op"
         bvector<int> nodeIdToDepthArray;
         jmdlRG_collectAndNumberExtendedFaceLoops (context.m_rgContext, &startArray, &sequenceArray, &faceSet);
         jmdlRG_setMarksetDepthByInwardSearch (context.m_rgContext, &nodeIdToDepthArray, &faceSet);
-        myStat = context.TryAssembleComponents (sequenceArray, nodeIdToDepthArray, result);
+        context.TryAssembleComponents (sequenceArray, nodeIdToDepthArray, result);
 	}
 
     return result;
@@ -721,7 +722,6 @@ const char * name = "op"
     
     CurveVectorPtr result;
     bvector<int> faceNodeIdArray;
-    bool myStat = false;
     context.SetNextGroupId (0);
 
     BoolSelect finalBoolOp = boolOp;
@@ -749,7 +749,7 @@ const char * name = "op"
         bvector<int> nodeIdToDepthArray;
         jmdlRG_collectAndNumberExtendedFaceLoops (context.m_rgContext, &startArray, &sequenceArray, &faceSet);
         jmdlRG_setMarksetDepthByInwardSearch (context.m_rgContext, &nodeIdToDepthArray, &faceSet);
-        myStat = context.TryAssembleComponents (sequenceArray, nodeIdToDepthArray, result);
+        context.TryAssembleComponents (sequenceArray, nodeIdToDepthArray, result);
 	}
 
     return result;

--- a/iModelCore/GeomLibs/geom/src/CurvePrimitive/cv_clone.cpp
+++ b/iModelCore/GeomLibs/geom/src/CurvePrimitive/cv_clone.cpp
@@ -546,18 +546,22 @@ static CurveVectorPtr CloneChainWithGapsClosed (CurveVectorCR source, CurveGapOp
     double maxAdjustAlongCurve = options.GetMaxAdjustAlongCurve ();
     bool   removePriorGaps = options.GetRemovePriorGapPrimitives ();
     static double s_nearParallelTolerance = 0.001;
+#ifdef DEBUG_CHAIN_GAPS
     size_t numGap = 0;
     double gapSum = 0.0;
     double a;
+#endif
     CurveVectorPtr result = CurveVector::Create (source.GetBoundaryType ());
     for (size_t i = 0, n = source.size (); i < n; i++)
         {
         if (removePriorGaps && source[i]->GetMarkerBit (ICurvePrimitive::CURVE_PRIMITIVE_BIT_GapCurve))
             {
             // skip it!!!
+#ifdef DEBUG_CHAIN_GAPS
             numGap++;
             source[i]->Length (a);
             gapSum += a;
+#endif
             }
         else
             {

--- a/iModelCore/GeomLibs/geom/src/CurvePrimitive/cv_hatch.cpp
+++ b/iModelCore/GeomLibs/geom/src/CurvePrimitive/cv_hatch.cpp
@@ -165,15 +165,10 @@ TransformCR transformA,
     {
     bool    boolstat;
     static double s_endTolerance = 1.0e-8;
-    double s_maxGapRelTol = 1.0e-6;
-    double maxGapTol = 1.0;
 
     DRange3d range;
     boundary.GetRange (range);
-    maxGapTol = s_maxGapRelTol * range.low.DistanceXY (range.high);
 
-    //cvHatch_appendWithArcsAsBezier (pBoundary, pBoundary);
-    //cvHatch_forceBezierAndLinestringEndsToNeighbors (pBoundary, maxGapTol);
     transform = transformA;
     zRangeLimits = false;
     altitudeTolerance = s_endTolerance;
@@ -913,7 +908,6 @@ int                             *pPlane0,
 int                             *pPlane1
 )
     {
-    int plane0, plane1;
     if (pContext->zRangeLimits)
         {
         if (*pPlane0 < pContext->minPlane)
@@ -925,8 +919,7 @@ int                             *pPlane1
     /* Watch for integer overflow case!!
         If plane1 is at maxint, "next" integer wraps to negative.
     */
-    plane0 = *pPlane0;
-    plane1 = *pPlane1;
+    int plane1 = *pPlane1;
     plane1++;
     if (plane1 < *pPlane1)
         {

--- a/iModelCore/GeomLibs/geom/src/CurvePrimitive/cv_offset.cpp
+++ b/iModelCore/GeomLibs/geom/src/CurvePrimitive/cv_offset.cpp
@@ -825,15 +825,13 @@ CurveVectorR collector
         curveC->FractionToPoint (0.0, tangentC0);
     DSegment3d segment;
     DEllipse3d arc;
-    bool done = false;
     if (curveB.TryGetLine (segment))
         {
         CollectOffsetSegment (tangentA1, segment, tangentC0, options, collector);
-        done = true;
         }
     else if (curveB.TryGetArc (arc))
         {
-        done = CollectOffsetCircularArc (tangentA1, arc, tangentC0, options, collector);
+        CollectOffsetCircularArc (tangentA1, arc, tangentC0, options, collector);
         }
 #ifdef primitiveSupport
     else

--- a/iModelCore/GeomLibs/geom/src/SolidPrimitive/sp_AreaMoments.cpp
+++ b/iModelCore/GeomLibs/geom/src/SolidPrimitive/sp_AreaMoments.cpp
@@ -403,7 +403,9 @@ bool AddBetween (DEllipse3d ellipseA, DEllipse3d ellipseB, double f0, double f1)
     {
     DPoint3d XA, XB, X;
     DVec3d  dXAdu, dXBdu, dXdv, dXdu, ddXA, ddXB;
+#ifndef NDEBUG
     double checksum = 0.0;
+#endif
     double u, v, wu, wv, detJ;
     DMatrix4d products = DMatrix4d::FromZero ();
     for (int i = 0; m_lineGauss.GetEval (i, f0, f1, u, wu); i++)
@@ -417,10 +419,12 @@ bool AddBetween (DEllipse3d ellipseA, DEllipse3d ellipseB, double f0, double f1)
             dXdu.Interpolate (dXAdu, v, dXBdu);
             detJ = dXdu.CrossProductMagnitude (dXdv);
             products.AddSymmetricScaledOuterProduct (X, detJ * wu * wv);
+#ifndef NDEBUG
             checksum += wu * wv;
+#endif
             }
         }
-    assert (DoubleOps::AlmostEqual (checksum, f1 - f0));
+    BeAssert (DoubleOps::AlmostEqual (checksum, f1 - f0));
     m_products.Add (products);        
     return true;
     

--- a/iModelCore/GeomLibs/geom/src/SolidPrimitive/sp_silhouette.cpp
+++ b/iModelCore/GeomLibs/geom/src/SolidPrimitive/sp_silhouette.cpp
@@ -1497,11 +1497,7 @@ void                    *pOutputParams
     int band;
     StatusInt bandStatus;
 
-    double phiSweep, thetaSweep;
-
-    thetaSweep  = theta1 - theta0;
-
-    phiSweep    = phi1 - phi0;
+    double phiSweep = phi1 - phi0;
 
     /* Two complete theta loops, each with restricted phi range */
     if (!Angle::IsFullCircle (phiSweep))
@@ -1706,15 +1702,11 @@ void                    *pOutputData
     double phiStart, phiEnd, thetaStart, thetaEnd;
     double smallAngle = bsiTrig_smallAngle ();
 
-    double phiSweep, thetaSweep;
     double thetaBandSweep;
     double phiBandSweep;
 
     double maxDTheta = bandTolerance;
     double maxDPhi   = bandTolerance;
-    thetaSweep  = theta1 - theta0;
-
-    phiSweep    = phi1 - phi0;
 
     /* Get the raw bubble limits */
     fillCriticalAngles (thetaCrit, &numThetaCrit, pThetaLimit, numThetaLimit, 0.0, msGeomConst_2pi);
@@ -1799,8 +1791,7 @@ void                *pUserData      /* => arbitrary pointer */
 )
     {
     StatusInt status = ERROR;
-    double a,b;
-    double theta0, theta1, thetaSweep, phi0, phi1, phiSweep;
+    double theta0, theta1, phi0, phi1;
 
     DPoint3d thetaLimit[8], phiLimit[8];
     int numThetaLimit, numPhiLimit;
@@ -1813,18 +1804,10 @@ void                *pUserData      /* => arbitrary pointer */
     if (!pSurface || RC_Torus != pSurface->type)
         return ERROR;
 
-    /* Torus sizes, correspond to analysis on paper */
-    a = 1.0;
-    b = pSurface->hoopRadius;
-
     theta0 = pSurface->parameterRange.low.x;
     theta1 = pSurface->parameterRange.high.x;
-    thetaSweep = theta1 - theta0;
-
     phi0 = pSurface->parameterRange.low.y;
     phi1 = pSurface->parameterRange.high.y;
-    phiSweep = phi1 - phi0;
-
 
     bsiRotatedConic_toroidalFormLimits (thetaLimit, &numThetaLimit, pMatrix, false);
     bsiRotatedConic_toroidalFormLimits (phiLimit, &numPhiLimit, pMatrix, true);

--- a/iModelCore/GeomLibs/geom/src/bezier/bezroot.cpp
+++ b/iModelCore/GeomLibs/geom/src/bezier/bezroot.cpp
@@ -589,6 +589,8 @@ int             order
 )
     {
     static int      sbPreferAnalytic = 0;
+
+#ifdef DEBUG_UNIVARIATE_ROOTS
     double testRoot[100];
     int numTestRoot;
     static double sErrorCount = 0;
@@ -637,13 +639,19 @@ int             order
                 }
             }
         }
+#endif
+
     bool    stat =  bsiBezier_univariateRootsOptionalAnalytic (pRootArray, pNumRoot, pA, order, 0 != sbPreferAnalytic);
+
+#ifdef DEBUG_UNIVARIATE_ROOTS
     if (*pNumRoot == 0)
         sNumRoot0++;
     else if (*pNumRoot == 1)
         sNumRoot1++;
     else
         sNumRootX += *pNumRoot;
+#endif
+
     return stat;
     }
 

--- a/iModelCore/GeomLibs/geom/src/bspline/BsplineCurveFit.cpp
+++ b/iModelCore/GeomLibs/geom/src/bspline/BsplineCurveFit.cpp
@@ -2473,7 +2473,6 @@ double                      ptol        /* => point equal tolerance, recommand s
 
     /* Initialize some variables */
 
-    ITLIM = 4;
     top = ptol;
     toc = 1.e-6;
     ktol = 0.0001;

--- a/iModelCore/GeomLibs/geom/src/bspline/BsplineCurveFit.cpp
+++ b/iModelCore/GeomLibs/geom/src/bspline/BsplineCurveFit.cpp
@@ -2452,11 +2452,9 @@ double                      Ep,         /* => parametric tolerance, recommand se
 double                      ptol        /* => point equal tolerance, recommand set to 0.01*geomTol */
 )
     {
-    int         ITLIM = 50;
     bool        keepTangent = false, closed = false;
-    int         nn, mm, i, j, k, km, kn, jj, kk, np, k1, k2, k3, mmm, m, u2size;
-    //int         save = ITLIM;
-    double      *U1, *U2, mintol, d1, d2, d3, du, top, toc, bigerr, dv, Ebnd, ktol, maxtol;
+    int         nn, mm, i, j, k, km, kn, jj, kk, np, k1, k2, k3, m, u2size;
+    double      *U1, *U2, mintol, d1, d2, d3, du, top, toc, dv, Ebnd, ktol, maxtol;
     DVec3d      Vs, Ve, V1, V2, VO;
     double      u, v;
     int         pp;
@@ -2496,7 +2494,6 @@ double                      ptol        /* => point equal tolerance, recommand s
     /* Do knot removal on degree 1 curve */
 
     mintol = std::min(Eg, Ep);
-    bigerr = 10.0*mintol;
     cur2.CopyFrom (cur1);
     cur2.RemoveKnotsBounded (60.0*mintol, 0, 0);
 
@@ -2843,7 +2840,6 @@ double                      ptol        /* => point equal tolerance, recommand s
 
             kk = kk+1;
             }
-        mmm = mm;     /* save it */
         mm = k2-1;    /* new high index for number of points and parameters */
         nn = km-p-1;  /* new high index of control points */
 
@@ -3620,7 +3616,7 @@ double          tolerance   // => fitting tolerance
     const double    top = 1.0e-02, toc = 1.0e-03;
     MSBsplineStatus status = MSB_SUCCESS;
     bool            apr;
-    int             k, l, nc, mc, nh, mh, mk, nsp, mlt, c, i, j, m = numPoints - 1, ps = iterDegree, pr = reqDegree;
+    int             k, l, nc, mc, nh, mh, mk, nsp, mlt, i, j, m = numPoints - 1, ps = iterDegree, pr = reqDegree;
     double          *U, d, ltop, ltoc;
     DPoint3d        R;
     DVec3d          As, Ae;
@@ -3639,7 +3635,6 @@ double          tolerance   // => fitting tolerance
 
     ltop = d*top;
     ltoc = toc;
-    c    = -1;
 
     /* Get tangents or derivatives */
 
@@ -3672,7 +3667,7 @@ double          tolerance   // => fitting tolerance
         D[1] = Ae;
 
         wd[0] = -1.0;  wd[1] = -1.0;
-        I[0]  = 0;     I[1]  = m;     c = 1;
+        I[0]  = 0;     I[1]  = m;
         }
 
     bvector<double> u (m+1), us (m+1), er (m+1), wp (m+1), knt;

--- a/iModelCore/GeomLibs/geom/src/bspline/MSBsplineCurve_Modify.cpp
+++ b/iModelCore/GeomLibs/geom/src/bspline/MSBsplineCurve_Modify.cpp
@@ -217,12 +217,11 @@ double              tol   // Tolerance to check removability
     {
     const double WMIN = 1e-5;
     const double WMAX = 200.0;
-    int i, j, k, ii, jj, first, last, off, n, m, r, s, fout, l, ns, lp, rp, lt, rt, left = 0, right = 0, p, nu, norem = 0;
+    int i, j, k, ii, jj, first, last, off, n, m, r, s, fout, l, lp, rp, lt, rt, left = 0, right = 0, p, nu, norem = 0;
     bool rmf, rem, rat = false;
     p = pCurve->params.order - 1;
     n = pCurve->params.numPoles - 1;
     m = n + p +1;
-    ns = n;
     nu = num - 1;
     
     bvector<DPoint4d> tmpPoles (2*p+1);
@@ -488,12 +487,11 @@ double              tol
     {
     const double WMIN = 1e-5;
     const double WMAX = 200.0;
-    int i, j, k, ii, jj, first, last, off, n, m, r, s, fout, l, ns, p, norem = 0;
+    int i, j, k, ii, jj, first, last, off, n, m, r, s, fout, l, p, norem = 0;
     bool rmf, rat = false;
     p = pCurve->params.order - 1;
     n = pCurve->params.numPoles - 1;
     m = n + p +1;
-    ns = n;
     
     bvector<DPoint4d> tmpPoles (2*p+1);
     bvector<DPoint4d> polesWeighted (n+1);
@@ -726,7 +724,6 @@ MSBsplineStatus MSBsplineCurve::RemoveKnotsBounded (double tol, int startPreserv
     double param[2], knot;
     int numParam = 0, status, paramType[2], iKnot, iMult, mult; 
     int degree = params.order - 1, m = params.numPoles + params.order - 1;
-    bool    bOverSaturatedKnot = false;
     
     if (startPreservation)
         {
@@ -739,10 +736,9 @@ MSBsplineStatus MSBsplineCurve::RemoveKnotsBounded (double tol, int startPreserv
         paramType[numParam++] = endPreservation;
         }
     
-        // flatten first knot if oversaturated
+    // flatten first knot if oversaturated
     if (knots[degree + 1] - knots[degree] < RELATIVE_BSPLINE_KNOT_TOLERANCE)
         {
-        bOverSaturatedKnot = true;
         knot = knots[0];
         for (iKnot = 1; iKnot <= m && knots[iKnot] - knot < RELATIVE_BSPLINE_KNOT_TOLERANCE; iKnot++)
             knots[iKnot] = knot;
@@ -751,7 +747,6 @@ MSBsplineStatus MSBsplineCurve::RemoveKnotsBounded (double tol, int startPreserv
     // flatten last knot if oversaturated
     if (knots[m - degree] - knots[m - degree - 1] < RELATIVE_BSPLINE_KNOT_TOLERANCE)
         {
-        bOverSaturatedKnot = true;
         knot = knots[m];
         for (iKnot = m - 1; iKnot >= 0 && knot - knots[iKnot] < RELATIVE_BSPLINE_KNOT_TOLERANCE; iKnot--)
             knots[iKnot] = knot;
@@ -766,7 +761,6 @@ MSBsplineStatus MSBsplineCurve::RemoveKnotsBounded (double tol, int startPreserv
             {
             for (iMult = 1; iMult < mult; iMult++)
                 knots[iKnot + iMult] = knot;
-            bOverSaturatedKnot = true;
             }
         }
 

--- a/iModelCore/GeomLibs/geom/src/bspline/MSBsplineSurface.cpp
+++ b/iModelCore/GeomLibs/geom/src/bspline/MSBsplineSurface.cpp
@@ -1337,7 +1337,7 @@ double              tol
     const double WMAX = 200.0;
     bool rmf, wfl, rat = false;
     int krm, i, j, k, l, row, col, ii, jj, first, last, off, fout, n, m, r, s,
-            ru = 0, su = 0, rv = 0, sv = 0, ns, ms;
+            ru = 0, su = 0, rv = 0, sv = 0, ns;
     int p, q, noremu = 0, noremv = 0;
     double *UQ = pSurf->uKnots, *VQ = pSurf->vKnots, lam = 0, oml = 0, wmin, wmax, pmax, al, be, bu = 0, bv = 0, wi, wj; 
     
@@ -1348,7 +1348,6 @@ double              tol
     r = pSurf->uParams.NumberAllocatedKnots () - 1;
     s = pSurf->vParams.NumberAllocatedKnots () - 1;
     ns = n;
-    ms = m;
     int num = pSurf->uParams.numPoles * pSurf->vParams.numPoles;
     bvector<DPoint4d> polesWeighted (num);
         
@@ -1985,7 +1984,6 @@ MSBsplineStatus MSBsplineSurface::RemoveKnotsBounded (int dir, double tol)
     int         uDegree, vDegree;
     int         iKnot, iMult, mult;
     double      knot;
-    bool        bOverSaturatedUKnot = false, bOverSaturatedVKnot = false;
 
     uDegree = uParams.order - 1;
     vDegree = vParams.order - 1;
@@ -1997,7 +1995,6 @@ MSBsplineStatus MSBsplineSurface::RemoveKnotsBounded (int dir, double tol)
         // flatten first u-knot if oversaturated
         if (uKnots[uDegree + 1] - uKnots[uDegree] < RELATIVE_BSPLINE_KNOT_TOLERANCE)
             {
-            bOverSaturatedUKnot = true;
             knot = uKnots[0];
             for (iKnot = 1; iKnot <= r && uKnots[iKnot] - knot < RELATIVE_BSPLINE_KNOT_TOLERANCE; iKnot++)
                 uKnots[iKnot] = knot;
@@ -2006,7 +2003,6 @@ MSBsplineStatus MSBsplineSurface::RemoveKnotsBounded (int dir, double tol)
         // flatten last u-knot if oversaturated
         if (uKnots[r - uDegree] - uKnots[r - uDegree - 1] < RELATIVE_BSPLINE_KNOT_TOLERANCE)
             {
-            bOverSaturatedUKnot = true;
             knot = uKnots[r];
             for (iKnot = r - 1; iKnot >= 0 && knot - uKnots[iKnot] < RELATIVE_BSPLINE_KNOT_TOLERANCE; iKnot--)
                 uKnots[iKnot] = knot;
@@ -2021,7 +2017,6 @@ MSBsplineStatus MSBsplineSurface::RemoveKnotsBounded (int dir, double tol)
                 {
                 for (iMult = 1; iMult < mult; iMult++)
                     uKnots[iKnot + iMult] = knot;
-                bOverSaturatedUKnot = true;
                 }
             }
         }
@@ -2031,7 +2026,6 @@ MSBsplineStatus MSBsplineSurface::RemoveKnotsBounded (int dir, double tol)
         // flatten first v-knot if oversaturated
         if (vKnots[vDegree + 1] - vKnots[vDegree] < RELATIVE_BSPLINE_KNOT_TOLERANCE)
             {
-            bOverSaturatedVKnot = true;
             knot = vKnots[0];
             for (iKnot = 1; iKnot <= s && vKnots[iKnot] - knot < RELATIVE_BSPLINE_KNOT_TOLERANCE; iKnot++)
                 vKnots[iKnot] = knot;
@@ -2040,7 +2034,6 @@ MSBsplineStatus MSBsplineSurface::RemoveKnotsBounded (int dir, double tol)
         // flatten last v-knot if oversaturated
         if (vKnots[s - vDegree] - vKnots[s - vDegree - 1] < RELATIVE_BSPLINE_KNOT_TOLERANCE)
             {
-            bOverSaturatedVKnot = true;
             knot = vKnots[s];
             for (iKnot = s - 1; iKnot >= 0 && knot - vKnots[iKnot] < RELATIVE_BSPLINE_KNOT_TOLERANCE; iKnot--)
                 vKnots[iKnot] = knot;
@@ -2055,7 +2048,6 @@ MSBsplineStatus MSBsplineSurface::RemoveKnotsBounded (int dir, double tol)
                 {
                 for (iMult = 1; iMult < mult; iMult++)
                     vKnots[iKnot + iMult] = knot;
-                bOverSaturatedVKnot = true;
                 }
             }
         }

--- a/iModelCore/GeomLibs/geom/src/bspline/MSBsplineSurfaceLofting.cpp
+++ b/iModelCore/GeomLibs/geom/src/bspline/MSBsplineSurfaceLofting.cpp
@@ -75,10 +75,10 @@ int             derivative      /* => Highest derivatives maintained. Ignored wh
     const double WMIN = 1e-5;
     const double WMAX = 200.0;
 
-    int   i, j, k, l, ll,   ii, jj, first, last, off, n, ns, m, r, s = 0, fout, p;
+    int   i, j, k, l, ll,   ii, jj, first, last, off, n, m, r, s = 0, fout, p;
     size_t kk = numCurves - 1;
 
-    double    *U, *a, wmin, wmax, pmax, alf, bet, lam = 0.0, oml = 0.0, bsum, wi, wj;
+    double    *U, wmin, wmax, pmax, alf, bet, lam = 0.0, oml = 0.0, bsum, wi, wj;
 
     bvector<DPoint4d> Pw;
 
@@ -102,7 +102,6 @@ int             derivative      /* => Highest derivatives maintained. Ignored wh
     p = out[kk]->GetIntOrder () - 1;
     m = out[kk]->NumberAllocatedKnots () - 1;
     U = out[kk]->knots;
-    ns = n;
 
     if( out[0]->rational )
         {
@@ -286,8 +285,7 @@ int             derivative      /* => Highest derivatives maintained. Ignored wh
                 {
                 for (int iTemp=0; iTemp<out[ll]->NumberAllocatedPoles (); iTemp++)
                     Pw[iTemp] = out[ll]->GetPoleDPoint4d (iTemp);
-                a = out[ll]->knots;
-
+    
                 i  = first;
                 j  = last;
                 ii = 1;
@@ -349,7 +347,6 @@ int             derivative      /* => Highest derivatives maintained. Ignored wh
                     {
                     for (int iTemp=0; iTemp<out[ll]->NumberAllocatedPoles (); iTemp++)
                         Pw[iTemp] = out[ll]->GetPoleDPoint4d (iTemp);
-                    a = out[ll]->knots;
 
                     i = first;
                     j = last;

--- a/iModelCore/GeomLibs/geom/src/bspline/bspSmoothPolyface.cpp
+++ b/iModelCore/GeomLibs/geom/src/bspline/bspSmoothPolyface.cpp
@@ -301,7 +301,6 @@ bool                laplacianSmoothing
     static double s_defaultCount = 10.0;
     //static double s_graphRelTol = 1.0e-10;
     VuSetP      graph = vu_newVuSet (0);
-    StatusInt status = SUCCESS;
     int    maxPerFace = 3;
 
     static double s_shortEdgeToleranceFactor = 1.0e-8;
@@ -335,12 +334,10 @@ bool                laplacianSmoothing
 
     if (s_maxEdge * meshXLength < dx)
         {
-        status = ERROR;
         meshXLength = dx / s_maxEdge;
         }
     if (s_maxEdge * meshYLength < dy)
         {
-        status = ERROR;
         meshYLength = dy / s_maxEdge;
         }
     

--- a/iModelCore/GeomLibs/geom/src/bspline/bspdcurv.cpp
+++ b/iModelCore/GeomLibs/geom/src/bspline/bspdcurv.cpp
@@ -1674,7 +1674,7 @@ int             initMethod      /* => 0 for equal parameter step, 1 for equal ar
 )
     {
     bool        converge;
-    int         status = ERROR, i, j, allocSize, numParams;
+    int         status = ERROR, i, j, numParams;
     double      paramTol, step, deltaPlus = 0, deltaMinus;
     DPoint3d    ends[2], tmp;
     outparams.clear ();
@@ -1693,7 +1693,7 @@ int             initMethod      /* => 0 for equal parameter step, 1 for equal ar
         return (SUCCESS);
         }
 
-    allocSize = ((numParams = (int)numSeg - 1)) * sizeof(double);
+    numParams = (int)numSeg - 1;
     ScopedArray <double>upDiagArray (numParams);    double   *upDiag     = upDiagArray.GetData ();
     ScopedArray <double>lowDiagArray (numParams);   double   *lowDiag    = lowDiagArray.GetData ();
     ScopedArray <double>midDiagArray (numParams);   double   *midDiag    = midDiagArray.GetData ();

--- a/iModelCore/GeomLibs/geom/src/bspline/bspicurv.cpp
+++ b/iModelCore/GeomLibs/geom/src/bspline/bspicurv.cpp
@@ -218,7 +218,7 @@ double          relTol              /* => relative tolerance for integration */
     {
     //bool            startIn = false;
     int             status = SUCCESS;
-    double          error, length, errorFactor;
+    double          error, length;
     double startParam = mdlBspline_fractionParameterToNaturalParameter (curveP, startFraction);
     double endParam   = mdlBspline_fractionParameterToNaturalParameter (curveP, endFraction);
     TangentialFunctionThunk thunk;
@@ -232,7 +232,6 @@ double          relTol              /* => relative tolerance for integration */
     *fP = 0.0;
     *errorAchievedP = 0.0;
     int numSegments = 1;    // NEEDS WORK -- get true segment count.
-    errorFactor = relTol / numSegments;
     s_maxDepth = 0;
     DRange1d interval = DRange1d::From (startParam, endParam);
     for (size_t i = 0; curveP->AdvanceToBezierInKnotInterval  (thunk.segment, i, interval);)

--- a/iModelCore/GeomLibs/geom/src/bspline/bspicurv.cpp
+++ b/iModelCore/GeomLibs/geom/src/bspline/bspicurv.cpp
@@ -216,7 +216,6 @@ double          absTol,             /* absolute tolerance on integration */
 double          relTol              /* => relative tolerance for integration */
 )
     {
-    //bool            startIn = false;
     int             status = SUCCESS;
     double          error, length;
     double startParam = mdlBspline_fractionParameterToNaturalParameter (curveP, startFraction);
@@ -231,7 +230,6 @@ double          relTol              /* => relative tolerance for integration */
     /* Loop each Bezier segment */
     *fP = 0.0;
     *errorAchievedP = 0.0;
-    int numSegments = 1;    // NEEDS WORK -- get true segment count.
     s_maxDepth = 0;
     DRange1d interval = DRange1d::From (startParam, endParam);
     for (size_t i = 0; curveP->AdvanceToBezierInKnotInterval  (thunk.segment, i, interval);)

--- a/iModelCore/GeomLibs/geom/src/bspline/bspmisc.cpp
+++ b/iModelCore/GeomLibs/geom/src/bspline/bspmisc.cpp
@@ -102,7 +102,7 @@ BsplineParam*   pParams         // <=> potentially modified only if poles given
 )
     {
     bool        badFullKnots = false;
-    int         divisor, numKnots, numInteriorKnots, i;
+    int         divisor, numKnots, i;
     double      *pP, *pStart, *pEnd, *pNext, accum, step;
 
     if (!pKnots || !pParams)
@@ -130,8 +130,6 @@ BsplineParam*   pParams         // <=> potentially modified only if poles given
         }
     else
         {
-        numInteriorKnots = numKnots - 2 * pParams->order;
-
         /* replace any decreasing interior knots with uniformly spaced knots */
         for (pP = pStart + 1; pP < pEnd; pP++)
             {

--- a/iModelCore/GeomLibs/geom/src/bspline/bsppolyface.cpp
+++ b/iModelCore/GeomLibs/geom/src/bspline/bsppolyface.cpp
@@ -570,14 +570,13 @@ double globalRelTol
 )
     {
     double tol;
-    double maxAbs, maxDiagonal;
+    double maxDiagonal;
     double a, b;
     DRange3d range;
     DVec3d diagonal;
     range.InitFrom(pXYZ, numXYZ);
     diagonal.DifferenceOf (range.low, range.high);
-    maxAbs = range.LargestCoordinate ();
-    maxDiagonal = diagonal.MaxAbs ();
+    maxDiagonal = diagonal.MaxAbs ();   // TODO: probably should be range.LargestCoordinate >= diagonal.MaxAbs 
 
     if (absTol < sDefaultAbsTol)
         absTol = sDefaultAbsTol;

--- a/iModelCore/GeomLibs/geom/src/bspline/bsppolyface.cpp
+++ b/iModelCore/GeomLibs/geom/src/bspline/bsppolyface.cpp
@@ -1751,12 +1751,12 @@ bvector<MeshRegion> &monotoneRegions
 )
     {
     int             xSlope, firstXSlope, lastXSlope,  ySlope, firstYSlope, lastYSlope,
-                    status, pointBufSize, index, nDistinct;
+                    status, index, nDistinct;
     bool            ascending;
     Intercept       *intersectionP;
     InterceptHeader crossHeader[2], touchHeader[2];
     int             iTop,iBottom;       /* These swap between 0 and 1 on successive cuts */
-    double yTop,yBottom,yNext;
+    double          yBottom, yNext;
     bvector<double> extrema;
 
     crossHeader[0].clear ();
@@ -1840,7 +1840,6 @@ bvector<MeshRegion> &monotoneRegions
     for (size_t i=1; i < extrema.size (); i++ )
         {
         /* Swap the old 'bottom' to be the current top */
-        yTop = yBottom;
         yBottom = extrema[i];
         iTop = iBottom;
         iBottom = 1 - iTop;
@@ -1862,8 +1861,6 @@ bvector<MeshRegion> &monotoneRegions
             _Analysis_assume_(intersectionP != nullptr); // see the conditional assignment above.
             monotoneRegions.push_back (MeshRegion ());
             MeshRegion &newRegion = monotoneRegions.back();
-
-            pointBufSize = 0;
 
             /* Left Side */
             ascending   = intersectionP[j].ascending;
@@ -2023,13 +2020,11 @@ DPoint2d            *paramScaleP,               /* => parameter scale */
 bool                reverse
 )
     {
-    int             status = ERROR, totalPoints, i, j;
+    int             status = ERROR, i, j;
 
     DPoint2d        pnt, min, max,
                     paramMin, paramDelta;
     DPoint2d delta;
-
-    totalPoints = nU * nV;
 
     if ( nU < 2 || nV < 2 )
         return SUCCESS;
@@ -2090,7 +2085,7 @@ DPoint2d            *paramScaleP,               /* => parameter scale */
 bool                reverse
 )
     {
-    int             status = ERROR, totalPoints, i, j, nU, nV, uMinIndex, uMaxIndex,
+    int             status = ERROR, i, j, nU, nV, uMinIndex, uMaxIndex,
                     vMinIndex, vMaxIndex;
     DPoint2d        pnt, min, max,
                     paramMin, paramDelta;
@@ -2112,7 +2107,6 @@ bool                reverse
 
     nU = (uMaxIndex - uMinIndex + 1);
     nV = (vMaxIndex - vMinIndex + 1);
-    totalPoints = nU * nV;
 
     mpP->handler.ClearArrays ();
     
@@ -2911,18 +2905,15 @@ bvector<DPoint2d>    &boundary,                 /* = region boundary */
 MSBsplineSurface    *surfaceP
 )
     {
-    int                 minIndex, maxIndex, nPnts, status, bufSize, j, next,
-                        minLeftIndex, maxLeftIndex, minRightIndex, maxRightIndex, index,
-                        pointBufSize;
+    int                 minIndex, maxIndex, nPnts, status, j, next,
+                        minLeftIndex, maxLeftIndex, minRightIndex, maxRightIndex, index;
     double              boundMin, boundMax;
     DPoint2d            *pnts, *pntP, *endP, minLeftPoint, maxLeftPoint,
-                        minRightPoint, maxRightPoint, *pointP;
+                        minRightPoint, maxRightPoint;
     
-    pointP = NULL;
     bvector<DPoint2d*> slicePointers;
     bvector<DPoint2d> slicePoints;
     bvector<DPoint2d>  points;  
-    pointBufSize = 0;
     pnts  = &boundary[0];
     nPnts = (int)boundary.size () - 1;
 
@@ -2942,7 +2933,6 @@ MSBsplineSurface    *surfaceP
             }
         }
 
-    bufSize = 0;
     minLeftIndex = minRightIndex = minIndex;
     minLeftPoint = minRightPoint = pnts[minIndex];
     int uNumSegs, vNumSegs;

--- a/iModelCore/GeomLibs/geom/src/bspline/bsprsurf.cpp
+++ b/iModelCore/GeomLibs/geom/src/bspline/bsprsurf.cpp
@@ -1106,7 +1106,7 @@ double                  processTol
     {
     bool            shift, mixed = false, lastClosed = false, currentClosed;
     int             i, j, rational, status = SUCCESS, numU, numV, numPoints;
-    double          *wPts = NULL, *wPoles = NULL, length, relativeTol, step, param;
+    double          *wPts = NULL, *wPoles = NULL, length, step, param;
     DPoint3d        *pPts = NULL, *pPoles = NULL, *pointsP;
     MSBsplineCurve  ruleCurves[2];
 
@@ -1115,7 +1115,7 @@ double                  processTol
         {
         if (processCurves)
             {
-            length = 0.0; relativeTol = 0.005;
+            length = 0.0;
             if (fabs(processTol) < 1.0e-15)
                 return  ERROR;
             else if (processTol < 0.0)
@@ -1178,7 +1178,6 @@ double                  processTol
         if (processCurves)
             {
             length = 0.0;
-            relativeTol = 0.005;
             numPoints = (int) (1.0 / processTol);
             if (numPoints < 2) numPoints = 2;
             pointsP = (DPoint3d*)malloc ((numPoints+2) * sizeof(DPoint3d));

--- a/iModelCore/GeomLibs/geom/src/bspline/bspsurfacetrim.cpp
+++ b/iModelCore/GeomLibs/geom/src/bspline/bspsurfacetrim.cpp
@@ -121,7 +121,7 @@ double param1                           // => end parameter on curve
     BeAssert(baseCount == curvePoints.size());
     DPoint3d curvePoint0, surfacePoint0, curvePoint1, surfacePoint1;
     double delta = param1 - param0;
-    double u, u0, u1;
+    double u, u0;
     double baseStep, localStep;
     int i, j, numJ, newNumJ;
     bool    bAddBasePoint;
@@ -135,7 +135,6 @@ double param1                           // => end parameter on curve
     static int sMaxJ = 2048;
     static double sMinParamStep = 1.0e-5;
     double curveError, surfaceError;
-    double curveError0, surfaceError0;
     if (curveTol <= 0.0)
         curveTol = sDefaultCurveTol;
     if (surfaceTol <= 0.0)
@@ -179,14 +178,9 @@ double param1                           // => end parameter on curve
         {
         baseCount = surfacePoints.size ();
         u0 = param0 + (i - 1) * baseStep;
-        u1 = param0 + i * baseStep;
-        if (i == minPoints - 1)
-            u1 = param1;
         numJ = 2;
-        curveError0 = 1.0e20;
-        surfaceError0 = 1.0e20;
         countFactor   = 1.0;
-        for (;; surfaceError0 = surfaceError, curveError0 = curveError)
+        for (;;)
             {
             localStep = baseStep / numJ;
             for (j = 1; j <= numJ; j++)
@@ -274,7 +268,6 @@ const MSBsplineSurface *surface
     static int sMaxJ = 2048;
     static double sMinParamStep = 1.0e-5;
     double surfaceError;
-    double surfaceError0;
 
     if (surfaceTol <= 0.0)
         surfaceTol = sDefaultSurfaceTol;
@@ -315,14 +308,10 @@ const MSBsplineSurface *surface
         {
         baseCount = surfacePoints.size();
         double u0 = (i - 1) * baseStep;
-        double u1 = i * baseStep;
-        if (i == minPoints - 1)
-            u1 = 1.0;
         numJ = 2;
 
-        surfaceError0 = 1.0e20;
         countFactor   = 1.0;
-        for (;; surfaceError0 = surfaceError)
+        for (;;)
             {
             localStep = baseStep / numJ;
             for (j = 1; j <= numJ; j++)
@@ -1434,7 +1423,7 @@ const MSBsplineSurface      *pSurface,
 int                         horizontal
 )
     {
-    int             prev, curr, next, numSpans, bufSize, numPoints;
+    int             prev, curr, next, bufSize, numPoints;
     double          scanHeight, near1;
     DPoint2d        *p;
     BsurfBoundary   *currBound, *endB;
@@ -1494,7 +1483,7 @@ int                         horizontal
         }
     else if (pSurface->numBounds > 0)
         {
-        numSpans = bufSize = 0;
+        bufSize = 0;
         near1 = 1.0 - fc_epsilon;
         if (!pSurface->holeOrigin)
             {

--- a/iModelCore/GeomLibs/geom/src/bspline/bsputil.cpp
+++ b/iModelCore/GeomLibs/geom/src/bspline/bsputil.cpp
@@ -3144,7 +3144,7 @@ int                     nFullCircleIsoparametrics
     {
     int                 nPoles = curveP->params.numPoles;
     double              angle;
-    DPoint3d            *poleP, *endP, *firstPoleP, *lastPoleP;
+    DPoint3d            *poleP, *endP, *lastPoleP;
     DVec3d              normal, lastNormal;
 
     if (curveP->rational)
@@ -3152,7 +3152,7 @@ int                     nFullCircleIsoparametrics
 
     angle = 0.0;
 
-    firstPoleP = lastPoleP = curveP->poles;
+    lastPoleP = curveP->poles;
     for (poleP = lastPoleP + 1, endP = lastPoleP + nPoles; poleP < endP; poleP++)
        {
        normal.NormalizedDifference (*lastPoleP, *poleP);

--- a/iModelCore/GeomLibs/geom/src/funcs/PolygonOps.cpp
+++ b/iModelCore/GeomLibs/geom/src/funcs/PolygonOps.cpp
@@ -355,7 +355,7 @@ bool             addVerticesAtCrossings
     VuMask      numberedNodeMask = vu_grabMask (graphP);
     VuP         faceP, originalNodeP;
     bool status = false;
-    int       i, numError;
+    int       i;
     int       originalIndex;
     int       outputIndex;
     int     separator = signedOneBasedIndices ? 0 : -1;
@@ -382,7 +382,6 @@ bool             addVerticesAtCrossings
         vu_flipTrianglesToImproveQuadraticAspectRatio (graphP);
 
     vu_collectInteriorFaceLoops (faceArrayP, graphP);
-    numError = 0;
 
     vu_arrayOpen (faceArrayP);
     status = true;
@@ -506,7 +505,6 @@ int PolygonOps::CoordinateFrameAndRank
     size_t numBeforeDisconnect = 0;
     //bool bDone = false;
     static double sFirstEdgeFactor = 0.001;
-    bool degenerateNormal = false;
     bool bOK = false;
     localToWorld.InitIdentity ();
     worldToLocal.InitIdentity ();
@@ -544,7 +542,6 @@ int PolygonOps::CoordinateFrameAndRank
         DVec3d vectorX, vectorY, vectorZ;
         vector.GetNormalizedTriad (vectorX, vectorY, vectorZ);
         normal = vectorY;
-        degenerateNormal = true;
         }
     // Capture x direction along first ong edge, and upwards orientation by first polygon area vectors ..
     bOK = false;

--- a/iModelCore/GeomLibs/geom/src/funcs/newton.cpp
+++ b/iModelCore/GeomLibs/geom/src/funcs/newton.cpp
@@ -316,8 +316,6 @@ FunctionRRToRRD &evaluator
     double u = uu;
     double v = vv;
     double f=0.0, g=0.0, dfdu, dfdv, dgdu, dgdv, du, dv;
-    double du0 = DBL_MAX;
-    double dv0 = DBL_MAX;
     double f0=0.0, g0=0.0;
     static double s_smallDeltaForFunctionValueTest = 1.0e-14;
     for (int numIterations = 0; CheckIterationStart (u, v, numIterations); numIterations++)
@@ -335,8 +333,6 @@ FunctionRRToRRD &evaluator
             }
         u -= du;
         v -= dv;
-        du0 = du;
-        dv0 = dv;
         if (CheckConvergence (u, v, f, g, du, dv, numConverged))
             {
             return SetReturnValues (uu, vv, u, v,
@@ -363,7 +359,6 @@ FunctionRToRD &evaluator
     int numConverged = 0;
     double u = uu;
     double f=0.0, dfdu;
-    double du0 = DBL_MAX;
     double f0=0.0;
     static double s_smallDeltaForFunctionValueTest = 1.0e-14;
     for (int numIterations = 0; CheckIterationStart (u, u, numIterations); numIterations++)
@@ -378,7 +373,6 @@ FunctionRToRD &evaluator
         if (!du.IsValid ())
             return false;
         u -= du;
-        du0 = du;
         if (CheckConvergence (u, u, f, f, du.Value (), du.Value (), numConverged))
             {
             return SetReturnValues (uu, u,

--- a/iModelCore/GeomLibs/geom/src/funcs/polygon3d.cpp
+++ b/iModelCore/GeomLibs/geom/src/funcs/polygon3d.cpp
@@ -2029,7 +2029,6 @@ int             numXYZB
     {
     DPoint3d originA, originB;
     DVec3d   normalA, normalB;
-    double   areaA,   areaB;
     int numParamA, numParamB;
     if (numXYZA < 2 || numXYZB < 2)
         return false;
@@ -2043,8 +2042,8 @@ int             numXYZB
                                             // a polygon intersecting at their commone edge. -TR# 274510.
 
     DRay3d ray;
-    areaA = bsiPolygon_polygonNormalAndArea (&normalA, &originA, pXYZArrayA, numXYZA);
-    areaB = bsiPolygon_polygonNormalAndArea (&normalB, &originB, pXYZArrayB, numXYZB);
+    bsiPolygon_polygonNormalAndArea (&normalA, &originA, pXYZArrayA, numXYZA);
+    bsiPolygon_polygonNormalAndArea (&normalB, &originB, pXYZArrayB, numXYZB);
 
     if (pNormalA)
         *pNormalA = normalA;

--- a/iModelCore/GeomLibs/geom/src/mtg/MtgFacetPlanarMerge.cpp
+++ b/iModelCore/GeomLibs/geom/src/mtg/MtgFacetPlanarMerge.cpp
@@ -360,7 +360,6 @@ PolyfaceHeaderPtr PolyfaceHeader::CloneWithMaximalPlanarFacets (bool mergeCoplan
     int readIndexOffset;
     if (!mtgFacets->GetGraphP ()->TrySearchLabelTag (MTG_LABEL_TAG_POLYFACE_READINDEX, readIndexOffset))
         return newMesh;
-    size_t errors = 0;
     MTGMask planarBoundaryMask = MTG_PRIMARY_EDGE_MASK;
     if (mtgFacets->BuildFacePlaneNormals ())
         {
@@ -374,9 +373,9 @@ PolyfaceHeaderPtr PolyfaceHeader::CloneWithMaximalPlanarFacets (bool mergeCoplan
             if (CountMaskParityErrorAroundVertexLoops (*mtgFacets->GetGraphP (), planarBoundaryMask) == 0)
                 {
                 bvector<bvector<MTGNodeId>> loopNodes;
-                errors += CollectExtendedFaceLoops (*mtgFacets->GetGraphP (), loopNodes, planarBoundaryMask, vertexInColinearEdgeMask);
+                CollectExtendedFaceLoops (*mtgFacets->GetGraphP (), loopNodes, planarBoundaryMask, vertexInColinearEdgeMask);
                 bvector<bvector<int>> readIndexLoops;
-                errors += CollectLabels (*mtgFacets->GetGraphP (), readIndexOffset, loopNodes, readIndexLoops);
+                CollectLabels (*mtgFacets->GetGraphP (), readIndexOffset, loopNodes, readIndexLoops);
 #ifdef PrintExtendedLoops
                 Check::PrintHeading ("ExtendedFaceLoops", "nodes");
                 for (auto &loop : loopNodes)

--- a/iModelCore/GeomLibs/geom/src/mtg/mtgflowlines.cpp
+++ b/iModelCore/GeomLibs/geom/src/mtg/mtgflowlines.cpp
@@ -349,7 +349,6 @@ bool FaceContainsPoint (MTGNodeId faceSeedNodeId, DPoint3dCR testXYZ, MTGPositio
     //   All areas are doubled, doubling will cancel in ratios.
     int numPositiveHit = 0;
     int numNegativeHit = 0;
-    double areaSum = 0.0;
     while (nodeIdB != faceSeedNodeId)
         {
         DPoint3d xyzB = m_facets.GetXYZ (nodeIdB);
@@ -359,7 +358,6 @@ bool FaceContainsPoint (MTGNodeId faceSeedNodeId, DPoint3dCR testXYZ, MTGPositio
         double areaOriginAB = vectorA.CrossProductXY (vectorB);
         double areaOriginAQ = vectorA.CrossProductXY (vectorQ);
         double areaOriginQB = vectorQ.CrossProductXY (vectorB);
-        areaSum += areaOriginAB;
         double lambdaA, lambdaB, lambdaAB;
         if (DoubleOps::SafeDivide (lambdaA, areaOriginAQ, areaOriginAB, 0.0)
             && DoubleOps::SafeDivide (lambdaB, areaOriginQB, areaOriginAB, 0.0))

--- a/iModelCore/GeomLibs/geom/src/polyface/IPolyfaceConstruction_Add.cpp
+++ b/iModelCore/GeomLibs/geom/src/polyface/IPolyfaceConstruction_Add.cpp
@@ -3041,18 +3041,10 @@ bool capped
         pointIndexA1 = FindOrAddPoint (pointA[i]);
         pointIndexB1 = FindOrAddPoint (xyzB1);
         double du = 0.0;
-        size_t visibiltyTestIndex;
-        if (i == 0)
-            {
-            visibiltyTestIndex = n - 1;
-            }
-        else
+        if (i > 0)
             {
             du = pointA[i-1].Distance (pointA[i]);
             accumulatedDistance += du;
-            visibiltyTestIndex = i + 1;
-            if (i == n - 1)
-                visibiltyTestIndex = 0;
             }
 
         if (i > 0 && i < n - 1)

--- a/iModelCore/GeomLibs/geom/src/polyface/Polyface.cpp
+++ b/iModelCore/GeomLibs/geom/src/polyface/Polyface.cpp
@@ -227,13 +227,9 @@ bool &colorsAreBySector
 )
     {
     colorsAreByVertex = colorsAreByFace = colorsAreBySector = false;
-    int select = 0;
     int indexArrayTag = 0;
     if (IntColor ().Active ())
-        {
         indexArrayTag = IntColor ().IndexedBy ();
-        select = 2;
-        }
     else
         return false;
 

--- a/iModelCore/GeomLibs/geom/src/polyface/PolyfaceQuery.cpp
+++ b/iModelCore/GeomLibs/geom/src/polyface/PolyfaceQuery.cpp
@@ -1075,8 +1075,8 @@ bool PolyfaceQuery::HasFacets () const
 +--------------------------------------------------------------------------------------*/
 bool PolyfaceQuery::IsTriangulated () const
     {
-    size_t numFacet, maxPerFace;
-    numFacet = GetNumFacet (maxPerFace);
+    size_t maxPerFace;
+    GetNumFacet (maxPerFace);
     return maxPerFace == 3;
     }
 

--- a/iModelCore/GeomLibs/geom/src/polyface/PolyfaceSectionMTG.h
+++ b/iModelCore/GeomLibs/geom/src/polyface/PolyfaceSectionMTG.h
@@ -573,22 +573,18 @@ CurveVectorPtr CollectChains (bool formRegions, bool markEdgeFractions)
     MTGMask edgeVisitedMask = m_graph.GrabMask ();
     m_graph.ClearMask (edgeVisitedMask);
     bvector<DPoint3d> chainXYZ;
-    CurveVector::BoundaryType topType, childType;
+    CurveVector::BoundaryType topType;
     size_t minSize;
-    bool addLinestringsAtTop = false;
     if (otherVerts == 0 && formRegions)
         {
         // The graph has nothing but closed loops !!! (All cheer)
         topType = CurveVector::BOUNDARY_TYPE_ParityRegion;
-        childType = CurveVector::BOUNDARY_TYPE_Outer;
         minSize = 3;
         }
     else
         {
         topType = CurveVector::BOUNDARY_TYPE_None;
-        childType = CurveVector::BOUNDARY_TYPE_Open;
         minSize = 2;
-        addLinestringsAtTop = true;
         }
     
     size_t numFace = m_graph.CountFaceLoops ();

--- a/iModelCore/GeomLibs/geom/src/polyface/PolyfaceStitch.cpp
+++ b/iModelCore/GeomLibs/geom/src/polyface/PolyfaceStitch.cpp
@@ -20,7 +20,6 @@ PolyfaceQueryCR mesh,
         {
         // Repeat 3 times:  Everything is visible.  We are not looking for coordinate overlap.  We are not looking at edge lengths.
         size_t numVertex = (size_t)mesh.GetPointCount ();
-        size_t numFacet;
         size_t numPerFacet;
         if (indexStyle == MESH_ELM_STYLE_TRIANGLE_GRID)
             {
@@ -30,7 +29,6 @@ PolyfaceQueryCR mesh,
             {
             numPerFacet = 4;
             }
-        numFacet = numVertex / numPerFacet;
         numPolygonEdge = numVertex;   // yes, its just one to one.  Each vertex is the base of a one edge...
         numMatedPair = 0;
         num1 = numPolygonEdge;

--- a/iModelCore/GeomLibs/geom/src/polyface/pf_cutFill.cpp
+++ b/iModelCore/GeomLibs/geom/src/polyface/pf_cutFill.cpp
@@ -432,17 +432,11 @@ void AddPolygon (size_t collectionIndex, bvector<DPoint3d> &xyz)
         if (directConstruction)
             {
             double area = vu_area (node);
-            VuP insideNode, outsideNode;
+            VuP outsideNode;
             if (area > 0.0)
-                {
-                insideNode = node;
                 outsideNode = vu_vsucc(node);
-                }
             else
-                {
                 outsideNode = node;
-                insideNode = vu_vsucc(node);
-                }
         
             vu_setMaskAroundFace (outsideNode, VU_EXTERIOR_EDGE);
             }

--- a/iModelCore/GeomLibs/geom/src/polyface/pf_heal.cpp
+++ b/iModelCore/GeomLibs/geom/src/polyface/pf_heal.cpp
@@ -195,18 +195,17 @@ bool GetA01B01PlaneNormal (DVec3d &unitNormal, DVec3dR vectorA0A1, DVec3dR vecto
     {
     vectorA0A1.DifferenceOf (m_A1.m_xyz, m_A0.m_xyz);
     vectorB0B1.DifferenceOf (m_B1.m_xyz, m_B0.m_xyz);
-    double d;
     if (vectorA0A1.IsParallelTo (vectorB0B1))
         {
         if (!m_A0.IsSameNode (m_B0))
             {
             DVec3d edge;
             edge.DifferenceOf (m_B0.m_xyz, m_A0.m_xyz);
-            d = unitNormal.NormalizedCrossProduct (vectorA0A1, edge);
+            unitNormal.NormalizedCrossProduct (vectorA0A1, edge);
             return !vectorA0A1.IsParallelTo (edge);
             }
         }
-    d = unitNormal.NormalizedCrossProduct (vectorA0A1, vectorB0B1);
+    unitNormal.NormalizedCrossProduct (vectorA0A1, vectorB0B1);
     return !vectorA0A1.IsParallelTo (vectorB0B1);
     }
 

--- a/iModelCore/GeomLibs/geom/src/regions/rg_gaps.cpp
+++ b/iModelCore/GeomLibs/geom/src/regions/rg_gaps.cpp
@@ -322,7 +322,8 @@ double          maxDiagBoxFraction
                         size_t num1 = xyz1.size ();
                         if (num1 > 2)
                             {
-                            xyz1.push_back(xyz1[0]);
+                            xyzA = xyz1[0];
+                            xyz1.push_back(xyzA);
                             ++num1;
                             }
                         for (j = 1; j < num1; j++)

--- a/iModelCore/GeomLibs/geom/src/regions/rg_gaps.cpp
+++ b/iModelCore/GeomLibs/geom/src/regions/rg_gaps.cpp
@@ -307,11 +307,9 @@ double          maxDiagBoxFraction
                         }
                     else if (s_addMode == 2)    /* Convex hull */
                         {
-                        int num00;
                         xyz0.clear ();
                         xyz1.clear ();
                         DPoint3d xyzA;
-                        num00 = 0;
                         for (i = i0; i < i1;  i++)
                             {
                             jmdlEmbeddedIntArray_getInt (pBlockIndexArray, &iIndex, i);

--- a/iModelCore/GeomLibs/geom/src/regions/rg_header.cpp
+++ b/iModelCore/GeomLibs/geom/src/regions/rg_header.cpp
@@ -2715,7 +2715,6 @@ double                          lowOffset,
 double                          highOffset
 )
     {
-    MTGNodeId mateId;
     DRange3d range;
     jmdlRG_freeEdgeRangeTree (pRG);
     rgXYRangeTree_initializeTree ((void**)&pRG->pEdgeRangeTree);
@@ -2725,7 +2724,6 @@ double                          highOffset
         if (jmdlRG_checkAbort (pRG, s_checkStopPeriod))
             return false;            
 
-        mateId = jmdlMTGGraph_getEdgeMate (pRG->pGraph, nodeId);
         if (   jmdlMTGGraph_getMask (pRG->pGraph, nodeId, MTG_DIRECTED_EDGE_MASK)
             && jmdlRG_getEdgeRange (pRG, &range, nodeId))
             {

--- a/iModelCore/GeomLibs/geom/src/regions/rg_inwardparity.cpp
+++ b/iModelCore/GeomLibs/geom/src/regions/rg_inwardparity.cpp
@@ -160,7 +160,7 @@ int                 noisy
         */
         pTempStack = pStack0;
         pStack0 = pStack1;
-        pStack1 = pStack0;
+        pStack1 = pTempStack;
         if (noisy)
             GEOMAPI_PRINTF(" stack swap # %d\n", ++swapCount);
         }

--- a/iModelCore/GeomLibs/geom/src/regions/rg_merge.cpp
+++ b/iModelCore/GeomLibs/geom/src/regions/rg_merge.cpp
@@ -144,7 +144,6 @@ const DPoint3d      *pPoint11
     static int s_noisy = 0;
 #endif
 
-    bool    myStat = false;
     MTGNodeId nodeId[2];
 
     point[0][0] = *pPoint00;
@@ -250,7 +249,6 @@ const DPoint3d      *pPoint11
             t = xx * inverseLength[iLong];
             jmdlRGMerge_selectOrigin (&i0, &i1, t);
             jmdlRGMerge_selectOrigin (&j0, &j1, s);
-            myStat = true;
 
 #ifdef DEBUG_MERGE
                 if (s_noisy)
@@ -331,8 +329,6 @@ int                 endSelect,
 RG_EdgeData         *pEdge1
 )
     {
-
-    double param0;
     double param1, dsq;
     DPoint3d nearPoint;
     double tol = jmdlRG_getTolerance (pRG);
@@ -342,7 +338,6 @@ RG_EdgeData         *pEdge1
     DPoint3d xyz;
     if (endSelect != 0)
         endSelect = 1;
-    param0 = endSelect == 0 ? 0.0 : 1.0;
 
     xyz = pEdge0->xyz[endSelect];
 
@@ -625,7 +620,6 @@ RG_IntersectionList             *pRGIL
         return jmdlRGMerge_findAllIntersections (pRG, pRGIL);
 
     MTGGraph *pGraph = pRG->pGraph;
-    MTGNodeId nodeA1Id;
     RangeTreeCCINodeContext context;
     HideTreeRange   nodeARange;
     DRange3d nodeADRange3d;
@@ -638,7 +632,6 @@ RG_IntersectionList             *pRGIL
 
     MTGARRAY_SET_LOOP (nodeA0Id, pGraph)
         {
-        nodeA1Id = jmdlMTGGraph_getEdgeMate (pGraph, nodeA0Id);
         if  (   jmdlMTGGraph_getMask (pGraph, nodeA0Id, MTG_DIRECTED_EDGE_MASK)
              && jmdlRG_getEdgeRange (pRG, &nodeADRange3d, nodeA0Id)
             )
@@ -1060,7 +1053,6 @@ double                          minGeomStep
     int master0 = i0 - 1;
     int master1 = i0 - 1;
     int master  = i0 - 1;
-    int currType;
     double dist;
     DPoint3d currPoint, startPoint, endPoint, prevPoint;
 
@@ -1139,7 +1131,6 @@ double                          minGeomStep
             RGI_SETMASK (pA->type, processedTypeMask);
             numEdge++;
             }
-        currType = RGI_GETPROCESSFIELD (pA->type);
         }
 
     return  numEdge;
@@ -1165,7 +1156,7 @@ bool                            noisy
     {
     int i, j;
     double param;
-    MTGNodeId firstChildEdgeBaseId, lastChildBaseId, currChildLeftId, currChildRightId, lastChildNodeId;
+    MTGNodeId firstChildEdgeBaseId, currChildLeftId, currChildRightId, lastChildNodeId;
     MTGNodeId previousChildBaseId;
     int currVertexIndex;
     DPoint3d currPoint;
@@ -1240,7 +1231,6 @@ bool                            noisy
             param = pA->param;
             jmdlMTGGraph_splitEdge (pRG->pGraph, &currChildLeftId, &currChildRightId, previousChildBaseId);
 
-            lastChildBaseId = currChildLeftId;
             jmdlRG_findOrCreateVertexFromEdgeData (pRG,
                             &currPoint, &currVertexIndex,
                             &parentEdge,

--- a/iModelCore/GeomLibs/geom/src/regions/rg_merge2.cpp
+++ b/iModelCore/GeomLibs/geom/src/regions/rg_merge2.cpp
@@ -116,15 +116,11 @@ int             noisy
 )
     {
     DPoint3d xyNodeId;
-    int numThisCluster, clusterIndex, blockIndex, numCluster, numBlockedIndex;
-    int *pBlockedIndexBuffer;
+    int numThisCluster, clusterIndex, blockIndex;
     int xyNodeIdIndex;
 
-    numCluster = jmdlVArrayDPoint3d_identifyMatchedVerticesXY
+    jmdlVArrayDPoint3d_identifyMatchedVerticesXY
                             (pXYNodeIdArray, NULL, pBlockedIndexArray, tolerance, 0.0);
-    pBlockedIndexBuffer = jmdlEmbeddedIntArray_getPtr (pBlockedIndexArray, 0);
-    numBlockedIndex = jmdlEmbeddedIntArray_getCount (pBlockedIndexArray);
-
 
     jmdlEmbeddedIntArray_empty (pNodeIdToVertexIndexArray);
     jmdlEmbeddedIntArray_setConstant (pNodeIdToVertexIndexArray, -1, maxNodeId);
@@ -190,7 +186,6 @@ int             noisy
     static double s_tolFactor = 4.0;
     static int s_numChords = 8;
     double lengthTol = s_tolFactor * clusterSize;
-    bool    loopEdge;
     pVVNArrayHeader->clear ();
 
     for (nodeId0 = 0; nodeId0 <= maxNodeId; nodeId0++)
@@ -201,8 +196,7 @@ int             noisy
             {
             nodeId1 = jmdlMTGGraph_getEdgeMate (pGraph, nodeId0);
             jmdlEmbeddedIntArray_getInt (pNodeIdToVertexIndexArray, &vvn.cluster1, nodeId1);
-            loopEdge = false;
-
+    
             if (noisy > 4)
                 {
                 if (vvn.cluster0 == vvn.cluster1)
@@ -215,7 +209,7 @@ int             noisy
                 quickLength = jmdlRG_quickChordLength (pRG, nodeId0, s_numChords);
                 if (quickLength > lengthTol)
                     {
-                    loopEdge = true;
+                    // this is a loop edge
                     }
                 else
                     {

--- a/iModelCore/GeomLibs/geom/src/rimsbs/rimsbs_intersect.cpp
+++ b/iModelCore/GeomLibs/geom/src/rimsbs/rimsbs_intersect.cpp
@@ -276,7 +276,6 @@ DEllipse3d          *pEllipse               /* => ellipse geometry from second c
     int         i;
     double      tol = jmdlRG_getTolerance (pRG);
     double      tol2 = tol * tol;
-    int         numClose;
 
     int lineNode, ellipseNode;
     int numIntersection;
@@ -288,7 +287,7 @@ DEllipse3d          *pEllipse               /* => ellipse geometry from second c
 
     pEllipse->EvaluateEndPoints (ellipsePoint[0], ellipsePoint[1]);
 
-    numClose = jmdlRIMSBS_computeSquaredXYDistancesExt (endDist2, isClose, linePoint, true, ellipsePoint, false, tol2);
+    jmdlRIMSBS_computeSquaredXYDistancesExt (endDist2, isClose, linePoint, true, ellipsePoint, false, tol2);
 
     jmdlRIMSBS_declareEndPointIntersections
                         (
@@ -360,7 +359,7 @@ DEllipse3d          *pEllipse1              /* => ellipse geometry from second c
     bool        isClose[2][2];
     double      endDist2[2][2];
 
-    int numIntersection, numClose;
+    int numIntersection;
     int i;
     double      tol = jmdlRG_getTolerance (pRG);
     double      tol2 = tol * tol;
@@ -375,7 +374,7 @@ DEllipse3d          *pEllipse1              /* => ellipse geometry from second c
     ellipse0NodeId = jmdlRGEdge_getNodeId (pEdgeData0, 0);
     ellipse1NodeId = jmdlRGEdge_getNodeId (pEdgeData1, 0);
 
-    numClose = jmdlRIMSBS_computeSquaredXYDistances (endDist2, isClose, ellipse0End, ellipse1End, tol2);
+    jmdlRIMSBS_computeSquaredXYDistances (endDist2, isClose, ellipse0End, ellipse1End, tol2);
 
     jmdlRIMSBS_declareEndPointIntersections
                         (
@@ -438,7 +437,6 @@ MSBsplineCurve      *pCurve                 /* => curve data from second edge */
     int             i;
     double          tol = jmdlRG_getTolerance (pRG);
     double          tol2 = tol * tol;
-    int             numClose;
 
     int             numIntersection;
     double          *pSegmentParam;
@@ -458,7 +456,7 @@ MSBsplineCurve      *pCurve                 /* => curve data from second edge */
     lineNodeId = jmdlRGEdge_getNodeId (pEdgeData0, 0);
     curveNodeId = jmdlRGEdge_getNodeId (pEdgeData1, 0);
 
-    numClose = jmdlRIMSBS_computeSquaredXYDistances (endDist2, isClose, linePoint, curvePoint, tol2);
+    jmdlRIMSBS_computeSquaredXYDistances (endDist2, isClose, linePoint, curvePoint, tol2);
 
     jmdlRIMSBS_declareEndPointIntersections
                         (
@@ -626,7 +624,7 @@ MSBsplineCurve      *pCurve1                /* => curve data from second edge */
     DPoint3d    *pIntersectionPoint;
     double      *pParam0, *pParam1;
 
-    int numIntersection, numClose;
+    int numIntersection;
     int i;
     double      tol = jmdlRG_getTolerance (pRG);
     double      intersectionTol = tol;
@@ -649,7 +647,7 @@ MSBsplineCurve      *pCurve1                /* => curve data from second edge */
     curve0NodeId = jmdlRGEdge_getNodeId (pEdgeData0, 0);
     curve1NodeId = jmdlRGEdge_getNodeId (pEdgeData1, 0);
 
-    numClose = jmdlRIMSBS_computeSquaredXYDistances (endDist2, isClose, curve0End, curve1End, tol2);
+    jmdlRIMSBS_computeSquaredXYDistances (endDist2, isClose, curve0End, curve1End, tol2);
 
     jmdlRIMSBS_declareEndPointIntersections
                         (
@@ -727,11 +725,11 @@ MSBsplineCurve      *pCurve1                /* => optional curve rep of ellipse.
     double      *pParam0, *pParam1, theta1;
     Transform ellipseFrame, inverseFrame;
 
-    int numIntersection, numClose;
+    int numIntersection;
     int i;
     double      tol = jmdlRG_getTolerance (pRG);
     double      tol2 = tol * tol;
-    double      f0, f1, s1;
+    double      f0, f1;
     MSBsplineCurve curve1;
     RotMatrix z0Matrix;
 
@@ -748,7 +746,7 @@ MSBsplineCurve      *pCurve1                /* => optional curve rep of ellipse.
     curve1NodeId = jmdlRGEdge_getNodeId (pEdgeData1, 0);
 
 
-    numClose = jmdlRIMSBS_computeSquaredXYDistances (endDist2, isClose, curve0End, curve1End, tol2);
+    jmdlRIMSBS_computeSquaredXYDistances (endDist2, isClose, curve0End, curve1End, tol2);
 
     jmdlRIMSBS_declareEndPointIntersections
                         (
@@ -805,7 +803,6 @@ MSBsplineCurve      *pCurve1                /* => optional curve rep of ellipse.
         for (i = 0; i < numIntersection; i++)
             {
             f0 = pParam0[i];
-            s1 = pParam1[i];
 
             inverseFrame.Multiply (&ellipseCoffs, &pIntersectionPoint[i], 1);
             theta1 = Angle::Atan2 (ellipseCoffs.y, ellipseCoffs.x);

--- a/iModelCore/GeomLibs/geom/src/structs/cpp/refmethods/refdplane3d.cpp
+++ b/iModelCore/GeomLibs/geom/src/structs/cpp/refmethods/refdplane3d.cpp
@@ -566,7 +566,6 @@ double          &toleranceOut
             return false;
         DVec3d vectorYMax, vectorY, vectorZ;
         vectorYMax.Zero ();
-        size_t iMax = 0;
         double a, aMax = 0.0;
         for (size_t i = 1; i < (size_t)numPoint; i++)
             {
@@ -575,7 +574,6 @@ double          &toleranceOut
             a = vectorZ.MagnitudeSquared ();
             if (a > aMax)
                 {
-                iMax = i;
                 aMax = a;
                 vectorYMax = vectorY;
                 }

--- a/iModelCore/GeomLibs/geom/src/structs/dconic4d.cpp
+++ b/iModelCore/GeomLibs/geom/src/structs/dconic4d.cpp
@@ -2388,9 +2388,7 @@ bool          clipZ
     DPoint2d trigPoints[2];
     DPoint4d hPoint;
     DPoint3d point;
-    //double *pPoint = (double *)&point;
     double alpha, beta, gamma, theta, fraction;
-    bool    goodPoint;
 
     clipSelect[0]   = clipX;
     clipSelect[1]   = clipY;
@@ -2427,7 +2425,6 @@ bool          clipZ
                         for (root = 0; root < numRoot; root++)
                             {
                             /* Clip against the other directons */
-                            goodPoint = true;
                             hPoint.SumOf(pConic->center, pConic->vector0, trigPoints[root].x, pConic->vector90, trigPoints[root].y);
 
                             if (hPoint.GetProjectedXYZ (point))
@@ -4502,7 +4499,7 @@ int        clipType
 
         if (numCritical > 0)
             {
-            double thetaMid, dtheta;
+            double thetaMid;
             //int numAccept = 0;
             for (i = 0; i < numCritical; i++)
                 {
@@ -4520,7 +4517,6 @@ int        clipType
             for (i = 1; i < numCritical; i++)
                 {
                 thetaMid = (pCriticalAngleArray[i-1].z + pCriticalAngleArray[i].z) * 0.5;
-                dtheta = pCriticalAngleArray[i].z - pCriticalAngleArray[i-1].z;
                 if (Angle::InSweepAllowPeriodShift (thetaMid, theta0, arcSweep))
                     {
                     DPoint4d midPoint;

--- a/iModelCore/GeomLibs/geom/src/structs/directEvaluationSpiral.h
+++ b/iModelCore/GeomLibs/geom/src/structs/directEvaluationSpiral.h
@@ -104,7 +104,7 @@ double DSpiral2dDirectEvaluation::FractionToVelocity(double fraction) const
         {
         velocity = uvD1.Magnitude ();
         }
-    return 0.0;
+    return velocity;
     }    
 
 double DSpiral2dDirectEvaluation::FractionToLocalAngle(double fraction) const

--- a/iModelCore/GeomLibs/geom/src/structs/dspiral2dbase.cpp
+++ b/iModelCore/GeomLibs/geom/src/structs/dspiral2dbase.cpp
@@ -949,14 +949,13 @@ double&   minDistance
 )
     {
     DSpiral2dBaseClosestPointSearcher searcher (spiral, spiralToWorld, spacePoint);
-    bool stat = false;
     if (startFraction * endFraction < 0.0)
         {
         // fraction0 is within the interval. Search strokes to each end.
         DVec2d uv0;
         uv0.Zero ();
-        stat = searcher.SearchStrokesInFractionInterval (0.0, endFraction, uv0)
-                && searcher.SearchStrokesInFractionInterval (0.0, startFraction, uv0);
+        if (searcher.SearchStrokesInFractionInterval (0.0, endFraction, uv0))
+            searcher.SearchStrokesInFractionInterval (0.0, startFraction, uv0);
         }
     else
         {

--- a/iModelCore/GeomLibs/geom/test/CurvePrimitiveTest/t_IGeometry.cpp
+++ b/iModelCore/GeomLibs/geom/test/CurvePrimitiveTest/t_IGeometry.cpp
@@ -613,16 +613,12 @@ void EndObject () override
     }
 void AddProperty (char const *name, int value) override
     {
-    char s[128];
-    sprintf (s, " :%s:%d", name, value);
-    AddToString (s);
+    AddToString (Utf8PrintfString(" :%s:%d", name, value).c_str());
     }
 
 void AddProperty (char const *name, size_t value) override
     {
-    char s[128];
-    sprintf (s, " (%s %d)", name, (int)value);
-    AddToString (s);
+    AddToString (Utf8PrintfString(" (%s %d)", name, (int)value).c_str());
     }
 };
 
@@ -640,9 +636,7 @@ void EndObject () override
     }
 void AddProperty (char const *name, int value) override
     {
-    char s[128];
-    sprintf (s, " %s=\"%d\"", name, value);
-    AddToString (s);
+    AddToString (Utf8PrintfString(" %s=\"%d\"", name, value).c_str());
     }
 
 };

--- a/iModelCore/GeomLibs/geom/test/CurvePrimitiveTest/t_frustum.cpp
+++ b/iModelCore/GeomLibs/geom/test/CurvePrimitiveTest/t_frustum.cpp
@@ -295,3 +295,30 @@ TEST(ConvexHull, GridTest)
         }
     Check::ClearGeometry("ConvexHull.GridTest");
     }
+
+static bool testPushBackWithRealloc(bvector<DPoint3d>& v)
+    {
+    if (v.size() != v.capacity())
+        return false;   // no realloc, don't care
+
+    // push_back will reallocate. Does it safely access v[0] before it is freed? VS2010 did not! 
+    v.push_back(v[0]);
+    Check::Exact(v.front(), v.back(), "push_back of first element with reallocate");
+    return true;
+    }
+
+TEST(ConvexHull, VectorPushBackTest)
+    {
+    bvector<DPoint3d> v({DPoint3d::From(41,37,59)});
+    if (!testPushBackWithRealloc(v))
+        {
+        // try shrinkwrap suggestion
+        v.shrink_to_fit();
+        if (!testPushBackWithRealloc(v))
+            {
+            // try the "swap trick" from Item 17 of "Effective STL" by Scott Meyers
+            bvector<DPoint3d>(v).swap(v);
+            testPushBackWithRealloc(v);
+            }
+        }
+    }

--- a/iModelCore/GeomLibs/geom/test/RootTest/univariateRoots_test.cpp
+++ b/iModelCore/GeomLibs/geom/test/RootTest/univariateRoots_test.cpp
@@ -729,11 +729,10 @@ TEST(BezierHull, Test3)
     printf ("SUCCESSIVE DERIVATIVES\n");
     while (function.order > 1)
         {
-        char title[1024];
-        sprintf (title, "(order %d)\n", function.order);
-        function.PrintCoffs (title);
+        Utf8PrintfString title("(order %d)\n", function.order);
+        function.PrintCoffs (title.c_str());
         BezHull function1 = function;
-        Solve (function1, roots, title);
+        Solve (function1, roots, title.c_str());
         function.Differentiate ();
         }
     }
@@ -754,11 +753,10 @@ TEST(BezierHull, Test4)
     printf ("SUCCESSIVE DERIVATIVES\n");
     while (function.order > 1)
         {
-        char title[1024];
-        sprintf (title, "(order %d)\n", function.order);
-        function.PrintCoffs (title);
+        Utf8PrintfString title("(order %d)\n", function.order);
+        function.PrintCoffs (title.c_str());
         BezHull function1 = function;
-        Solve (function1, roots, title);
+        Solve (function1, roots, title.c_str());
         function.Differentiate ();
         }
     }
@@ -777,10 +775,8 @@ TEST(BezierHull, Test5)
     printf ("SUCCESSIVE DERIVATIVES\n");
     while (function.order > 1)
         {
-        char title[1024];
-        sprintf (title, "(order %d)\n", function.order);
         BezHull function1 = function;
-        Solve (function1, roots, title);
+        Solve (function1, roots, Utf8PrintfString("(order %d)\n", function.order).c_str());
         function.Differentiate ();
         }
     }

--- a/iModelCore/GeomLibs/geom/test/src/FileOps.cpp
+++ b/iModelCore/GeomLibs/geom/test/src/FileOps.cpp
@@ -84,7 +84,7 @@ bool GTestFileOps::WriteByteArrayToTextFile(bvector<Byte> &bytes, WCharCP direct
         static uint32_t maxBytesOnLine = 120;
         for (size_t i = 0; i < bytes.size (); i++)
             {
-            sprintf (string, "%d", bytes[i]);
+            snprintf (string, sizeof(string), "%d", bytes[i]);
             uint32_t newBytes = (uint32_t)strlen(string);
             if (newBytes + 1 + bytesOnLine > maxBytesOnLine)
                 {

--- a/iModelCore/GeomLibs/geom/test/src/checkers.cpp
+++ b/iModelCore/GeomLibs/geom/test/src/checkers.cpp
@@ -45,67 +45,40 @@ void Check::StartScope (char const *string)
 
 void Check::StartScope (char const *name, double value)
     {
-    char buffer[2048];
-    sprintf (buffer, "(%s %.15lg)", name, value);
-    StartScope (buffer);
+    StartScope (Utf8PrintfString("(%s %.15lg)", name, value).c_str());
     }
 
 void Check::StartScope (char const *name, size_t value)
     {
-    char buffer[2048];
-    sprintf (buffer, "(%s %u)", name, (unsigned int)value);
-    StartScope (buffer);
+    StartScope (Utf8PrintfString("(%s %u)", name, (unsigned int)value).c_str());
     }
 
 void Check::StartScope(char const *name, int value)
     {
-    char buffer[2048];
-    sprintf(buffer, "(%s %d)", name, value);
-    StartScope(buffer);
+    StartScope(Utf8PrintfString("(%s %d)", name, value).c_str());
     }
 
 
 void Check::StartScope (char const *name, DPoint3dCR value)
     {
-    char buffer[2048];
-    sprintf (buffer, "(%s %.15lg %.15lg %.15lg)", name, value.x, value.y, value.z);
-    StartScope (buffer);
+    StartScope (Utf8PrintfString("(%s %.15lg %.15lg %.15lg)", name, value.x, value.y, value.z).c_str());
     }
 
 void Check::StartScope (char const *name, DRay3dCR value)
     {
-    char buffer[2048];
-    sprintf (buffer, "(%s (origin %.15lg %.15lg %.15lg) (dir %.15lg %.15lg %.15lg))",
-            name,
-            value.origin.x, value.origin.y, value.origin.z,
-            value.direction.x, value.direction.y, value.direction.z
-            );
-    StartScope (buffer);
+    StartScope (Utf8PrintfString("(%s (origin %.15lg %.15lg %.15lg) (dir %.15lg %.15lg %.15lg))", name, value.origin.x, value.origin.y, value.origin.z, value.direction.x, value.direction.y, value.direction.z).c_str());
     }
 
 void Check::StartScope (char const *name, RotMatrixCR value)
     {
-    char buffer[2048];
-    sprintf (buffer, "(%s \n  (RowX %.15lg %.15lg %.15lg)\n  (RowY %.15lg %.15lg %.15lg)\n  (RowY %.15lg %.15lg %.15lg))",
-            name,
-            value.form3d[0][0], value.form3d[0][1], value.form3d[0][2],
-            value.form3d[1][0], value.form3d[1][1], value.form3d[1][2],
-            value.form3d[2][0], value.form3d[2][1], value.form3d[2][2]
-            );
-    StartScope (buffer);
+    StartScope (Utf8PrintfString("(%s \n  (RowX %.15lg %.15lg %.15lg)\n  (RowY %.15lg %.15lg %.15lg)\n  (RowY %.15lg %.15lg %.15lg))", name, value.form3d[0][0], value.form3d[0][1], value.form3d[0][2], value.form3d[1][0], value.form3d[1][1], value.form3d[1][2], value.form3d[2][0], value.form3d[2][1], value.form3d[2][2]).c_str());
     }
 
 
 
 void Check::StartScope (char const *name, DPlane3dCR value)
     {
-    char buffer[2048];
-    sprintf (buffer, "(%s \n  (origin %.15lg %.15lg %.15lg)  (normal %.15lg %.15lg %.15lg))",
-            name,
-            value.origin.x, value.origin.y, value.origin.z,
-            value.normal.x, value.normal.y, value.normal.z
-            );
-    StartScope (buffer);
+    StartScope (Utf8PrintfString("(%s \n  (origin %.15lg %.15lg %.15lg)  (normal %.15lg %.15lg %.15lg))", name, value.origin.x, value.origin.y, value.origin.z, value.normal.x, value.normal.y, value.normal.z).c_str());
     }
 
 void Check::EndScope ()
@@ -241,10 +214,8 @@ bool Check::LessThanOrEqual (double a, double b, char const*pString)
     {
     if (a <= b)
         return true;
-    char message[2048];
-    sprintf (message, "(fail %.17g <= %.17g) %s\n", a, b, pString ? pString : "");
     Check::PrintScope ();
-    Check::Fail (message);
+    Check::Fail (Utf8PrintfString("(fail %.17g <= %.17g) %s\n", a, b, pString ? pString : "").c_str());
     return false;
     }
 
@@ -470,9 +441,7 @@ bool Check::Parallel (DVec3dCR a, DVec3dCR b, char const*pString, double refValu
     double tol = Tol (theta, refValue);
     if (fabs (theta) < tol)
         return true;
-    char string[1024];
-    sprintf (string, " Parallel actual %le %s", theta, pString);
-    Check::True (stat, string);
+    Check::True (stat, Utf8PrintfString(" Parallel actual %le %s", theta, pString).c_str());
     return false;
     }
 
@@ -481,10 +450,8 @@ bool Check::Perpendicular (DVec3dCR a, DVec3dCR b, char const*pString, double re
     bool stat = a.IsPerpendicularTo (b);
     if (stat)
         return true;
-    char string[1024];
     double theta = a.AngleTo (b);
-    sprintf (string, " Perpendicular actual %le %s", theta, pString);
-    Check::True (stat, string);
+    Check::True (stat, Utf8PrintfString(" Perpendicular actual %le %s", theta, pString).c_str());
     return false;
     }
 
@@ -497,31 +464,23 @@ bool Check::Near (DPoint3dCR a, DPoint3dCR b, char const*pString, double refValu
     if (d <= tol)
         return true;
     Check::PrintScope ();
-    char message[1024];
-    sprintf (message, "%s Point distance (%.16g,%.16g,%.16g)(%.16g,%.16g,%.16g)",
-                    pString,
-                    a.x, a.y, a.z, b.x, b.y, b.z);
-    AssertNear (d, 0.0, tol, message);
+    AssertNear (d, 0.0, tol, Utf8PrintfString("%s Point distance (%.16g,%.16g,%.16g)(%.16g,%.16g,%.16g)", pString, a.x, a.y, a.z, b.x, b.y, b.z).c_str());
     return false;
     }
 
 void Check::Near (DPoint2dCP a, DPoint2dCP b, int n, char const*pName, double refValue)
     {
-    char longName[2048];
     for (int i = 0; i < n; i++)
         {
-        sprintf (longName, "DPoint2d[%d]%s", i, pName ? pName : "");
-        Check::Near (a[i], b[i], longName, refValue);
+        Check::Near (a[i], b[i], Utf8PrintfString("DPoint2d[%d]%s", i, pName ? pName : "").c_str(), refValue);
         }
     }
 
 void Check::Near (DPoint3dCP a, DPoint3dCP b, int n, char const*pName, double refValue)
     {
-    char longName[2048];
     for (int i = 0; i < n; i++)
         {
-        sprintf (longName, "DPoint3d[%d]%s", i, pName ? pName : "");
-        Check::Near (a[i], b[i], longName, refValue);
+        Check::Near (a[i], b[i], Utf8PrintfString("DPoint3d[%d]%s", i, pName ? pName : "").c_str(), refValue);
         }
     }
 
@@ -611,9 +570,7 @@ void Check::Near (DMatrix4d a, DMatrix4d b, char const*pString, double refValue)
         {
         for (int j = 0; j < 4; j++)
             {
-            char message[128];
-            sprintf (message, "[%d][%d]", i, j);
-            Check::StartScope (message);
+            Check::StartScope (Utf8PrintfString("[%d][%d]", i, j).c_str());
             Check::Near (a.coff[i][j], b.coff[i][j], pString, refValue);
             Check::EndScope ();
             }
@@ -1215,18 +1172,17 @@ void Check::Print (bvector<double> const &data, char const *name)
         return;
 
     printf ("(%s", name == nullptr ? "doubles" : name);
-    char buffer[100];
     size_t numChars = 2 + strlen (name);
     for (size_t i = 0; i < data.size (); i++)
         {
-        sprintf (buffer, "  %.17g", data[i]);
-        size_t numChars1 = strlen (buffer);
+        Utf8PrintfString buffer("  %.17g", data[i]);
+        size_t numChars1 = strlen (buffer.c_str());
         if (numChars + numChars1 > 70)
             {
             printf ("\n");
             numChars = numChars1;
             }
-        printf ("%s",buffer);
+        printf ("%s",buffer.c_str());
         }
 
     printf (")\n");
@@ -1677,29 +1633,17 @@ void Check::DirectKeyin (char const *message)
     }
 void Check::KeyinText (DPoint3dCR xyz, char const *text)
     {
-    char message[2048];
-    sprintf (message,
-        "facet import dgnjs --text@[%lg,%lg,%lg]=%s\n",
-                xyz.x,xyz.y, xyz.z,
-                text
-                );
-    DirectKeyin (message);
+    DirectKeyin (Utf8PrintfString("facet import dgnjs --text@[%lg,%lg,%lg]=%s\n", xyz.x, xyz.y, xyz.z, text).c_str());
     }
 
 void Check::KeyinTextSize (double height)
     {
-    char message[2048];
-    sprintf (message,
-        "facet import dgnjs --textsize=%lg\n", height);
-    DirectKeyin (message);
+    DirectKeyin (Utf8PrintfString("facet import dgnjs --textsize=%lg\n", height).c_str());
     }
 
 void Check::KeyinOrigin(DPoint3dCR origin)
     {
-    char message[2048];
-    sprintf (message,
-        "facet import dgnjs --origin=[%lg,%lg,%lg]\n", origin.x, origin.y, origin.z);
-    DirectKeyin (message);
+    DirectKeyin (Utf8PrintfString("facet import dgnjs --origin=[%lg,%lg,%lg]\n", origin.x, origin.y, origin.z).c_str());
     }
 
 void Check::KeyinImport (char const *name, char const *extension)
@@ -1714,10 +1658,7 @@ void Check::KeyinImport (char const *name, char const *extension)
     BeStringUtilities::Utf8ToWChar (extensionString, extension);
     path.AppendExtension (extensionString.c_str ());
 
-    char message[2048];
-    sprintf (message,
-        "facet import dgnjs %ls\n", path.c_str ());
-    DirectKeyin (message);
+    DirectKeyin (Utf8PrintfString("facet import dgnjs %ls\n", path.c_str()).c_str());
     }
 
 static int s_save = 1;

--- a/iModelCore/GeomLibs/geom/test/src/checkers.cpp
+++ b/iModelCore/GeomLibs/geom/test/src/checkers.cpp
@@ -71,7 +71,7 @@ void Check::StartScope (char const *name, DRay3dCR value)
 
 void Check::StartScope (char const *name, RotMatrixCR value)
     {
-    StartScope (Utf8PrintfString("(%s \n  (RowX %.15lg %.15lg %.15lg)\n  (RowY %.15lg %.15lg %.15lg)\n  (RowY %.15lg %.15lg %.15lg))", name, value.form3d[0][0], value.form3d[0][1], value.form3d[0][2], value.form3d[1][0], value.form3d[1][1], value.form3d[1][2], value.form3d[2][0], value.form3d[2][1], value.form3d[2][2]).c_str());
+    StartScope (Utf8PrintfString("(%s \n  (RowX %.15lg %.15lg %.15lg)\n  (RowY %.15lg %.15lg %.15lg)\n  (RowZ %.15lg %.15lg %.15lg))", name, value.form3d[0][0], value.form3d[0][1], value.form3d[0][2], value.form3d[1][0], value.form3d[1][1], value.form3d[1][2], value.form3d[2][0], value.form3d[2][1], value.form3d[2][2]).c_str());
     }
 
 

--- a/iModelCore/GeomLibs/vu/src/GeomPrintFuncs.cpp
+++ b/iModelCore/GeomLibs/vu/src/GeomPrintFuncs.cpp
@@ -34,23 +34,17 @@ void GeomPrintFuncs::EmitString (char const *pString)
 
 void GeomPrintFuncs::EmitInt (int value)
     {
-    char buffer[100];
-    sprintf (buffer, "%i", value);
-    EmitString (buffer);
+    EmitString (Utf8PrintfString("%i", value).c_str());
     }
 
 void GeomPrintFuncs::EmitDouble (double value)
     {
-    char buffer[100];
-    sprintf (buffer, "%g", value);
-    EmitString (buffer);
+    EmitString (Utf8PrintfString("%g", value).c_str());
     }
 
 void GeomPrintFuncs::EmitHex (int value)
     {
-    char buffer[100];
-    sprintf (buffer, "%x", value);
-    EmitString (buffer);
+    EmitString (Utf8PrintfString("%x", value).c_str());
     }
 
 void GeomPrintFuncs::EmitLineBreak ()

--- a/iModelCore/GeomLibs/vu/src/VuOps.cpp
+++ b/iModelCore/GeomLibs/vu/src/VuOps.cpp
@@ -453,7 +453,6 @@ Options_vu_createTrianglated const &optionsIn
     static double s_defaultCount = 10.0;
     //static double s_graphRelTol = 1.0e-10;
     VuSetP      graph = vu_newVuSet (0);
-    StatusInt status = SUCCESS;
     int    maxPerFace = 3;
 
     static double s_shortEdgeToleranceFactor = 1.0e-8;
@@ -477,12 +476,10 @@ Options_vu_createTrianglated const &optionsIn
 
     if (s_maxEdge * options.meshXLength < dx)
         {
-        status = ERROR;
         options.meshXLength = dx / s_maxEdge;
         }
     if (s_maxEdge * options.meshYLength < dy)
         {
-        status = ERROR;
         options.meshYLength = dy / s_maxEdge;
         }
     

--- a/iModelCore/GeomLibs/vu/src/vuSearch.cpp
+++ b/iModelCore/GeomLibs/vu/src/vuSearch.cpp
@@ -1107,7 +1107,6 @@ void RetriangulateFromBaseVertex (VuP edgeNode, VuMarkedEdgeSetP edgeSet)
     int numEdge = numNode - 3;
     VuP farNode = vu_fsucc (edgeNode);
     VuP nearNode = edgeNode;
-    double lambda;
     for (int i = 0; i < numEdge; i++)
         {
         farNode = vu_fsucc (farNode);
@@ -1115,10 +1114,10 @@ void RetriangulateFromBaseVertex (VuP edgeNode, VuMarkedEdgeSetP edgeSet)
         vu_join (m_graph, nearNode, farNode, &newA, &newB);
         if (nullptr != edgeSet)
             vu_markedEdgeSetTestAndAdd(edgeSet,newA);
-        lambda = AssessFace (newB);
+        AssessFace (newB);
         nearNode = newA;
         }
-    lambda = AssessFace (nearNode);
+    AssessFace (nearNode);
     }
 
 public:

--- a/iModelCore/GeomLibs/vu/src/vucoord.cpp
+++ b/iModelCore/GeomLibs/vu/src/vucoord.cpp
@@ -2098,7 +2098,7 @@ VuSetP pGraph
         VU_SET_LOOP (pCurr, pGraph)
             {
             /* Only start at INTERIOR UNVISITED */
-            if (!vu_getMask (pCurr, visitMask))
+            if (!vu_getMask (pCurr, seedMask))
                 {
                 VuP pSearchNode;
                 vu_arrayAdd (pStack, pCurr);

--- a/iModelCore/GeomLibs/vu/src/vugrid.cpp
+++ b/iModelCore/GeomLibs/vu/src/vugrid.cpp
@@ -400,7 +400,6 @@ static void gc_runIncidenceMarkup
 GridContext *pGC
 )
     {
-    VuP pMate;
     VuMask visitMask = vu_grabMask (pGC->pGraph);
     VuMask skipMask  = visitMask;   // | EXTERIOR?
 
@@ -409,7 +408,6 @@ GridContext *pGC
         {
         if (!vu_getMask (pCurrNode, skipMask))
             {
-            pMate = vu_edgeMate (pCurrNode);
             gc_recordEdgeIncidence (pGC, pCurrNode);
             vu_setMask (pCurrNode, visitMask);
             }

--- a/iModelCore/GeomLibs/vu/src/vumem.cpp
+++ b/iModelCore/GeomLibs/vu/src/vumem.cpp
@@ -102,9 +102,7 @@ int     id1
     static int s_printGraph = 0;
     if (s_printGraph)
         {
-        char buffer[1024];
-        sprintf (buffer, "%s (%d, %d)\n", pAppName ? pAppName : "postGraphToTrapFunc", id0, id1);
-         vu_printFaceLabels (pGraph, buffer);
+         vu_printFaceLabels (pGraph, Utf8PrintfString("%s (%d, %d)\n", pAppName ? pAppName : "postGraphToTrapFunc", id0, id1).c_str());
         }
 #endif
     }

--- a/iModelCore/GeomLibs/vu/src/vumod2.cpp
+++ b/iModelCore/GeomLibs/vu/src/vumod2.cpp
@@ -69,7 +69,7 @@ VuMask          fixedMask
     VuP             nextP, leftP, rightP;
     VuP             insideP, outsideP;
     VuP             newLeftP, newRightP;
-    double          v0, v1, vLine;
+    double          v1, vLine;
     int             i;
     VuMask          mask;
 
@@ -114,7 +114,6 @@ VuMask          fixedMask
             {
             leftP = nextP;
             nextP = VU_FPRED (leftP);
-            v0 = v1;
             v1 = VU_V (nextP);
             }
         while (v1 < vLine && VU_BELOW (leftP, nextP));
@@ -144,7 +143,6 @@ VuMask          fixedMask
             {
             rightP = nextP;
             nextP = VU_FSUCC (rightP);
-            v0 = v1;
             v1 = VU_V (nextP);
             }
         while (v1 < vLine && VU_BELOW (rightP, nextP));

--- a/iModelCore/GeomLibs/vu/src/vumulticlip.cpp
+++ b/iModelCore/GeomLibs/vu/src/vumulticlip.cpp
@@ -167,8 +167,6 @@ void SetupForLoopOverFaces (bool primarySelect, bool clipperSelect) override
     VuMask visitMask = vu_grabMask (m_pGraph);
     vu_clearMaskInSet (m_pGraph, visitMask);
     vu_arrayClear (m_pFaceArray);
-    double totalArea = 0.0;
-    double area;
     VU_SET_LOOP (pCurr, m_pGraph)
         {
         if (!vu_getMask (pCurr, visitMask))
@@ -178,8 +176,6 @@ void SetupForLoopOverFaces (bool primarySelect, bool clipperSelect) override
             if (   (primarySelect == (0 == vu_getMask (pCurr, s_PRIMARY_EXTERIOR_MASK)))
                 && (clipperSelect == (0 == vu_getMask (pCurr, s_SECONDARY_COMPOSITE_EXTERIOR_MASK))))
                 {
-                area = vu_area (pCurr);
-                totalArea += area;
                 vu_arrayAdd (m_pFaceArray, pCurr);
                 }
             }

--- a/iModelCore/GeomLibs/vu/src/vupoly.cpp
+++ b/iModelCore/GeomLibs/vu/src/vupoly.cpp
@@ -202,7 +202,7 @@ bool                addVerticesAtCrossings
     VuMask      numberedNodeMask = graphP ? vu_grabMask (graphP) : 0;
     VuP         faceP, originalNodeP;
     StatusInt status = ERROR;
-    int       i, numError;
+    int       i;
     int       originalIndex;
     int       outputIndex;
     int     separator = signedOneBasedIndices ? 0 : -1;
@@ -242,7 +242,6 @@ bool                addVerticesAtCrossings
             vu_flipTrianglesToImproveQuadraticAspectRatio (graphP);
 
         vu_collectInteriorFaceLoops (faceArrayP, graphP);
-        numError = 0;
 
         // force numbered node indices everywhere.  Last one seen at a vertex wins
         // (And this will do each loop at least 2X.)
@@ -1098,7 +1097,7 @@ DPoint3d            *meshOrigin
     VuArrayP    faceArrayP = vu_grabArray (graphP);
     VuP         faceP;
     StatusInt status = SUCCESS;
-    int       i, numError;
+    int       i;
     int     separator = 0;
     int    maxPerFace = 3;
     static double s_shortEdgeToleranceFactor = 1.0e-8;
@@ -1271,7 +1270,6 @@ DPoint3d            *meshOrigin
         }
     END_VU_SET_LOOP (currNode, graphP)
     vu_collectInteriorFaceLoops (faceArrayP, graphP);
-    numError = 0;
     VuMask visibleMask = (NULL == pVisible ? VU_BOUNDARY_EDGE : secondaryMask);
     vu_arrayOpen (faceArrayP);
     for (i = 0; vu_arrayRead (faceArrayP, &faceP); i++)

--- a/iModelCore/GeomLibs/vu/src/vupoly_bsplineBoundaryLoops.cpp
+++ b/iModelCore/GeomLibs/vu/src/vupoly_bsplineBoundaryLoops.cpp
@@ -125,8 +125,7 @@ DPoint2d    *pointP,
 int         numPoint
 )
     {
-    VuP faceP;
-    faceP = vu_makeLoopFromArray (graphP, pointP, numPoint, true, true);
+    vu_makeLoopFromArray (graphP, pointP, numPoint, true, true);
     }
 
 /*---------------------------------------------------------------------------------**//**
@@ -139,11 +138,9 @@ BsurfBoundary   *boundsP,
 int             numBounds
 )
     {
-    int i;
-    VuP faceP;
-    for (i = 0; i < numBounds; i++ )
+    for (int i = 0; i < numBounds; i++ )
         {
-        faceP = vu_makeLoopFromArray
+        vu_makeLoopFromArray
                             (
                             graphP,
                             boundsP[i].points,
@@ -168,13 +165,12 @@ double          ymax
 )
     {
     DPoint2d corner[4];
-    VuP faceP;
     corner[0].x = corner[3].x = xmin;
     corner[1].x = corner[2].x = xmax;
     corner[0].y = corner[1].y = ymin;
     corner[2].y = corner[3].y = ymax;
 
-    faceP = vu_makeLoopFromArray (graphP, corner, 4, true, true);
+    vu_makeLoopFromArray (graphP, corner, 4, true, true);
     }
 
 /*---------------------------------------------------------------------------------**//**
@@ -523,7 +519,6 @@ bool            isVerticalSeam      /* True for vertical seam (left and right),
         VuP high0P = vu_fpred (high1P);
         VuP high2P = vu_fsucc (high1P);
         VuP low0P  = vu_fpred (low1P);
-        VuP low2P  = vu_fsucc (low1P);
 
         /* Jump across top. */
         vu_join (graphP, high1P, low1P, &newHighNodeP, &newLowNodeP);
@@ -550,7 +545,6 @@ bool            isVerticalSeam      /* True for vertical seam (left and right),
             /* Skitter down the low side until the seam disappears */
             low1P = low0P;
             low0P = vu_fpred (low1P);
-            low2P = vu_fsucc (low1P);
             vu_setMask (low1P,  deleteMask);
             } while (vu_isExteriorSeamNode (low0P, lowParam, isVerticalSeam));
 


### PR DESCRIPTION
Sweep geomlibs to address compiler warnings:
* Replace remaining invocations of sprintf (follow-up to #4) 
* Remove local variables that were initialized but unused (follow-up to OSF PR #259097)
* Remove clang ignore switch for these local vars. Clang will now flag them in geomlibs.

Also:
* Backport the push_back fix and test from #95
* Fix typo bugs (see "bug fix" commits)