### PR TITLE
Move `BeJsValue.h` away from `jsoncpp`

### DIFF
--- a/iModelCore/BeSQLite/BeSQLite.PartFile.xml
+++ b/iModelCore/BeSQLite/BeSQLite.PartFile.xml
@@ -4,7 +4,7 @@
 
     <!-- Bind my own PublicAPI and VendorAPI into BuildContext. Note that this part does not cause any sub-part PublicAPIs to be bound. Also deliver my notices. -->
     <Part Name="PublicAPI" BentleyBuildMakeFile="BeSQLite.prewire.mke">
-        <SubPart PartName="PublicAPI" PartFile="iModelCore/libsrc/jsoncpp/BeJsonCpp" />
+        <SubPart PartName="BeRapidJson" PartFile="iModelCore/Bentley/Bentley" />
         <SubPart PartName="PublicAPI"  PartFile="iModelCore/libsrc/google_re2/google_re2" />
         <Bindings>
             <PublicAPI Domain="BeSQLite" />
@@ -18,7 +18,6 @@
         <SubPart PartName="PublicAPI" />
         <SubPart PartName="BentleyDll" PartFile="iModelCore/Bentley/Bentley" />
         <SubPart LibType="Static" PartName="Compress" PartFile="iModelCore\libsrc\compress\Zlib"/>
-        <SubPart PartName="BeJsonCpp"  PartFile="iModelCore/libsrc/jsoncpp/BeJsonCpp" />
         <SubPart PartName="google_re2"  PartFile="iModelCore/libsrc/google_re2/google_re2" />
         <SubPart PartName="BeCurl" PartFile="iModelCore\libsrc\curl\BeCurl"/>
         <SubPart PartName="Library" PartFile="iModelCore\libsrc\openssl\BeOpenSSL"/>

