### PR TITLE
Presentation: Fix getting nodes when child specs use different vars

### DIFF
--- a/iModelCore/ECPresentation/Source/Hierarchies/NavNodeProviders.cpp
+++ b/iModelCore/ECPresentation/Source/Hierarchies/NavNodeProviders.cpp
@@ -3922,10 +3922,9 @@ CachedStatementPtr CachedCombinedHierarchyLevelProvider::_GetUsedVariablesStatem
             PHYSICAL_HIERARCHY_LEVELS_SETUP_HL_TABLE_ALIAS ".[Id] = ? "
             "AND " PHYSICAL_HIERARCHY_LEVELS_SETUP_HL_TABLE_ALIAS ".[RemovalId] IS ?"
         )
-        "SELECT [dsv].[Variables] "
+        "SELECT [phl].[" PHYSICAL_HIERARCHY_LEVELS_COLUMN_NAME_Variables "] "
         "  FROM [" PHYSICAL_HIERARCHY_LEVELS_TABLE_NAME "] phl "
-        "  CROSS JOIN [" NODESCACHE_TABLENAME_Variables "] dsv ON [dsv].[Id] = [phl].[" PHYSICAL_HIERARCHY_LEVELS_COLUMN_NAME_VariablesId "]"
-        " WHERE " NODESCACHE_FUNCNAME_VariablesMatch "([dsv].[Variables], ?) ";
+        " WHERE " NODESCACHE_FUNCNAME_VariablesMatch "([phl].[" PHYSICAL_HIERARCHY_LEVELS_COLUMN_NAME_Variables "], ?) ";
 
     DIAGNOSTICS_DEV_LOG(DiagnosticsCategory::Hierarchies, LOG_TRACE, Utf8PrintfString("Used variables query: `%s`", query));
 
@@ -3954,7 +3953,6 @@ CachedStatementPtr CachedCombinedHierarchyLevelProvider::_GetResultInstanceNodes
         )
         "SELECT DISTINCT [ni].[ECClassId] "
         "  FROM [" PHYSICAL_HIERARCHY_LEVELS_TABLE_NAME "] phl "
-        "  CROSS JOIN [" NODESCACHE_TABLENAME_Variables "] dsv ON [dsv].[Id] = [phl].[" PHYSICAL_HIERARCHY_LEVELS_COLUMN_NAME_VariablesId "] "
         "  CROSS JOIN [" NODESCACHE_TABLENAME_DataSourceNodes "] dsn ON [dsn].[DataSourceId] = [phl].[" PHYSICAL_HIERARCHY_LEVELS_COLUMN_NAME_DataSourceId "] "
         "  CROSS JOIN [" NODESCACHE_TABLENAME_DataSources "] ds ON [ds].[Id] = [phl].[" PHYSICAL_HIERARCHY_LEVELS_COLUMN_NAME_DataSourceId "] "
         "  CROSS JOIN [" NODESCACHE_TABLENAME_Nodes "] n ON [n].[Id] = [dsn].[NodeId]"
@@ -3962,7 +3960,7 @@ CachedStatementPtr CachedCombinedHierarchyLevelProvider::_GetResultInstanceNodes
         " WHERE [ds].[InstanceFilter] IS ? "
         "       AND [ds].[ResultSetSizeLimit] IS ? "
         "       AND [dsn].[Visibility] = ? "
-        "       AND " NODESCACHE_FUNCNAME_VariablesMatch "([dsv].[Variables], ?) ";
+        "       AND " NODESCACHE_FUNCNAME_VariablesMatch "([phl].[" PHYSICAL_HIERARCHY_LEVELS_COLUMN_NAME_Variables "], ?) ";
 
     DIAGNOSTICS_DEV_LOG(DiagnosticsCategory::Hierarchies, LOG_TRACE, Utf8PrintfString("Result instance node class IDs query: `%s`", query));
 
