### PR TITLE
Presentation: Fix infinite recursion

### DIFF
--- a/iModelCore/ECPresentation/Source/PresentationManagerImpl.cpp
+++ b/iModelCore/ECPresentation/Source/PresentationManagerImpl.cpp
@@ -614,6 +614,13 @@ protected:
         {
         auto scope = Diagnostics::Scope::Create("Create nodes provider");
         NavNodeCPtr parent = context.GetVirtualParentNode();
+
+        if (parent.IsValid() && NodesFinalizer(context).HasSimilarNodeInHierarchy(*parent))
+            {
+            DIAGNOSTICS_DEV_LOG(DiagnosticsCategory::Hierarchies, LOG_TRACE, "Parent node has similar ancestor - returning empty data source");
+            return EmptyNavNodesProvider::Create(context);
+            }
+
         NavNodesProviderPtr provider;
         if (parent.IsNull())
             {
@@ -1002,12 +1009,6 @@ std::unique_ptr<INodeInstanceKeysProvider> RulesDrivenECPresentationManagerImpl:
 NavNodesDataSourcePtr RulesDrivenECPresentationManagerImpl::GetCachedDataSource(NavNodesProviderContextR context, PageOptionsCP pageOptions) const
     {
     auto scope = Diagnostics::Scope::Create("Create data source");
-
-    if (context.GetVirtualParentNode().IsValid() && NodesFinalizer(context).HasSimilarNodeInHierarchy(*context.GetVirtualParentNode()))
-        {
-        DIAGNOSTICS_DEV_LOG(DiagnosticsCategory::Hierarchies, LOG_TRACE, "Parent node has similar ancestor - returning empty data source");
-        return nullptr;
-        }
 
     NavNodesProviderPtr provider;
     if (!pageOptions || pageOptions->GetPageStart() == 0)


### PR DESCRIPTION
Existing infinite recursion prevention took effect when requesting child nodes at the top level `RulesDrivenECPresentationManagerImpl` API. The code wasn't being executed when we needed to create hierarchy due to reasons other than a top level request, e.g. when handling the "hide if no children" or similar flag. In that case we ended up in infinite recursion...

The change moves that check down into our nodes provider factory - we return an empty provider if we detect similar ancestor there.