### PR TITLE
Presentation: Use default format based on persistence unit

### DIFF
--- a/iModelCore/ECPresentation/Source/Shared/ValueHelpers.cpp
+++ b/iModelCore/ECPresentation/Source/Shared/ValueHelpers.cpp
@@ -4,6 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 #include <ECPresentationPch.h>
 #include "ValueHelpers.h"
+#include "../RulesEngineTypes.h"
 
 /*---------------------------------------------------------------------------------**//**
 * @bsimethod
@@ -918,7 +919,8 @@ static bvector<Utf8String> const& GetUnitSystemGroupNames(ECPresentation::UnitSy
 Formatting::Format const* ValueHelpers::GetPresentationFormat(KindOfQuantityCR koq, ECPresentation::UnitSystem unitSystemGroup, std::map<std::pair<Utf8String, ECPresentation::UnitSystem>, std::shared_ptr<Formatting::Format>> const& defaultFormats)
     {
     Formatting::Format const* format = nullptr;
-    for (Utf8StringCR unitSystemName : GetUnitSystemGroupNames(unitSystemGroup))
+    bvector<Utf8String> const& unitSystems = GetUnitSystemGroupNames(unitSystemGroup);
+    for (Utf8StringCR unitSystemName : unitSystems)
         {
         // find the first presentation format that uses one of the unit systems in the group
         auto formatIter = std::find_if(koq.GetPresentationFormats().begin(), koq.GetPresentationFormats().end(), [&unitSystemName](NamedFormatCR f)
@@ -933,20 +935,24 @@ Formatting::Format const* ValueHelpers::GetPresentationFormat(KindOfQuantityCR k
             break;
             }
         }
-    if (!format)
+
+    Formatting::Format const* defaultFormat = koq.GetDefaultPresentationFormat();
+    // find default format that matches one of the unit systems in the group
+    if (!format && defaultFormat->HasCompositeMajorUnit())
         {
-        Formatting::Format const* defaultFormat = koq.GetDefaultPresentationFormat();
-        if (defaultFormat->HasCompositeMajorUnit())
-            {
-            std::pair<Utf8String, UnitSystem> pair = std::make_pair(defaultFormat->GetCompositeMajorUnit()->GetPhenomenon()->GetName(), unitSystemGroup);
-            auto it = defaultFormats.find(pair);
-            if (it != defaultFormats.end())
-                format = it->second.get();
-            }
-        // if format based on requested unit systems group was not found, use default
-        if (!format)
-            format = defaultFormat;
+        std::pair<Utf8String, UnitSystem> pair = std::make_pair(defaultFormat->GetCompositeMajorUnit()->GetPhenomenon()->GetName(), unitSystemGroup);
+        auto it = defaultFormats.find(pair);
+        if (it != defaultFormats.end())
+            format = it->second.get();
         }
+
+    // if persistence unit matches one of the unit systems in the group, use it
+    if (!format && ContainerHelpers::Contains(unitSystems, [&](Utf8String const& unitSystemName) {return koq.GetPersistenceUnit()->GetUnitSystem()->GetName().EqualsI(unitSystemName); }))
+        format = koq.GetPersistenceFormat();
+
+    // if format based on requested unit systems group was not found, use default
+    if (!format)
+        format = defaultFormat;
 
     return format;
     }

--- a/iModelCore/ECPresentation/Tests/NonPublished/Unit/Content/DefaultPropertyFormatterTests.cpp
+++ b/iModelCore/ECPresentation/Tests/NonPublished/Unit/Content/DefaultPropertyFormatterTests.cpp
@@ -21,6 +21,7 @@ USING_NAMESPACE_ECPRESENTATIONTESTS
             <ECProperty propertyName="Prop6" typeName="point2d" />
             <ECProperty propertyName="Prop7" typeName="point3d" />
             <ECProperty propertyName="Prop7" typeName="DateTime" />
+            <ECProperty propertyName="SmallLengthProp" typeName="double" kindOfQuantity="SmallLength" />
         </ECClass>
         <ECEnumeration typeName="TestIntEnum" backingTypeName="int" isStrict="true">
             <ECEnumerator value="0" displayLabel="Zero"/>
@@ -34,6 +35,8 @@ USING_NAMESPACE_ECPRESENTATIONTESTS
         </ECEnumeration>
         <KindOfQuantity typeName="Length" displayLabel="Length" persistenceUnit="M" relativeError="1e-6"
             presentationUnits="FT(real4u);M(real4u);FT(fi8);IN(real)" />
+        <KindOfQuantity typeName="SmallLength" displayLabel="Small Length" persistenceUnit="M" relativeError="0"
+            presentationUnits="FT(real4u);IN(real)" />
     </ECSchema>
 )xml"
 
@@ -206,4 +209,17 @@ TEST_F(DefaultPropertyFormatterTests, DefaultPropertyFormatterHandlesDefaultMap)
 
     EXPECT_EQ(SUCCESS, m_formatter.GetFormattedPropertyValue(formattedValue, *prop, value, ECPresentation::UnitSystem::Undefined));
     EXPECT_STREQ(Utf8PrintfString("123%c0 m", decimalSeparator).c_str(), formattedValue.c_str());
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* @betest
++---------------+---------------+---------------+---------------+---------------+------*/
+TEST_F(DefaultPropertyFormatterTests, UsesPersistenceUnitFormatInsteadOfDefaultFormatIfItMatchesUnitSystem)
+    {
+    ECPropertyCP prop = m_class->GetPropertyP("SmallLengthProp");
+    ECValue value(123.0);
+
+    Utf8String formattedValue;
+    EXPECT_EQ(SUCCESS, m_formatter.GetFormattedPropertyValue(formattedValue, *prop, value, ECPresentation::UnitSystem::Metric));
+    EXPECT_STREQ("123.0 m", formattedValue.c_str());
     }

--- a/iModelCore/ecobjects/PublicApi/ECObjects/ECSchema.h
+++ b/iModelCore/ecobjects/PublicApi/ECObjects/ECSchema.h
@@ -1227,6 +1227,7 @@ public:
     ECOBJECTS_EXPORT ECObjectsStatus AddPersistenceUnitByName(Utf8StringCR unitName, std::function<ECUnitCP(Utf8StringCR, Utf8StringCR)> const& nameToUnitMapper);
     ECOBJECTS_EXPORT ECObjectsStatus SetPersistenceUnit(ECUnitCR unit); //!< Sets the provided ECUnit as the persistence unit.
     ECUnitCP GetPersistenceUnit() const {return m_persistenceUnit;} //!< Gets the Unit of measurement used for persisting the information
+    NamedFormatCP GetPersistenceFormat() const {return GetCachedPersistenceFormat();} //!< Get default format based on persistence unit.
 
     //! Constructs a NamedFormat and sets it as the default (First in the presentation format list).
     ECObjectsStatus SetDefaultPresentationFormat(ECFormatCR parent, Nullable<int32_t> precisionOverride = nullptr, ECUnitCP inputUnitOverride = nullptr, Utf8CP labelOverride = nullptr)


### PR DESCRIPTION
Updated property format lookup to use persistence unit format before deciding to use default format.

Persistence unit format is used if there are no other formats  (presentation formats defined on koq or [defaultFormats](https://github.com/iTwin/itwinjs-core/blob/317ae48f58cff0635d3894be38a307e94e93da96/presentation/backend/src/presentation-backend/PresentationManager.ts#L280) setup on backend)  matching requested unit system and persistence unit does match requested unit system. Otherwise, default koq presentation format is used.

Closes #58 