@@ -3994,7 +3992,6 @@ CachedStatementPtr CachedCombinedHierarchyLevelProvider::_GetNodesStatement() co
         "SELECT " NODE_SELECT_STMT("hl", "n", "nk")
         "  FROM [" PHYSICAL_HIERARCHY_LEVELS_TABLE_NAME "] phl "
         "  CROSS JOIN [" NODESCACHE_TABLENAME_HierarchyLevels "] hl ON [hl].[Id] = [phl].[" PHYSICAL_HIERARCHY_LEVELS_COLUMN_NAME_HierarchyLevelId "] "
-        "  CROSS JOIN [" NODESCACHE_TABLENAME_Variables "] dsv ON [dsv].[Id] = [phl].[" PHYSICAL_HIERARCHY_LEVELS_COLUMN_NAME_VariablesId "] "
         "  CROSS JOIN [" NODESCACHE_TABLENAME_DataSources "] ds ON [ds].[Id] = [phl].[" PHYSICAL_HIERARCHY_LEVELS_COLUMN_NAME_DataSourceId "] "
         "  CROSS JOIN [" NODESCACHE_TABLENAME_DataSourceNodes "] dsn ON [dsn].[DataSourceId] = [ds].[Id] "
         "  CROSS JOIN [" NODESCACHE_TABLENAME_Nodes "] n ON [n].[Id] = [dsn].[NodeId] "
@@ -4002,7 +3999,7 @@ CachedStatementPtr CachedCombinedHierarchyLevelProvider::_GetNodesStatement() co
         " WHERE [ds].[InstanceFilter] IS ? "
         "       AND [ds].[ResultSetSizeLimit] IS ? "
         "       AND [dsn].[Visibility] = ? "
-        "       AND " NODESCACHE_FUNCNAME_VariablesMatch "([dsv].[Variables], ?) "
+        "       AND " NODESCACHE_FUNCNAME_VariablesMatch "([phl].[" PHYSICAL_HIERARCHY_LEVELS_COLUMN_NAME_Variables "], ?) "
         " ORDER BY " NODESCACHE_FUNCNAME_ConcatBinaryIndex "([phl].[" PHYSICAL_HIERARCHY_LEVELS_COLUMN_NAME_DataSourceIndex "], [dsn].[NodeIndex]) ";
     if (GetContext().HasPageOptions())
         query.append(" LIMIT ? OFFSET ? ");
@@ -4045,13 +4042,12 @@ CachedStatementPtr CachedCombinedHierarchyLevelProvider::_GetCountStatement() co
         )
         "SELECT COUNT(1) "
         "  FROM [" PHYSICAL_HIERARCHY_LEVELS_TABLE_NAME "] phl "
-        "  CROSS JOIN [" NODESCACHE_TABLENAME_Variables "] dsv ON [dsv].[Id] = [phl].[" PHYSICAL_HIERARCHY_LEVELS_COLUMN_NAME_VariablesId "] "
         "  CROSS JOIN [" NODESCACHE_TABLENAME_DataSources "] ds ON [ds].[Id] = [phl].[" PHYSICAL_HIERARCHY_LEVELS_COLUMN_NAME_DataSourceId "] "
         "  CROSS JOIN [" NODESCACHE_TABLENAME_DataSourceNodes "] dsn ON [dsn].[DataSourceId] = [ds].[Id] "
         " WHERE [dsn].[Visibility] = ? "
         "       AND [ds].[InstanceFilter] IS ? "
         "       AND [ds].[ResultSetSizeLimit] IS ? "
-        "       AND " NODESCACHE_FUNCNAME_VariablesMatch "([dsv].[Variables], ?) ";
+        "       AND " NODESCACHE_FUNCNAME_VariablesMatch "([phl].[" PHYSICAL_HIERARCHY_LEVELS_COLUMN_NAME_Variables "], ?) ";
 
     DIAGNOSTICS_DEV_LOG(DiagnosticsCategory::Hierarchies, LOG_TRACE, Utf8PrintfString("Nodes count query: `%s`", query));
 

