### PR TITLE
Presentation: Fix test failures in debug builds

### DIFF
--- a/iModelCore/ECPresentation/Source/Hierarchies/NavigationQueryBuilder.cpp
+++ b/iModelCore/ECPresentation/Source/Hierarchies/NavigationQueryBuilder.cpp
@@ -2657,6 +2657,9 @@ public:
         bvector<PresentationQueryBuilderPtr> queries;
         for (auto const& entry : orderedSelects)
             {
+            if (entry.second.empty())
+                continue;
+
             PresentationQueryBuilderPtr query = entry.first->CreateQuery(entry.second, m_groupingFilters);
             if (query.IsNull())
                 {


### PR DESCRIPTION
Introduced with https://github.com/iTwin/imodel-native/pull/187.

Only fails in DEBUG builds because of assertion failure. CI uses optimized builds, which don't do assertions.