### PR TITLE
Locked the imodeljsnodeaddon build to just Win, Linux, and MacOS x64/Arm

### DIFF
--- a/iModelCore/Bentley/Bentley.PartFile.xml
+++ b/iModelCore/Bentley/Bentley.PartFile.xml
@@ -10,7 +10,7 @@
         <ProductDirectory Name="TestBin"         Path="Dlls"/>
     </ProductDirectoryList>
 
-    <Part Name="BentleyLib" PrgOutputDir="BentleyLib">
+    <Part Name="BentleyLib">
         <SubPart PartName="BentleyDll" />
     </Part>
 

--- a/iModelCore/GeomLibs/geomlibs.PartFile.xml
+++ b/iModelCore/GeomLibs/geomlibs.PartFile.xml
@@ -232,7 +232,7 @@
 
     <!-- ***NEEDS WORK: Does this really need to be a product? Does PRG build it? -->
     <ProductDirectoryList ListName="Empty" />
-    <Product Name="GeomLibsTested" AddIn="true" PrgOutputDir="GeomLibs" >
+    <Product Name="GeomLibsTested" AddIn="true">
         <SubPart PartName="RunGtest" />
         <Directories DirectoryListName="Empty" />
     </Product>
@@ -241,7 +241,7 @@
     <!-- //////////////////////////////////////////////////////////////////////////////////////////////////// -->
     <!-- GeomLibs Product -->
     <!-- //////////////////////////////////////////////////////////////////////////////////////////////////// -->
-    <Product Name="GeomLibs" PrgOutputDir="Geomlibs">
+    <Product Name="GeomLibs">
         <SubPart PartName= "GeomDlls" />
         <SubPart PartName="GeomDlls" LibType="Static"/>
         <SubPart PartName="GeomlibsSerialization"/>

--- a/iModelCore/Units/Units.PartFile.xml
+++ b/iModelCore/Units/Units.PartFile.xml
@@ -60,7 +60,7 @@
         <ProductDirectory Name="VendorNotices"                   Path="Notices"/>
     </ProductDirectoryList>
 
-    <Product Name="UnitsTested" PrgOutputDir="Units" SaveProduct="true" AddIn="true">
+    <Product Name="UnitsTested" SaveProduct="true" AddIn="true">
         <SubPart PartName="RunGtest" />
         <SubPart PartName="RunAndroidJUnitTest" />
         <SubPart PartName="RuniOSXCTest" />

--- a/iModelCore/ecobjects/ECObjects.PartFile.xml
+++ b/iModelCore/ecobjects/ECObjects.PartFile.xml
@@ -282,7 +282,7 @@
         <SubPart PartName="SchemaRoundtripDependencies"/>
     </Part>
 
-    <Product Name="SchemaRoundtripValidation" SaveProduct="true" PrgOutputDir="SchemaRoundtripValidation">
+    <Product Name="SchemaRoundtripValidation" SaveProduct="true">
         <Directories DirectoryListName="AllBisSchemas-Directories" PartFile="schemas\BisSchemas\BisSchemas"/>
         <Directories DirectoryListName="SchemaComparison"/>
         <Directories DirectoryListName="SchemaRoundtrip"/>
@@ -313,7 +313,7 @@
         <Directories DirectoryListName="ECObjectsToolsNuGet" />
     </NuGetProduct>
 
-    <Part Name="ECObjectsToolsNuGet-TopLevel" PrgOutputDir="ECObjectsTools">
+    <Part Name="ECObjectsToolsNuGet-TopLevel">
         <SubNuGetProduct NuGetProductName="ECObjectsToolsNuGet" />
     </Part>
 
@@ -451,7 +451,7 @@
     <ProductDirectoryList ListName="ECObjectsTested">
     </ProductDirectoryList>
 
-    <Product Name="ECObjectsTested" PrgOutputDir="ECObjects" SaveProduct="true" AddIn="true">
+    <Product Name="ECObjectsTested" SaveProduct="true" AddIn="true">
         <SubProduct ProductName="ECObjects" />
         <!-- SubProduct ProductName="ECObjectsStatic" /-->
         <SubProduct ProductName="ECObjects-Tests" />