--- a/iModelCore/ECPresentation/Source/Hierarchies/NavNodesCache.cpp
+++ b/iModelCore/ECPresentation/Source/Hierarchies/NavNodesCache.cpp
@@ -2075,13 +2075,12 @@ bvector<uint64_t> NodesCache::_GetNodeIndex(BeGuidCR hierarchyLevelId, BeGuidCR 
         )
         "SELECT " NODESCACHE_FUNCNAME_ConcatBinaryIndex "([phl].[" PHYSICAL_HIERARCHY_LEVELS_COLUMN_NAME_DataSourceIndex "], [dsn].[NodeIndex]) "
         "  FROM [" PHYSICAL_HIERARCHY_LEVELS_TABLE_NAME "] phl "
-        "  JOIN [" NODESCACHE_TABLENAME_Variables "] dsv ON [dsv].[Id] = [phl].[" PHYSICAL_HIERARCHY_LEVELS_COLUMN_NAME_VariablesId "]"
         "  JOIN [" NODESCACHE_TABLENAME_DataSourceNodes "] dsn ON [dsn].[DataSourceId] = [phl].[" PHYSICAL_HIERARCHY_LEVELS_COLUMN_NAME_DataSourceId "] "
         "  JOIN [" NODESCACHE_TABLENAME_DataSources "] ds ON [ds].[Id] = [dsn].[DataSourceId] "
         " WHERE [dsn].[NodeId] = ? "
         "       AND [ds].[InstanceFilter] IS ? "
         "       AND [ds].[ResultSetSizeLimit] IS ? "
-        "       AND " NODESCACHE_FUNCNAME_VariablesMatch "([dsv].[Variables], ?) ";
+        "       AND " NODESCACHE_FUNCNAME_VariablesMatch "([phl].[" PHYSICAL_HIERARCHY_LEVELS_COLUMN_NAME_Variables "], ?) ";
 
     CachedStatementPtr stmt;
     if (BE_SQLITE_OK != m_statements.GetPreparedStatement(stmt, *m_db.GetDbFile(), query))

--- a/iModelCore/ECPresentation/Source/Hierarchies/NavNodesCacheHelpers.h
+++ b/iModelCore/ECPresentation/Source/Hierarchies/NavNodesCacheHelpers.h
@@ -66,7 +66,7 @@ BEGIN_BENTLEY_ECPRESENTATION_NAMESPACE
 #define PHYSICAL_HIERARCHY_LEVELS_SETUP_HL_TABLE_ALIAS "[hl]"
 #define PHYSICAL_HIERARCHY_LEVELS_COLUMN_NAME_DataSourceId "DataSourceId"
 #define PHYSICAL_HIERARCHY_LEVELS_COLUMN_NAME_DataSourceIndex "DataSourceIndex"
-#define PHYSICAL_HIERARCHY_LEVELS_COLUMN_NAME_VariablesId "VariablesId"
+#define PHYSICAL_HIERARCHY_LEVELS_COLUMN_NAME_Variables "Variables"
 #define PHYSICAL_HIERARCHY_LEVELS_COLUMN_NAME_InstanceFilter "InstanceFilter"
 #define PHYSICAL_HIERARCHY_LEVELS_COLUMN_NAME_HierarchyLevelId "HierarchyLevelId"
 #define PHYSICAL_HIERARCHY_LEVELS_COLUMN_NAME_VirtualParentNodeId "VirtualParentNodeId"
@@ -79,7 +79,7 @@ BEGIN_BENTLEY_ECPRESENTATION_NAMESPACE
     PHYSICAL_HIERARCHY_LEVELS_TABLE_NAME " (" \
         PHYSICAL_HIERARCHY_LEVELS_COLUMN_NAME_DataSourceId ", " \
         PHYSICAL_HIERARCHY_LEVELS_COLUMN_NAME_DataSourceIndex ", " \
-        PHYSICAL_HIERARCHY_LEVELS_COLUMN_NAME_VariablesId ", " \
+        PHYSICAL_HIERARCHY_LEVELS_COLUMN_NAME_Variables ", " \
         PHYSICAL_HIERARCHY_LEVELS_COLUMN_NAME_InstanceFilter ", " \
         PHYSICAL_HIERARCHY_LEVELS_COLUMN_NAME_HierarchyLevelId ", " \
         PHYSICAL_HIERARCHY_LEVELS_COLUMN_NAME_VirtualParentNodeId ", " \
