### PR TITLE
Improve error message for 'too many columns' error

### DIFF
--- a/iModelCore/ECDb/ECDb/SchemaManagerDispatcher.cpp
+++ b/iModelCore/ECDb/ECDb/SchemaManagerDispatcher.cpp
@@ -1464,7 +1464,8 @@ BentleyStatus MainSchemaManager::CanCreateOrUpdateRequiredTables() const
     stmt.Prepare(m_ecdb, ecsql.c_str());
     if (stmt.Step() == BE_SQLITE_ROW)
         {
-        LOG.errorv("Schema Import> Error importing %s:%s class. Could not create or update %s table as there are %d persisted columns, but a maximum of %d columns is allowed for a table.",
+        m_ecdb.GetImpl().Issues().ReportV(IssueSeverity::Error, IssueCategory::BusinessProperties, IssueType::ECDbIssue,
+            "Schema Import> Error importing %s:%s class. Could not create or update %s table as there are %d persisted columns, but a maximum of %d columns is allowed for a table.",
             stmt.GetValueText(0), stmt.GetValueText(1), stmt.GetValueText(2), stmt.GetValueInt64(3), maxColumns);
         return ERROR;
         }

--- a/iModelCore/ECDb/ECDb/SchemaManagerDispatcher.cpp
+++ b/iModelCore/ECDb/ECDb/SchemaManagerDispatcher.cpp
@@ -1435,6 +1435,45 @@ ClassMappingStatus MainSchemaManager::MapDerivedClasses(SchemaImportContext& ctx
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //+---------------+---------------+---------------+---------------+---------------+------
+BentleyStatus MainSchemaManager::CanCreateOrUpdateRequiredTables() const
+    {
+    ECDB_PERF_LOG_SCOPE("Schema import> Can create or update tables");
+    const int maxColumns = m_ecdb.GetLimit(DbLimits::Column);
+
+    Utf8String ecsql;
+    ecsql.Sprintf(R"sql(
+        SELECT
+            [sc].[Name] [SchemaName],
+            [cl].[Name] [ClassName],
+            tb.name [Table],
+            COUNT (*) [PersistedColumns]
+        FROM
+            [ec_PropertyMap] [pm]
+            JOIN [ec_Column] [co] ON [co].[Id] = [pm].[ColumnId]
+            JOIN [ec_Table] [tb] ON [tb].[Id] = [co].[TableId]
+            JOIN [ec_Class] [cl] ON [cl].[Id] = [pm].[ClassId]
+            JOIN [ec_Schema] [sc] ON [sc].[Id] = [cl].[SchemaId]
+            JOIN [ec_ClassMap] [cm] ON [cm].[ClassId] = [cl].[id]
+        WHERE
+            [co].[IsVirtual] = 0
+            AND [cm].[MapStrategy] <> 3
+        GROUP BY [cl].[Id], tb.Id
+        HAVING COUNT (*) >= %d;)sql", maxColumns);
+
+    Statement stmt;
+    stmt.Prepare(m_ecdb, ecsql.c_str());
+    if (stmt.Step() == BE_SQLITE_ROW)
+        {
+        LOG.errorv("Schema Import> Error importing %s:%s class. Could not create or update %s table as there are %d persisted columns, but a maximum of %d columns is allowed for a table.",
+            stmt.GetValueText(0), stmt.GetValueText(1), stmt.GetValueText(2), stmt.GetValueInt64(3), maxColumns);
+        return ERROR;
+        }
+    return SUCCESS;
+    }
+
+//---------------------------------------------------------------------------------------
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+------
 BentleyStatus MainSchemaManager::CreateOrUpdateRequiredTables() const
     {
     ECDB_PERF_LOG_SCOPE("Schema import> Create or update tables");
@@ -1443,6 +1482,9 @@ BentleyStatus MainSchemaManager::CreateOrUpdateRequiredTables() const
     int nCreated = 0;
     int nUpdated = 0;
     int nWasUpToDate = 0;
+
+    if (SUCCESS != CanCreateOrUpdateRequiredTables())
+        return ERROR;
 
     for (DbTable const* table : GetDbSchema().Tables().GetTablesInDependencyOrder())
         {

--- a/iModelCore/ECDb/ECDb/SchemaManagerDispatcher.h
+++ b/iModelCore/ECDb/ECDb/SchemaManagerDispatcher.h
@@ -192,6 +192,7 @@ private:
     ClassMappingStatus MapClass(SchemaImportContext&, ClassMappingInfo const&) const;
     ClassMappingStatus MapDerivedClasses(SchemaImportContext&, ECN::ECClassCR baseClass) const;
     BentleyStatus SaveDbSchema(SchemaImportContext&) const;
+    BentleyStatus CanCreateOrUpdateRequiredTables() const;
     BentleyStatus CreateOrUpdateRequiredTables() const;
     BentleyStatus CreateOrUpdateIndexesInDb(SchemaImportContext&) const;
     BentleyStatus PurgeOrphanTables(SchemaImportContext&) const;


### PR DESCRIPTION
Make the error message more informative when attempting to create or alter a table with too many columns. The error message now includes information about the class that failed to import, and the maximum number of columns a table can have.