--- a/iModelCore/BeSQLite/BeSQLite.mke
+++ b/iModelCore/BeSQLite/BeSQLite.mke
@@ -92,7 +92,6 @@ BeSQLiteRequiredLibs = $(ContextSubPartsStaticLibs)$(stlibprefix)BeZlib$(stlibex
 BeSQLiteRequiredLibs + $(ContextSubPartsStaticLibs)$(stlibprefix)snappy$(stlibext)
 BeSQLiteRequiredLibs + $(ContextSubPartsStaticLibs)$(stlibprefix)lzma$(stlibext)
 BeSQLiteRequiredLibs + $(ContextSubPartsLibs)$(libprefix)iTwinBentley$(libext)
-BeSQLiteRequiredLibs + $(ContextSubPartsLibs)$(libprefix)iTwinJsonCpp$(libext)
 BeSQLiteRequiredLibs + $(ContextSubPartsLibs)$(stlibprefix)BeCurl$(stlibext)
 BeSQLiteRequiredLibs + $(ContextSubPartsLibs)$(stlibprefix)BeOpenSSL$(stlibext)
 BeSQLiteRequiredLibs + $(ContextSubPartsLibs)$(stlibprefix)iTwin_google_re2$(stlibext)

--- a/iModelCore/BeSQLite/PublicAPI/BeSQLite/BeSQLite.h
+++ b/iModelCore/BeSQLite/PublicAPI/BeSQLite/BeSQLite.h
@@ -8,7 +8,7 @@
 #include <Bentley/bset.h>
 #include <Bentley/BeId.h>
 #include <Bentley/BeEvent.h>
-#include <json/BeJsValue.h>
+#include <BeRapidJson/BeJsValue.h>
 #include <list>
 #include <type_traits>
 #include <functional>

--- a/iModelCore/Bentley/BeRapidJson/PublicAPI/BeRapidJson/BeJsValue.h
+++ b/iModelCore/Bentley/BeRapidJson/PublicAPI/BeRapidJson/BeJsValue.h
@@ -17,7 +17,7 @@
 #include <Bentley/ByteStream.h>
 #include <Bentley/Base64Utilities.h>
 #include <BeRapidJson/BeRapidJson.h>
-#include "json.h"
+#include <json/json.h>
 
 namespace Napi {
 class Value;

--- a/iModelCore/Bentley/Bentley.PartFile.xml
+++ b/iModelCore/Bentley/Bentley.PartFile.xml
@@ -204,7 +204,8 @@
     </Part>
 
     <Part Name="BeRapidJson" BentleyBuildMakeFile="BeRapidJson/BeRapidJson.mke">
-        <SubPart PartName="rapidjsonapi" PartFile="iModelCore\libsrc\rapidjson\rapidjson"/>
+        <SubPart PartName="rapidjsonapi" PartFile="iModelCore/libsrc/rapidjson/rapidjson"/>
+        <SubPart PartName="BeJsonCpp" PartFile="iModelCore/libsrc/jsoncpp/BeJsonCpp" />
         <Bindings>
             <PublicAPI Domain="BeRapidJson"/>
         </Bindings>

--- a/iModelCore/ECPresentation/ECPresentation.PartFile.xml
+++ b/iModelCore/ECPresentation/ECPresentation.PartFile.xml
@@ -18,7 +18,6 @@
 
     <Part Name="ECPresentation-Library" BentleyBuildMakeFile="ECPresentation.mke">
         <SubPart PartName="ECPresentation-PublicAPI" />
-        <SubPart PartName="BeJsonCpp" PartFile="iModelCore/libsrc/jsoncpp/BeJsonCpp" />
         <SubPart PartName="BeRapidJson" PartFile="iModelCore/Bentley/Bentley" />
         <SubPart PartName="folly" PartFile="iModelCore/libsrc/facebook/facebook" />
         <SubPart PartName="BeXml" PartFile="iModelCore/Bentley/Bentley" />

--- a/iModelCore/GeoCoord/GeoCoord.PartFile.xml
+++ b/iModelCore/GeoCoord/GeoCoord.PartFile.xml
@@ -11,6 +11,7 @@
     <Part Name="GeoCoord" BentleyBuildMakeFile="BaseGeoCoord/GeoCoord.mke">
         <SubPart PartName="csmapStatic"             PartFile="iModelCore/libsrc/csmap/csmap" />
         <SubPart PartName="BeJsonCpp"               PartFile="iModelCore/libsrc/jsoncpp/BeJsonCpp" />
+        <SubPart PartName="BeRapidJson"             PartFile="iModelCore/Bentley/Bentley" />
         <SubPart PartName="BeXml"                   PartFile="iModelCore/Bentley/Bentley" />
         <SubPart PartName="GeoCoordHeaderFiles" />
         <SubPart PartName="BeSQLite"        PartFile="iModelCore/BeSQLite/BeSQLite" />
@@ -26,12 +27,12 @@
     <Part Name="GeoCoord-Dev">
         <SubPart PartName= "GeoCoord-Tested" />
     </Part>
-    
+
     <Part Name="GeoCoord-FullyTested">
         <SubPart PartName= "GeoCoord-Dev" />
         <SubPart PartName= "GeoCoord-ExtensiveTested" />
     </Part>
-    
+
     <!-- ******************************** Unit Tests ************************************** -->
 
     <Part Name="UnitTests-NonPublished" DeferType="BuildUnitTests" BentleyBuildMakeFile="Tests/BuildTests.mke" BentleyBuildMakeOptions="-dTestDir=NonPublished">
@@ -140,9 +141,9 @@
     <Part Name="GeoCoord-ExtensiveTested">
         <SubPart PartName="RunExtensiveGtest" />
     </Part>
-    
+
     <ProductDirectoryList ListName="GeoCoordExtensiveGTestsDir" >
         <ProductDirectory Name="CSMap"                Deliver="false" />
     </ProductDirectoryList>
-    
+
 </BuildContext>

--- a/iModelCore/GeoCoord/PublicAPI/GeoCoord/BaseGeoCoord.h
+++ b/iModelCore/GeoCoord/PublicAPI/GeoCoord/BaseGeoCoord.h
@@ -12,7 +12,7 @@
 #define GEOCOORD_ENHANCEMENT
 #endif
 
-#include <json/BeJsValue.h>
+#include <BeRapidJson/BeJsValue.h>
 #include <Geom/GeomApi.h>
 #include "BaseGeoDefs.r.h"
 #include <BeJsonCpp/BeJsonUtilities.h>

--- a/iModelCore/GeomLibs/PublicAPI/GeomJsonWireFormat/BeJsGeomUtils.h
+++ b/iModelCore/GeomLibs/PublicAPI/GeomJsonWireFormat/BeJsGeomUtils.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #include <Geom/GeomApi.h>
-#include <json/BeJsValue.h>
+#include <BeRapidJson/BeJsValue.h>
 
 BEGIN_BENTLEY_GEOMETRY_NAMESPACE
 PUSH_MSVC_IGNORE(4701) // potentially uninitialized

--- a/iModelCore/GeomLibs/PublicAPI/GeomSerialization/GeomLibsJsonSerialization.h
+++ b/iModelCore/GeomLibs/PublicAPI/GeomSerialization/GeomLibsJsonSerialization.h
@@ -8,7 +8,7 @@
 //#include <Bentley/BeConsole.h>
 #include <Geom/GeomApi.h>
 #include <BeJsonCpp/BeJsonUtilities.h>
-#include <json/BeJsValue.h>
+#include <BeRapidJson/BeJsValue.h>
 
 BEGIN_BENTLEY_GEOMETRY_NAMESPACE
 
@@ -95,4 +95,3 @@ public: static GEOMLIBS_SERIALIZATION_EXPORT bool TryIModelJsonValueToTaggedNume
 };
 
 END_BENTLEY_GEOMETRY_NAMESPACE
-

--- a/iModelCore/GeomLibs/geomlibs.PartFile.xml
+++ b/iModelCore/GeomLibs/geomlibs.PartFile.xml
@@ -23,6 +23,7 @@
 
     <Part Name="GeomDlls" BentleyBuildMakeFile="geom/build/BentleyGeom/BentleyGeom.mke">
         <SubPart PartName="BentleyDll" PartFile="iModelCore/Bentley/Bentley" />
+        <SubPart PartName="BeRapidJson" PartFile="iModelCore/Bentley/Bentley" />
         <SubPart PartName="BeJsonCpp" PartFile="iModelCore/libsrc/jsoncpp/BeJsonCpp" />
         <SubPart PartName="PublicAPI" />
         <Bindings>
@@ -35,7 +36,8 @@
         <SubPart PartName="GeomDlls"/>
         <SubPart PartName="BentleyDll" PartFile="iModelCore/Bentley/Bentley" />
         <SubPart PartName="Headers" PartFile="iModelCore/libsrc/flatbuffers/flatbuffers"/>
-        <SubPart PartName="BeJsonCpp"       PartFile="iModelCore/libsrc/jsoncpp/BeJsonCpp" />
+        <SubPart PartName="BeJsonCpp" PartFile="iModelCore/libsrc/jsoncpp/BeJsonCpp" />
+        <SubPart PartName="BeRapidJson" PartFile="iModelCore/Bentley/Bentley" />
         <Bindings>
             <Assemblies>Delivery/$(shlibprefix)iTwinGeomSerialization$(shlibext)</Assemblies>
             <Libs>Delivery/$(libprefix)iTwinGeomSerialization$(libext)</Libs>

--- a/iModelCore/Units/PublicAPI/Formatting/FormattingApi.h
+++ b/iModelCore/Units/PublicAPI/Formatting/FormattingApi.h
@@ -8,7 +8,7 @@
 #include <Formatting/FormattingEnum.h>
 #include <Formatting/AliasMappings.h>
 #include <Bentley/Nullable.h>
-#include <json/BeJsValue.h>
+#include <BeRapidJson/BeJsValue.h>
 
 namespace BEU = BentleyApi::Units;
 

--- a/iModelCore/Units/Units.PartFile.xml
+++ b/iModelCore/Units/Units.PartFile.xml
@@ -11,6 +11,7 @@
     <Part Name="UnitsNative" BentleyBuildMakeFile="Units.mke">
         <SubPart PartName="PublicAPI" />
         <SubPart PartName="BentleyDll"  PartFile="iModelCore/Bentley/Bentley" />
+        <SubPart PartName="BeRapidJson" PartFile="iModelCore/Bentley/Bentley" />
         <SubPart PartName="BeJsonCpp"   PartFile="iModelCore/libsrc/jsoncpp/BeJsonCpp" />
         <Bindings>
             <Libs>Delivery/$(libprefix)iTwinUnits$(libext)</Libs>

--- a/iModelCore/ecobjects/PublicApi/ECObjects/ECJsonUtilities.h
+++ b/iModelCore/ecobjects/PublicApi/ECObjects/ECJsonUtilities.h
@@ -9,7 +9,7 @@
 #include <Bentley/DateTime.h>
 #include <Bentley/ByteStream.h>
 #include <Geom/GeomApi.h>
-#include <json/BeJsValue.h>
+#include <BeRapidJson/BeJsValue.h>
 
 BEGIN_BENTLEY_ECOBJECT_NAMESPACE
 //=================================================================================

--- a/iModelCore/ecobjects/PublicApi/ECObjects/ECSchema.h
+++ b/iModelCore/ecobjects/PublicApi/ECObjects/ECSchema.h
@@ -17,7 +17,7 @@
 #include <Bentley/Nullable.h>
 #include <Bentley/Logging.h>
 #include <Formatting/FormattingApi.h>
-#include <json/BeJsValue.h>
+#include <BeRapidJson/BeJsValue.h>
 #include <pugixml/src/pugixml.hpp>
 #include <pugixml/src/BePugiXmlHelper.h>
 

--- a/iModelCore/ecobjects/PublicApi/ECObjects/ECUnit.h
+++ b/iModelCore/ecobjects/PublicApi/ECObjects/ECUnit.h
@@ -8,7 +8,7 @@
 #include <Units/Units.h>
 #include <Bentley/Nullable.h>
 #include <Formatting/FormattingApi.h>
-#include <json/BeJsValue.h>
+#include <BeRapidJson/BeJsValue.h>
 
 BEGIN_BENTLEY_ECOBJECT_NAMESPACE
 

--- a/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/DgnElement.h
+++ b/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/DgnElement.h
@@ -10,7 +10,7 @@
 #include <DgnPlatform/CodeSpec.h>
 #include <Napi/napi.h>
 #include <map>
-#include <json/BeJsValue.h>
+#include <BeRapidJson/BeJsValue.h>
 
 BEGIN_BENTLEY_RENDER_NAMESPACE
 struct Graphic;

--- a/iModelCore/iModelPlatform/Tests/DgnProject/NonPublished/ExternalSource_Test.cpp
+++ b/iModelCore/iModelPlatform/Tests/DgnProject/NonPublished/ExternalSource_Test.cpp
@@ -3,7 +3,7 @@
 * See LICENSE.md in the repository root for full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 #include "DgnHandlersTests.h"
-#include "json/BeJsValue.h"
+#include <BeRapidJson/BeJsValue.h>
 
 struct ExternalSourceTest : public GenericDgnModel2dTestFixture
 {

--- a/iModelCore/iModelPlatform/iModelPlatform.PartFile.xml
+++ b/iModelCore/iModelPlatform/iModelPlatform.PartFile.xml
@@ -25,6 +25,7 @@
         <SubPart PartName="ECObjects"     PartFile="iModelCore/ecobjects/ECObjects" />
         <SubPart PartName="Freetype2Library" PartFile="iModelCore/libsrc/freetype2/freetype2"/>
         <SubPart PartName="BeJsonCpp"           PartFile="iModelCore/libsrc/jsoncpp/BeJsonCpp" />
+        <SubPart PartName="BeRapidJson" PartFile="iModelCore/Bentley/Bentley" />
         <SubPart LibType="Static" PartName="pnglib" PartFile="iModelCore/libsrc/png/png"/>
         <SubPart PartName="BeJpeg" PartFile="iModelCore/Bentley/Bentley" />
         <SubPart PartName="Headers" PartFile="iModelCore/libsrc/flatbuffers/flatbuffers"/>

--- a/iModelCore/libsrc/jsoncpp/BeJsonCpp.PartFile.xml
+++ b/iModelCore/libsrc/jsoncpp/BeJsonCpp.PartFile.xml
@@ -8,7 +8,6 @@
     </Part>
 
     <Part Name="PublicAPI" BentleyBuildMakeFile="prewire.mke">
-        <SubPart PartName="BeRapidJson" PartFile="iModelCore/Bentley/Bentley"/>
         <Bindings>
             <PublicAPI Domain="BeJsonCpp" />
             <PublicAPI Domain="json" />

--- a/iModelCore/libsrc/jsoncpp/tests/NonPublished/BeJsonUtilitiesTests.cpp
+++ b/iModelCore/libsrc/jsoncpp/tests/NonPublished/BeJsonUtilitiesTests.cpp
@@ -6,7 +6,7 @@
 #include <Bentley/BeTest.h>
 #include <Bentley/LocalState.h>
 #include <BeJsonCpp/BeJsonUtilities.h>
-#include <json/BeJsValue.h>
+#include <BeRapidJson/BeJsValue.h>
 
 USING_NAMESPACE_BENTLEY
 
@@ -262,4 +262,3 @@ TEST(GetConstArrayMember, OnlyModifiesNonConstValue)
     EXPECT_TRUE(nc[1].isNull());
     EXPECT_EQ(nc.size(), 2);
     }
-

--- a/node-addon-api/Napi/napi.h
+++ b/node-addon-api/Napi/napi.h
@@ -7,7 +7,7 @@
 #include "node_api-config.h"
 #include "node-src/napi.h"
 #include <Bentley/ByteStream.h>
-#include <json/BeJsValue.h>
+#include <BeRapidJson/BeJsValue.h>
 #include <limits>
 
 BEGIN_BENTLEY_NAMESPACE
@@ -125,8 +125,8 @@ protected:
     }
     virtual double GetDouble(double defVal) const override { return isNumeric() ? m_napiVal.ToNumber() : defVal; }
     virtual bool GetBoolean(bool defVal) const override { return isNull() ? defVal : m_napiVal.ToBoolean(); }