@@ -90,7 +90,7 @@ BEGIN_BENTLEY_ECPRESENTATION_NAMESPACE
     ") AS (" \
     "    SELECT ds.Id, " \
     "           ds.[Index], " \
-    "           ds.VariablesId, " \
+    "           dsv.Variables, " \
     "           ds.InstanceFilter, " \
     "           " PHYSICAL_HIERARCHY_LEVELS_SETUP_HL_TABLE_ALIAS ".Id, " \
     "           " PHYSICAL_HIERARCHY_LEVELS_SETUP_HL_TABLE_ALIAS ".ParentNodeId, " \
@@ -100,11 +100,12 @@ BEGIN_BENTLEY_ECPRESENTATION_NAMESPACE
     "           " PHYSICAL_HIERARCHY_LEVELS_SETUP_HL_TABLE_ALIAS ".RemovalId " \
     "    FROM [" NODESCACHE_TABLENAME_HierarchyLevels "] AS " PHYSICAL_HIERARCHY_LEVELS_SETUP_HL_TABLE_ALIAS \
     "    CROSS JOIN [" NODESCACHE_TABLENAME_DataSources "] AS ds ON [ds].[HierarchyLevelId] = " PHYSICAL_HIERARCHY_LEVELS_SETUP_HL_TABLE_ALIAS ".[Id] " \
+    "    CROSS JOIN [" NODESCACHE_TABLENAME_Variables "] AS dsv ON [dsv].[Id] = [ds].[VariablesId] " \
     "    WHERE " SETUP_WHERE_CLAUSE \
     "    UNION ALL " \
     "    SELECT ds.Id, " \
     "           " NODESCACHE_FUNCNAME_ConcatBinaryIndex "([phl].[" PHYSICAL_HIERARCHY_LEVELS_COLUMN_NAME_DataSourceIndex "], [dsn].[NodeIndex], [ds].[Index]), " \
-    "           ds.VariablesId, " \
+    "           dsv.Variables, " \
     "           ds.InstanceFilter, " \
     "           chl.Id, " \
     "           dsn.NodeId, " \
@@ -117,8 +118,10 @@ BEGIN_BENTLEY_ECPRESENTATION_NAMESPACE
     "    CROSS JOIN [" NODESCACHE_TABLENAME_HierarchyLevels "] AS chl ON [chl].[ParentNodeId] = [dsn].[NodeId] " \
     "    CROSS JOIN [" NODESCACHE_TABLENAME_DataSources "] AS ds " \
     "         ON     [ds].[HierarchyLevelId] = [chl].[Id] " \
-    "            AND [ds].[VariablesId] = [phl].[VariablesId] " \
     "            AND [ds].[InstanceFilter] IS [phl].[" PHYSICAL_HIERARCHY_LEVELS_COLUMN_NAME_InstanceFilter "] " \
