### PR TITLE
don't use getenv_s in conditional debug code since it doesn't exist on linux

### DIFF
--- a/iModelCore/ECDb/ECDb/SchemaManagerDispatcher.cpp
+++ b/iModelCore/ECDb/ECDb/SchemaManagerDispatcher.cpp
@@ -1007,18 +1007,13 @@ BentleyStatus MainSchemaManager::ImportSchemas(SchemaImportContext& ctx, bvector
     In Debug builds, the environment variable can be set to a directory path to
     dump existing and incoming schemas to for every ImportSchemas call.
     */
-    Utf8CP envVarName = "ECDB_SCHEMAIMPORT_DUMP_TO";
-    size_t requiredSize;
-    if (getenv_s(&requiredSize, NULL, 0, envVarName) == 0 && requiredSize != 0)
+    BeFileName dumpSchemaDir;
+    const char* const schemaImportDumpTo = getenv("ECDB_SCHEMAIMPORT_DUMP_TO");
+    if (schemaImportDumpTo != NULL)
         {
-        BeFileName dumpSchemaDir;
-        std::vector<char> chars(requiredSize);
-        if (getenv_s(&requiredSize, chars.data(), requiredSize, envVarName) == 0)
-            {
-            dumpSchemaDir.AssignUtf8(chars.data());
-            DumpSchemasToFile(dumpSchemaDir, m_ecdb.Schemas().GetSchemas(true), "existing");
-            DumpSchemasToFile(dumpSchemaDir, schemas, "incoming");
-            }
+        dumpSchemaDir.AssignUtf8(schemaImportDumpTo);
+        DumpSchemasToFile(dumpSchemaDir, m_ecdb.Schemas().GetSchemas(true), "existing");
+        DumpSchemasToFile(dumpSchemaDir, schemas, "incoming");
         }
     #endif
 

--- a/iModelCore/ECDb/ECDb/SchemaManagerDispatcher.cpp
+++ b/iModelCore/ECDb/ECDb/SchemaManagerDispatcher.cpp
@@ -1007,10 +1007,10 @@ BentleyStatus MainSchemaManager::ImportSchemas(SchemaImportContext& ctx, bvector
     In Debug builds, the environment variable can be set to a directory path to
     dump existing and incoming schemas to for every ImportSchemas call.
     */
-    BeFileName dumpSchemaDir;
     const char* const schemaImportDumpTo = getenv("ECDB_SCHEMAIMPORT_DUMP_TO");
     if (schemaImportDumpTo != NULL)
         {
+        BeFileName dumpSchemaDir;
         dumpSchemaDir.AssignUtf8(schemaImportDumpTo);
         DumpSchemasToFile(dumpSchemaDir, m_ecdb.Schemas().GetSchemas(true), "existing");
         DumpSchemasToFile(dumpSchemaDir, schemas, "incoming");


### PR DESCRIPTION
- affects optional debug only code
- fixes debug building on linux (`getenv_s` is a microsoft extension)
- assumes the security benefits of `getenv_s` aren't necessary since this code doesn't exist in release/NDEBUG versions