### PR TITLE
iModel Evolution Tests Fixed

### DIFF
--- a/iModelCore/iModelPlatform/Tests/DgnProject/Compatibility/CompatibilityRunner/RunPulledTestRunners.py
+++ b/iModelCore/iModelPlatform/Tests/DgnProject/Compatibility/CompatibilityRunner/RunPulledTestRunners.py
@@ -27,7 +27,13 @@ def createGTestFilter(exeDir):
     exePath = os.path.join(exeDir, "iModelEvolutionTests.exe")
     sys.stdout.flush();
     output = subprocess.Popen([exePath, "--gtest_list_tests"], stdout=subprocess.PIPE).communicate()[0].decode()
-    output = output.split("BEGTEST_LOGGING_CONFIG in environment.")[1].split('\n')
+
+    subStr = "BEGTEST_LOGGING_CONFIG in environment."
+    if subStr in output:
+        print("Cleanup is required in logs...")
+        output = output.split(subStr)[1]
+        
+    output = output.split('\n')
     output = [i.strip() for i in output]
     testsList = filter(lambda x: x != "", output)
     testsList = list(testsList)

--- a/iModelCore/iModelPlatform/iModelPlatform.PartFile.xml
+++ b/iModelCore/iModelPlatform/iModelPlatform.PartFile.xml
@@ -145,8 +145,8 @@
     <!-- Entry point part -->
     <Part Name="RunIModelEvolutionTests" PrgOutputDir="IModelEvolutionTests">
         <SubPart PartName="IModelEvolutionRunAllTestRunners"/>
-        <SubNuGetProduct NuGetProductName="IModelEvolutionTestRunnerNuget"/>
-        <SubNuGetProduct NuGetProductName="IModelEvolutionTestFilesNuget"/>
+        <SubNuGetProduct NuGetProductName="IModelEvolutionTestRunnerNuget_imodelNative"/>
+        <SubNuGetProduct NuGetProductName="IModelEvolutionTestFilesNuget_imodelNative"/>
     </Part>
 
     <!-- Runs all compatibility tests:
@@ -239,12 +239,13 @@
         </Bindings>
     </Part>
 
-    <NuGetProduct Name="IModelEvolutionTestRunnerNuget" Description="Create nuget that contains the current test runner">
+    <NuGetProduct Name="IModelEvolutionTestRunnerNuget_imodelNative" Description="Create nuget that contains the current test runner">
         <Directories DirectoryListName="GtestProduct" PartFile="iModelCore/BeGTest/BeGTest"/>
         <SubPart PartName="BuildIModelEvolutionGTest"/>
+        <SubPart PartName="napi-stub" PartFile="node-addon-api/node-addon-api"/>
     </NuGetProduct>
 
-    <NuGetProduct Name="IModelEvolutionTestFilesNuget" Description="Create the test files nuget">
+    <NuGetProduct Name="IModelEvolutionTestFilesNuget_imodelNative" Description="Create the test files nuget">
         <Directories DirectoryListName="IModelEvolutionTestFilesForNugetPackage"/>
         <SubPart PartName="PrepareIModelEvolutionTestFilesNugetPackaging"/>
     </NuGetProduct>


### PR DESCRIPTION
This PR contains following fixes related to iModel evolution tests:
- A new part is called so that the `iTwinNapi.dll` can be added to the packaged NuGet.
- The new runner logs do not need clean up for creating the gtest filter.