### PR TITLE
Presentation: Add valgrind suppression for `ThreadPool::GetCpuPool()`

### DIFF
--- a/iModelCore/ECPresentation/Tests/valgrind.supp
+++ b/iModelCore/ECPresentation/Tests/valgrind.supp
@@ -7,3 +7,23 @@
    fun:_ZN12BentleyM020018BeFileListIterator15GetNextFileNameERNS_10BeFileNameE
    ...
 }
+
+# PresentationManager uses a static `ThreadPool::GetCpuPool()` for returning folly futures. There's no way to destroy the thread pool - it
+# only gets cleaned up when terminating the application.
+{
+   CpuThreadPool
+   Memcheck:Leak
+   match-leak-kinds: possible
+   ...
+   fun:_ZN12BentleyM020017BeThreadUtilities14StartNewThreadEPFPvS1_ES1_i
+   fun:Start
+   fun:_ZN7BeFolly10ThreadPoolC1EiPKc
+   fun:CpuThreadPoolImp
+   fun:operator()
+   fun:_ZNSt17_Function_handlerIFPN12_GLOBAL__N_116CpuThreadPoolImpEvEZN5folly9SingletonIS1_NS4_6detail10DefaultTagES7_EC1EDnSt8functionIFvS2_EEEUlvE_E9_M_invokeERKSt9_Any_data
+   fun:operator()
+   fun:_ZN5folly6detail15SingletonHolderIN12_GLOBAL__N_116CpuThreadPoolImpEE14createInstanceEv
+   ...
+   fun:_ZN7BeFolly10ThreadPool10GetCpuPoolEv
+   ...
+}


### PR DESCRIPTION
Add a suppression for the following:

https://dev.azure.com/bentleycs/iModelTechnologies/_build/results?buildId=1995386&view=logs&j=502f68b3-17c3-5e6e-19b1-e8b7c76cdbb4&t=626d5962-b3fb-584d-1451-aeaa2b305f7d&l=5412

