### PR TITLE
Presentation: Should not support filtering nodes built with `parent` symbol

### DIFF
--- a/iModelCore/ECPresentation/Source/Hierarchies/HierarchiesFiltering.cpp
+++ b/iModelCore/ECPresentation/Source/Hierarchies/HierarchiesFiltering.cpp
@@ -198,10 +198,14 @@ public:
     void _Visit(InstanceNodesOfSpecificClassesSpecification const& spec) override
         {
         HandleCommonAttributes(spec);
+        if (spec.GetInstanceFilter().ContainsI("parent."))
+            REPORT_ISSUE(Utf8PrintfString("%s does not support filtering due to \"parent\" symbol being used in instance filter", DiagnosticsHelpers::CreateRuleIdentifier(spec).c_str()));
         }
     void _Visit(RelatedInstanceNodesSpecification const& spec) override
         {
         HandleCommonAttributes(spec);
+        if (spec.GetInstanceFilter().ContainsI("parent."))
+            REPORT_ISSUE(Utf8PrintfString("%s does not support filtering due to \"parent\" symbol being used in instance filter", DiagnosticsHelpers::CreateRuleIdentifier(spec).c_str()));
         if (spec.GetSkipRelatedLevel() != 0)
             REPORT_ISSUE(Utf8PrintfString("%s does not support filtering due to deprecated \"skip related level\" attribute", DiagnosticsHelpers::CreateRuleIdentifier(spec).c_str()));
         if (!spec.GetSupportedSchemas().empty())


### PR DESCRIPTION
Note: this likely requires regenerating presentation-full-stack-test snapshots. Will do that a bit later, will then associate this PR with snapshot update PR.