### PR TITLE
Presentation: Fix hierarchy update

### DIFF
--- a/iModelJsNodeAddon/presentation/UiStateProvider.cpp
+++ b/iModelJsNodeAddon/presentation/UiStateProvider.cpp
@@ -28,7 +28,7 @@ void IModelJsECPresentationUiStateProvider::_OnConnectionEvent(ConnectionEvent c
     auto iter = m_uiState.begin();
     while (iter != m_uiState.end())
         {
-        if (iter->first.first == &evt.GetConnection())
+        if (iter->first.first->GetId() == evt.GetConnection().GetId())
             iter = m_uiState.erase(iter);
         else
             ++iter;
@@ -70,7 +70,7 @@ bvector<RulesetUiState> IModelJsECPresentationUiStateProvider::_GetUiState(IConn
     bvector<RulesetUiState> result;
     for (auto const& entry : m_uiState)
         {
-        if (entry.first.first == &connection)
+        if (entry.first.first->GetId() == connection.GetId())
             result.push_back(RulesetUiState(entry.first.second, std::make_shared<UiState>(*entry.second)));
         }
     return result;

--- a/iModelJsNodeAddon/presentation/UiStateProvider.h
+++ b/iModelJsNodeAddon/presentation/UiStateProvider.h
@@ -9,6 +9,24 @@
 
 BEGIN_BENTLEY_ECPRESENTATION_NAMESPACE
 
+typedef bpair<IConnectionCP, Utf8String> UiStateKey;
+
+/*=================================================================================**//**
+* @bsiclass
++===============+===============+===============+===============+===============+======*/
+struct UiStateKeyComparer
+{
+    bool operator()(UiStateKey const& lhs, UiStateKey const& rhs) const
+        {
+        int connectionIdCmp = lhs.first->GetId().CompareTo(rhs.first->GetId());
+        if (connectionIdCmp < 0)
+            return true;
+        if (connectionIdCmp > 0)
+            return false;
+        return lhs.second < rhs.second;
+        }
+};
+
 /*=================================================================================**//**
 * @bsiclass
 +===============+===============+===============+===============+===============+======*/
@@ -17,7 +35,7 @@ struct IModelJsECPresentationUiStateProvider : IUiStateProvider, IConnectionsLis
 private:
     mutable BeMutex m_mutex;
     ECPresentationManager const* m_manager;
-    bmap<bpair<IConnectionCP, Utf8String>, std::unique_ptr<UiState>> m_uiState;
+    bmap<UiStateKey, std::unique_ptr<UiState>, UiStateKeyComparer> m_uiState;
 
 private:
     UiState& GetUiState(IConnectionCR, Utf8StringCR);


### PR DESCRIPTION
Fixed some problems that caused hierarchy update to stop working:
- Changed UIState lookup to use Connection Id
- Fixed ECPresentationSerializer to correctly parse strings
- Reintroduced parent node lookup logic during update that was removed with changes adding hierarchy filtering.