### PR TITLE
geomlibs: remove more unused-but-set vars

### DIFF
--- a/iModelCore/GeomLibs/geom/src/bspline/bspsurfacetrim.cpp
+++ b/iModelCore/GeomLibs/geom/src/bspline/bspsurfacetrim.cpp
@@ -1423,7 +1423,7 @@ const MSBsplineSurface      *pSurface,
 int                         horizontal
 )
     {
-    int             prev, curr, next, bufSize, numPoints;
+    int             prev, curr, next, numPoints;
     double          scanHeight, near1;
     DPoint2d        *p;
     BsurfBoundary   *currBound, *endB;
@@ -1483,8 +1483,6 @@ int                         horizontal
         }
     else if (pSurface->numBounds > 0)
         {
-        bufSize = 0;
-        near1 = 1.0 - fc_epsilon;
         if (!pSurface->holeOrigin)
             {
             pFractionArray->push_back ( 0.0);

--- a/iModelCore/GeomLibs/geom/src/polyface/PolyfaceStitch.cpp
+++ b/iModelCore/GeomLibs/geom/src/polyface/PolyfaceStitch.cpp
@@ -20,15 +20,6 @@ PolyfaceQueryCR mesh,
         {
         // Repeat 3 times:  Everything is visible.  We are not looking for coordinate overlap.  We are not looking at edge lengths.
         size_t numVertex = (size_t)mesh.GetPointCount ();
-        size_t numPerFacet;
-        if (indexStyle == MESH_ELM_STYLE_TRIANGLE_GRID)
-            {
-            numPerFacet = 3;
-            }
-        else
-            {
-            numPerFacet = 4;
-            }
         numPolygonEdge = numVertex;   // yes, its just one to one.  Each vertex is the base of a one edge...
         numMatedPair = 0;
         num1 = numPolygonEdge;


### PR DESCRIPTION
New version of clang caught a few more.