```
==4378==    by 0x5044189: allocate_stack (allocatestack.c:584)
==4378==    by 0x5044189: pthread_create@@GLIBC_2.2.5 (pthread_create.c:663)
==4378==    by 0x197427A: BentleyM0200::BeThreadUtilities::StartNewThread(void* (*)(void*), void*, int) (BeThread.cpp:351)
==4378==    by 0x19563EA: Start (BeFolly.cpp:84)
==4378==    by 0x19563EA: BeFolly::ThreadPool::ThreadPool(int, char const*) (BeFolly.cpp:99)
==4378==    by 0x195ADCA: CpuThreadPoolImp (BeFolly.cpp:162)
==4378==    by 0x195ADCA: operator() (Singleton.h:563)
==4378==    by 0x195ADCA: std::_Function_handler<(anonymous namespace)::CpuThreadPoolImp* (), folly::Singleton<(anonymous namespace)::CpuThreadPoolImp, folly::detail::DefaultTag, folly::detail::DefaultTag>::Singleton(decltype(nullptr), std::function<void ((anonymous namespace)::CpuThreadPoolImp*)>)::{lambda()#1}>::_M_invoke(std::_Any_data const&) (functional:1716)
==4378==    by 0x195B225: operator() (functional:2127)
==4378==    by 0x195B225: folly::detail::SingletonHolder<(anonymous namespace)::CpuThreadPoolImp>::createInstance() (Singleton-inl.h:248)
==4378==    by 0x1956AE3: try_get_fast (Singleton-inl.h:136)
==4378==    by 0x1956AE3: try_get_fast (Singleton.h:558)
==4378==    by 0x1956AE3: BeFolly::ThreadPool::GetCpuPool() (BeFolly.cpp:182)
==4378==    by 0x160CA97: folly::Future<BentleyM0200::ECPresentation::ECPresentationResponse<BentleyM0200::ECPresentation::NavNodesContainer> > BentleyM0200::ECPresentation::ECPresentationTasksManager::CreateAndExecute<BentleyM0200::ECPresentation::ECPresentationResponse<BentleyM0200::ECPresentation::NavNodesContainer> >(std::function<BentleyM0200::ECPresentation::ECPresentationResponse<BentleyM0200::ECPresentation::NavNodesContainer> (BentleyM0200::ECPresentation::IECPresentationTaskWithResult<BentleyM0200::ECPresentation::ECPresentationResponse<BentleyM0200::ECPresentation::NavNodesContainer> >&)>, BentleyM0200::ECPresentation::ECPresentationTaskParams const&) (TaskScheduler.h:654)
==4378==    by 0x160C7C0: BentleyM0200::ECPresentation::ECPresentationManager::GetNodes(BentleyM0200::ECPresentation::WithPageOptions<BentleyM0200::ECPresentation::WithAsyncTaskParams<BentleyM0200::ECPresentation::HierarchyRequestParams> > const&) (ECPresentationManager.cpp:483)
==4378==    by 0x80C492: operator() (HierarchyUpdateTests.cpp:99)
==4378==    by 0x80C492: std::_Function_handler<BentleyM0200::ECPresentation::ECPresentationResponse<BentleyM0200::ECPresentation::NavNodesContainer> (), HierarchyUpdateTests_RemovesECInstanceNodeAfterECInstanceDelete_Test::TestBody()::$_0>::_M_invoke(std::_Any_data const&) (functional:1716)
==4378== 
{
   <insert_a_suppression_name_here>
   Memcheck:Leak
   match-leak-kinds: possible
   fun:calloc
   fun:allocate_dtv
   fun:_dl_allocate_tls
   fun:allocate_stack
   fun:pthread_create@@GLIBC_2.2.5
   fun:_ZN12BentleyM020017BeThreadUtilities14StartNewThreadEPFPvS1_ES1_i
   fun:Start
   fun:_ZN7BeFolly10ThreadPoolC1EiPKc
   fun:CpuThreadPoolImp
   fun:operator()
   fun:_ZNSt17_Function_handlerIFPN12_GLOBAL__N_116CpuThreadPoolImpEvEZN5folly9SingletonIS1_NS4_6detail10DefaultTagES7_EC1EDnSt8functionIFvS2_EEEUlvE_E9_M_invokeERKSt9_Any_data
   fun:operator()
   fun:_ZN5folly6detail15SingletonHolderIN12_GLOBAL__N_116CpuThreadPoolImpEE14createInstanceEv
   fun:try_get_fast
   fun:try_get_fast
   fun:_ZN7BeFolly10ThreadPool10GetCpuPoolEv
   fun:_ZN12BentleyM020014ECPresentation26ECPresentationTasksManager16CreateAndExecuteINS0_22ECPresentationResponseINS0_17NavNodesContainerEEEEEN5folly6FutureIT_EESt8functionIFS8_RNS0_29IECPresentationTaskWithResultIS8_EEEERKNS0_24ECPresentationTaskParamsE
   fun:_ZN12BentleyM020014ECPresentation21ECPresentationManager8GetNodesERKNS0_15WithPageOptionsINS0_19WithAsyncTaskParamsINS0_22HierarchyRequestParamsEEEEE
   fun:operator()
   fun:_ZNSt17_Function_handlerIFN12BentleyM020014ECPresentation22ECPresentationResponseINS1_17NavNodesContainerEEEvEZN68HierarchyUpdateTests_RemovesECInstanceNodeAfterECInstanceDelete_Test8TestBodyEvE3$_0E9_M_invokeERKSt9_Any_data
}
==4378== LEAK SUMMARY:
==4378==    definitely lost: 0 bytes in 0 blocks
==4378==    indirectly lost: 0 bytes in 0 blocks
==4378==      possibly lost: 3,040 bytes in 10 blocks
==4378==    still reachable: 200,996 bytes in 1,558 blocks
==4378==                       of which reachable via heuristic:
==4378==                         length64           : 128 bytes in 2 blocks
==4378==         suppressed: 0 bytes in 0 blocks
==4378== Reachable blocks (those to which a pointer was found) are not shown.
==4378== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==4378== 
==4378== For counts of detected and suppressed errors, rerun with: -v
==4378== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```