+    "    CROSS JOIN [" NODESCACHE_TABLENAME_Variables "] AS dsv " \
+    "         ON     [dsv].[Id] = [ds].[VariablesId] " \
+    "            AND " NODESCACHE_FUNCNAME_VariablesMatch "([dsv].[Variables], [phl].[" PHYSICAL_HIERARCHY_LEVELS_COLUMN_NAME_Variables "]) " \
     ")"
 
 /*=================================================================================**//**

--- a/iModelCore/ECPresentation/Tests/Performance/Analysis/HierarchyPerformanceAnalysis.cpp
+++ b/iModelCore/ECPresentation/Tests/Performance/Analysis/HierarchyPerformanceAnalysis.cpp
@@ -119,31 +119,31 @@ TEST_F(HierarchyPerformanceAnalysis, Run)
         Reset(&project);
 
         // now load all hierarchy in pages (cold cache)
-        totalNodesCount = 0;
         createFullHierarchyTime.Init(true);
         HierarchyPagedLoadPerformanceMetricsStorage metricsColdCache(HierarchyCacheState::Cold);
-        totalNodesCount = PresentationManagerTestsHelper::GatAllNodesPaged(*m_manager, params, HIERARCHY_REQUEST_PAGE_SIZE, [&metricsColdCache](int pageIndex, double pageTime, double countTime)
+        size_t totalNodesCountPagedColdCache = PresentationManagerTestsHelper::GatAllNodesPaged(*m_manager, params, HIERARCHY_REQUEST_PAGE_SIZE, [&metricsColdCache](int pageIndex, double pageTime, double countTime)
             {
             metricsColdCache.ReportPageLoad(pageIndex, pageTime, countTime);
             }, &depthLimiter).get();
         createFullHierarchyTime.Stop();
         metricsColdCache.ReportTotalTime(createFullHierarchyTime.GetElapsed());
         metricsColdCache.Save(reporter);
-        NativeLogging::CategoryLogger(LOGGER_NAMESPACE).infov("    Loaded all hierarchy with %" PRIu64 " nodes in pages with cold cache in %.2f s", (uint64_t)totalNodesCount, createFullHierarchyTime.GetElapsed().ToSeconds());
+        NativeLogging::CategoryLogger(LOGGER_NAMESPACE).infov("    Loaded all hierarchy with %" PRIu64 " nodes in pages with cold cache in %.2f s", (uint64_t)totalNodesCountPagedColdCache, createFullHierarchyTime.GetElapsed().ToSeconds());
         LogDepthLimitReachCount(depthLimiter);
+        EXPECT_EQ(totalNodesCount, totalNodesCountPagedColdCache);
 
         // now load all hierarchy in pages again (warm cache)
-        totalNodesCount = 0;
         createFullHierarchyTime.Init(true);
         HierarchyPagedLoadPerformanceMetricsStorage metricsWarmCache(HierarchyCacheState::Warm);
-        totalNodesCount = PresentationManagerTestsHelper::GatAllNodesPaged(*m_manager, params, HIERARCHY_REQUEST_PAGE_SIZE, [&metricsWarmCache](int pageIndex, double pageTime, double countTime)
+        size_t totalNodesCountPagedWarmCache = PresentationManagerTestsHelper::GatAllNodesPaged(*m_manager, params, HIERARCHY_REQUEST_PAGE_SIZE, [&metricsWarmCache](int pageIndex, double pageTime, double countTime)
             {
             metricsWarmCache.ReportPageLoad(pageIndex, pageTime, countTime);
             }, &depthLimiter).get();
         createFullHierarchyTime.Stop();
         metricsWarmCache.ReportTotalTime(createFullHierarchyTime.GetElapsed());
         metricsWarmCache.Save(reporter);
-        NativeLogging::CategoryLogger(LOGGER_NAMESPACE).infov("    Loaded all hierarchy with %" PRIu64 " nodes in pages with warm cache in %.2f s", (uint64_t)totalNodesCount, createFullHierarchyTime.GetElapsed().ToSeconds());
+        NativeLogging::CategoryLogger(LOGGER_NAMESPACE).infov("    Loaded all hierarchy with %" PRIu64 " nodes in pages with warm cache in %.2f s", (uint64_t)totalNodesCountPagedWarmCache, createFullHierarchyTime.GetElapsed().ToSeconds());
         LogDepthLimitReachCount(depthLimiter);
+        EXPECT_EQ(totalNodesCount, totalNodesCountPagedWarmCache);
         });
     }


### PR DESCRIPTION
Fixes https://github.com/iTwin/imodel-native/issues/202.

Also, turns out our performance tests have been producing this issue for a while now:
```
INFO     Performance.RulesEngine   Ruleset: VisibilityTree.json
INFO     Performance.RulesEngine     Loaded all hierarchy with 3976 nodes in 18.10 s
INFO     Performance.RulesEngine     Loaded all hierarchy with 2 nodes in pages with cold cache in 0.16 s
INFO     Performance.RulesEngine     Loaded all hierarchy with 2 nodes in pages with warm cache in 0.02 s
```
The PR contains a change to perf tests to verify counts of nodes that we get when requesting them in different ways.