--- a/iModelCore/iModelPlatform/iModelPlatform.PartFile.xml
+++ b/iModelCore/iModelPlatform/iModelPlatform.PartFile.xml
@@ -143,7 +143,7 @@
          ********************************************************************************************** -->
 
     <!-- Entry point part -->
-    <Part Name="RunIModelEvolutionTests" PrgOutputDir="IModelEvolutionTests">
+    <Part Name="RunIModelEvolutionTests">
         <SubPart PartName="IModelEvolutionRunAllTestRunners"/>
         <SubNuGetProduct NuGetProductName="IModelEvolutionTestRunnerNuget"/>
         <SubNuGetProduct NuGetProductName="IModelEvolutionTestFilesNuget"/>

--- a/iModelCore/libsrc/libjpegturbo/vendor/config.h
+++ b/iModelCore/libsrc/libjpegturbo/vendor/config.h
@@ -1,14 +1,7 @@
-/*--------------------------------------------------------------------------------------+
-|
-|     $Source: vendor/config.h $
-|    $RCSfile: HIERasterReference.cpp,v $
-|   $Revision: 1.207 $
-|       $Date: 2011/01/18 15:06:27 $
-|     $Author: Marc.Bedard $
-|
-|  $Copyright: (c) 2017 Bentley Systems, Incorporated. All rights reserved. $
-|
-+--------------------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the repository root for full copyright notice.
+*--------------------------------------------------------------------------------------------*/
 #pragma once
 
 //This is a wrapper file that includes that define config for a visual studio compilation. We kept the original extension(.in) to 

--- a/iModelCore/libsrc/libjpegturbo/vendor/jconfig.h
+++ b/iModelCore/libsrc/libjpegturbo/vendor/jconfig.h
@@ -1,14 +1,7 @@
-/*--------------------------------------------------------------------------------------+
-|
-|     $Source: vendor/jconfig.h $
-|    $RCSfile: HIERasterReference.cpp,v $
-|   $Revision: 1.207 $
-|       $Date: 2011/01/18 15:06:27 $
-|     $Author: Marc.Bedard $
-|
-|  $Copyright: (c) 2017 Bentley Systems, Incorporated. All rights reserved. $
-|
-+--------------------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the repository root for full copyright notice.
+*--------------------------------------------------------------------------------------------*/
 #pragma once
 
 //This is a wrapper file that includes that define config for a visual studio compilation. We kept the original extension(.in) to 

--- a/iModelJsNodeAddon/iModelJsNodeAddon.PartFile.xml
+++ b/iModelJsNodeAddon/iModelJsNodeAddon.PartFile.xml
@@ -7,7 +7,7 @@
     <SubPart PartName="iModelJsNodeAddonPRG"/>
   </Part>
 
-  <Part Name="iModelJsNodeAddonPRG" PrgOutputDir="iModelJsNodeAddon">
+  <Part Name="iModelJsNodeAddonPRG" PrgOutputDir="iModelJsNodeAddon" OnlyPlatforms="x64,linuxx64,macosx64,macosarm64">
     <SubPart PartName="iModelJsMakePackages"/>
     <SubPart PartName="RunUnitTests"/>
     <SubPart PartName="RunUnitTestsMacOSARM64"/>
@@ -165,7 +165,6 @@
   </Part>
 
   <Part Name="RunUnitTestsMacOSARM64" DeferType="RunUnitTests" BentleyBuildMakeFile="api_package/ts/runTests.mke" OnlyPlatforms="MacOSARM64">
-    <RequiredRepository>nodejs16</RequiredRepository>
     <SubPart PartName="iModelJsMakePackages"/>
   </Part>
 


### PR DESCRIPTION
This will allow us to build imodeljsnodeaddon with mobile OS's and have it just build the imodelcore portion. Also cleaned up some additional partfile stuff and fixed some file headers.