### PR TITLE
CloudSQLite: Do not error out if a path contains a symlink

### DIFF
--- a/iModelCore/BeSQLite/SQLite/bcvutil.c
+++ b/iModelCore/BeSQLite/SQLite/bcvutil.c
@@ -3295,7 +3295,7 @@ int bcvOpenLocal(
   memset(pFd, 0, nByte);
   zOpen = &((char*)pFd)[pVfs->szOsFile + 4];
   rc = pVfs->xFullPathname(pVfs, zFile, pVfs->mxPathname+1, zOpen);
-  if( rc==SQLITE_OK ){
+  if( (rc & 0xFF)==SQLITE_OK ){
     int n = strlen(zOpen);
     zOpen[n+1] = '\0';
     rc = pVfs->xOpen(pVfs, zOpen, pFd, flags, &flags);

--- a/iModelCore/BeSQLite/SQLite/blockcachevfs.c
+++ b/iModelCore/BeSQLite/SQLite/blockcachevfs.c
@@ -3588,6 +3588,7 @@ char *bcvGetFullpath(int *pRc, const char *zDir){
   zRet = bcvMallocRc(pRc, pVfs->mxPathname+1);
   if( zRet ){
     int rc = pVfs->xFullPathname(pVfs, zDir, pVfs->mxPathname, zRet);
+    rc = (rc & 0xFF);
     if( rc ){
       sqlite3_free(zRet);
       zRet = 0;


### PR DESCRIPTION
'Do not error out if a path passed to sqlite3_bcv_download() or similar contains one or more components that are symbolic links'