### PR TITLE
Ensure that bcvfsDispatchRunAll() issues callbacks for all pending jobs before returning

### DIFF
--- a/iModelCore/BeSQLite/SQLite/bcv_int.h
+++ b/iModelCore/BeSQLite/SQLite/bcv_int.h
@@ -487,8 +487,6 @@ int bcvContainerOpen(
 );
 void bcvContainerClose(BcvContainer*);
 
-void bcvDispatchFail(BcvDispatch*, BcvContainer*, int, const char*);
-
 int bcv_socket_is_valid(BCV_SOCKET_TYPE s);
 void bcv_close_socket(BCV_SOCKET_TYPE s);
 void bcv_socket_init();

--- a/iModelCore/BeSQLite/SQLite/bcvutil.c
+++ b/iModelCore/BeSQLite/SQLite/bcvutil.c
@@ -2889,31 +2889,27 @@ static void bcvDispatchJobUpdate(BcvDispatchJob *pJob){
 }
 
 
-void bcvDispatchFail(
+static void bcvDispatchFail(
   BcvDispatch *pDisp, 
-  BcvContainer *p, 
   int rc, 
   const char *zErr
 ){
-  BcvDispatchJob *pJob;
   BcvDispatchJob *pNext;
 
-  for(pJob=pDisp->pJobList; pJob; pJob=pNext){
-    pNext = pJob->pNext;
-    if( pJob->pCont==p ){
-      BcvDispatchReq *pReq;
-      while( (pReq = pJob->pWaiting) ){
-        pJob->pWaiting = pReq->pNext;
-        pReq->rc = rc;
-        sqlite3_free(pReq->zStatus);
-        pReq->zStatus = (char*)zErr;
-        pReq->xCallback(pJob, pReq, pReq->pApp);
-        pReq->zStatus = 0;
-        curl_multi_remove_handle(pDisp->pMulti, pReq->pCurl);
-        bcvDispatchReqFree(pReq);
-      }
-      bcvDispatchJobUpdate(pJob);
+  while( pDisp->pJobList ){
+    BcvDispatchJob *pJob = pDisp->pJobList;
+    BcvDispatchReq *pReq;
+    while( (pReq = pJob->pWaiting) ){
+      pJob->pWaiting = pReq->pNext;
+      pReq->rc = rc;
+      sqlite3_free(pReq->zStatus);
+      pReq->zStatus = (char*)zErr;
+      pReq->xCallback(pJob, pReq, pReq->pApp);
+      pReq->zStatus = 0;
+      curl_multi_remove_handle(pDisp->pMulti, pReq->pCurl);
+      bcvDispatchReqFree(pReq);
     }
+    bcvDispatchJobUpdate(pJob);
   }
 }
 
@@ -3009,6 +3005,14 @@ int bcvDispatchRun(BcvDispatch *p, struct curl_waitfd *aFd, int nFd, int ms){
   i64 nMs;                        /* ms to wait for */
   i64 iTime = 0;                  /* Current time */
 
+#ifdef SQLITE_DEBUG
+  {
+    void *pRet = sqlite3_malloc64(64);
+    if( pRet==0 ) return SQLITE_NOMEM;
+    sqlite3_free(pRet);
+  }
+#endif
+
   for(pJob=p->pJobList; pJob; pJob=pJob->pNext){
     i64 iJobTime = bcvDispatchJobRetryTime(pJob);
     if( iJobTime && (iMinTime==0 || iJobTime<iMinTime) ) iMinTime = iJobTime;
@@ -3093,6 +3097,10 @@ int bcvDispatchRunAll(BcvDispatch *p){
   while( rc==SQLITE_OK && p->pJobList ){
     rc = bcvDispatchRun(p, 0, 0, 1000);
   }
+  if( rc!=SQLITE_OK ){
+    bcvDispatchFail(p, rc, 0);
+  }
+  assert( p->pJobList==0 );
   return rc;
 }
 

--- a/iModelCore/BeSQLite/SQLite/blockcachevfs.c
+++ b/iModelCore/BeSQLite/SQLite/blockcachevfs.c
@@ -755,7 +755,7 @@ static void bcvfsProxyCloseTransactionIf(BcvfsFile *pFile){
 }
 
 static void bcvKVStoreFree(BcvKVStore *pKv){
-  sqlite3_close(pKv->db);
+  sqlite3_close_v2(pKv->db);
   sqlite3_free(pKv->zETag);
   memset(pKv, 0, sizeof(BcvKVStore));
 }
@@ -6970,6 +6970,9 @@ static int bcvFileVtabSync(sqlite3_vtab *tab){
   rc = sqlite3_exec(pTab->pFile->kv.db, "COMMIT", 0, 0, &pTab->base.zErrMsg);
   if( rc==SQLITE_OK ){
     rc = bcvKVStorePush(pTab);
+  }
+  if( rc!=SQLITE_OK ){
+    bcvKVStoreFree(&pTab->pFile->kv);
   }
   return rc;
 }


### PR DESCRIPTION
Fix for the abort that Mike stumbled upon when running node with the cpu profiler. This doesn't fix the root issue, just exits gracefully when the issue occurs.

https://sqlite.org/cloudsqlite/info/744d952b109a61b8d0ed