-    virtual Json::Int GetInt(Json::Int defVal) const override { return isNumeric() ? m_napiVal.ToNumber() : defVal; }
-    virtual Json::UInt GetUInt(Json::UInt defVal) const override { return isNumeric() ? m_napiVal.ToNumber() : defVal; }
+    virtual int32_t GetInt(int32_t defVal) const override { return isNumeric() ? m_napiVal.ToNumber() : defVal; }
+    virtual uint32_t GetUInt(uint32_t defVal) const override { return isNumeric() ? m_napiVal.ToNumber() : defVal; }
     virtual BentleyStatus GetBinary(std::vector<Byte>& dest) const override {
         dest.clear();
         if (m_napiVal.IsTypedArray()) {

--- a/node-addon-api/node-addon-api.PartFile.xml
+++ b/node-addon-api/node-addon-api.PartFile.xml
@@ -4,7 +4,7 @@
 
     <!-- The delivers the "Napi/napi.h" source files. -->
     <Part Name="VendorAPI" BentleyBuildMakeFile="prewire-api.mke">
-        <SubPart PartName="BeJsonCpp"  PartFile="iModelCore/libsrc/jsoncpp/BeJsonCpp" />
+        <SubPart PartName="BeRapidJson"  PartFile="iModelCore/Bentley/Bentley" />
         <Bindings>
             <VendorAPI Domain="Napi"/>
         </Bindings>
@@ -12,6 +12,7 @@
 
     <Part Name="napi-lib" BentleyBuildMakeFile="node-addon-lib.mke">
         <SubPart PartName="VendorAPI"/>
+        <SubPart PartName="BentleyDll" PartFile="iModelCore/Bentley/Bentley" />
         <Bindings>
             <Libs>Delivery/$(stlibprefix)iTwinNapi$(stlibext)</Libs>
         </Bindings>


### PR DESCRIPTION
Related to https://github.com/iTwin/itwinjs-backlog/issues/444#issuecomment-1454712836.

This PR inverts the dependency between `BeRapidJson` and `BeJsonCpp` parts - previously `BeJsonCpp` had a `BeRapidJson` dependency and now it's the opposite. 

I initially tried to avoid making `BeRapidJson` depend on `BeJsonCpp`, but that required removing jsoncpp-related implicit constructors from `BeJsConst` and `BeJsValue`. That broke tons of code across the whole repository in places where `jsoncpp` is still used... I believe we need to first get rid of `jsoncpp` usages before removing this dependency.