### PR TITLE
PrgOutputDir is defined

### DIFF
--- a/iModelCore/iModelPlatform/iModelPlatform.PartFile.xml
+++ b/iModelCore/iModelPlatform/iModelPlatform.PartFile.xml
@@ -143,7 +143,7 @@
          ********************************************************************************************** -->
 
     <!-- Entry point part -->
-    <Part Name="RunIModelEvolutionTests">
+    <Part Name="RunIModelEvolutionTests" PrgOutputDir="IModelEvolutionTests">
         <SubPart PartName="IModelEvolutionRunAllTestRunners"/>
         <SubNuGetProduct NuGetProductName="IModelEvolutionTestRunnerNuget"/>
         <SubNuGetProduct NuGetProductName="IModelEvolutionTestFilesNuget"/>


### PR DESCRIPTION
The attribute is required for `bb taglist` command. 

**Note:** The build has started failing with error: `PrgOutputDir does not exist for part RunIModelEvolutionTests. It is needed for the name of the tag file`