### PR TITLE
Treat numeric INF/NAN as NULL in IModels

### DIFF
--- a/iModelCore/ECDb/ECDb/ECSql/ArrayECSqlBinder.h
+++ b/iModelCore/ECDb/ECDb/ECSql/ArrayECSqlBinder.h
@@ -27,12 +27,12 @@ private:
             std::map<ECN::ECPropertyId, JsonValueBinder> m_structMemberBinders;
             //only relevant if binder is an array binder
             std::unique_ptr<JsonValueBinder> m_currentArrayElementBinder;
-            
+
             //only relevant if binder is a struct binder
             IECSqlBinder& CreateStructMemberBinder(ECN::ECPropertyCR);
             //only relevant if binder is an array binder
             IECSqlBinder& MoveCurrentArrayElementBinder(ECDbCR, ECSqlTypeInfo const& arrayTypeInfo);
-            
+
             ECSqlStatus FailIfTypeMismatch(ECN::PrimitiveType boundType) const;
             ECSqlStatus FailIfInvalid() const;
 

--- a/iModelCore/ECDb/ECDb/ECSql/PrimitiveECSqlBinder.cpp
+++ b/iModelCore/ECDb/ECDb/ECSql/PrimitiveECSqlBinder.cpp
@@ -82,6 +82,9 @@ ECSqlStatus PrimitiveECSqlBinder::_BindDateTime(uint64_t julianDayMsec, DateTime
 //---------------------------------------------------------------------------------------
 ECSqlStatus PrimitiveECSqlBinder::_BindDateTime(double julianDay, DateTime::Info const& metadata)
     {
+    if (std::isnan(julianDay) || std::isinf(julianDay))
+        return _BindNull();
+
     const ECSqlStatus stat = CanBind(PRIMITIVETYPE_DateTime);
     if (!stat.IsSuccess())
         return stat;
@@ -112,6 +115,9 @@ ECSqlStatus PrimitiveECSqlBinder::_BindDateTime(double julianDay, DateTime::Info
 //---------------------------------------------------------------------------------------
 ECSqlStatus PrimitiveECSqlBinder::_BindDouble(double value)
     {
+    if (std::isnan(value) || std::isinf(value))
+        return _BindNull();
+
     const ECSqlStatus stat = CanBind(PRIMITIVETYPE_Double);
     if (!stat.IsSuccess())
         return stat;

--- a/iModelCore/ECDb/Tests/NonPublished/InstanceReaderTest.cpp
+++ b/iModelCore/ECDb/Tests/NonPublished/InstanceReaderTest.cpp
@@ -282,6 +282,28 @@ TEST_F(InstanceReaderFixture, ecsql_read_property) {
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //+---------------+---------------+---------------+---------------+---------------+------
+TEST_F(InstanceReaderFixture, rapid_json_patch_to_render_inf_and_nan_as_null_instead_of_failing) {
+        // Test for bentley specific change \src\imodel-native\iModelCore\libsrc\rapidjson\vendor\include\rapidjson\writer.h#551
+        // Patch to RapidJson write null instead of failing
+       BeJsDocument docNan;
+       docNan.toObject();
+       docNan["a"] = 0.1;
+       docNan["c"] = std::numeric_limits<double>::quiet_NaN();
+       docNan["e"] = 4.4;
+       ASSERT_STRCASEEQ("{\"a\":0.1,\"c\":null,\"e\":4.4}", docNan.Stringify().c_str());
+
+
+       BeJsDocument docInf;
+       docInf.toObject();
+       docInf["a"] = 0.1;
+       docInf["c"] = std::numeric_limits<double>::infinity();
+       docInf["e"] = 4.4;
+       ASSERT_STRCASEEQ("{\"a\":0.1,\"c\":null,\"e\":4.4}", docInf.Stringify().c_str());
+}
+
+//---------------------------------------------------------------------------------------
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+------
 TEST_F(InstanceReaderFixture, instance_reader) {
     ASSERT_EQ(BE_SQLITE_OK, SetupECDb("instanceReader.ecdb"));
 

--- a/iModelCore/libsrc/rapidjson/vendor/include/rapidjson/writer.h
+++ b/iModelCore/libsrc/rapidjson/vendor/include/rapidjson/writer.h
@@ -1,5 +1,5 @@
 // Tencent is pleased to support the open source community by making RapidJSON available.
-// 
+//
 // Copyright (C) 2015 THL A29 Limited, a Tencent company, and Milo Yip.
 //
 // Licensed under the MIT License (the "License"); you may not use this file except
@@ -7,9 +7,9 @@
 //
 // http://opensource.org/licenses/MIT
 //
-// Unless required by applicable law or agreed to in writing, software distributed 
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
 #ifndef RAPIDJSON_WRITER_H_
@@ -52,7 +52,7 @@ RAPIDJSON_NAMESPACE_BEGIN
 ///////////////////////////////////////////////////////////////////////////////
 // WriteFlag
 
-/*! \def RAPIDJSON_WRITE_DEFAULT_FLAGS 
+/*! \def RAPIDJSON_WRITE_DEFAULT_FLAGS
     \ingroup RAPIDJSON_CONFIG
     \brief User-defined kWriteDefaultFlags definition.
 
@@ -76,7 +76,7 @@ enum WriteFlag {
 
     User may programmatically calls the functions of a writer to generate JSON text.
 
-    On the other side, a writer can also be passed to objects that generates events, 
+    On the other side, a writer can also be passed to objects that generates events,
 
     for example Reader::Parse() and Document::Accept().
 
@@ -99,7 +99,7 @@ public:
         \param levelDepth Initial capacity of stack.
     */
     explicit
-    Writer(OutputStream& os, StackAllocator* stackAllocator = 0, size_t levelDepth = kDefaultLevelDepth) : 
+    Writer(OutputStream& os, StackAllocator* stackAllocator = 0, size_t levelDepth = kDefaultLevelDepth) :
         os_(&os), level_stack_(stackAllocator, levelDepth * sizeof(Level)), maxDecimalPlaces_(kDefaultMaxDecimalPlaces), hasRoot_(false) {}
 
     explicit
@@ -153,7 +153,7 @@ public:
     /*!
         This setting truncates the output with specified number of decimal places.
 
-        For example, 
+        For example,
 
         \code
         writer.SetMaxDecimalPlaces(3);
@@ -258,7 +258,7 @@ public:
     //! Simpler but slower overload.
     bool String(const Ch* const& str) { return String(str, internal::StrLen(str)); }
     bool Key(const Ch* const& str) { return Key(str, internal::StrLen(str)); }
-    
+
     //@}
 
     //! Write a raw JSON value.
@@ -425,7 +425,7 @@ protected:
                     PutUnsafe(*os_, hexDigits[(trail >> 12) & 15]);
                     PutUnsafe(*os_, hexDigits[(trail >>  8) & 15]);
                     PutUnsafe(*os_, hexDigits[(trail >>  4) & 15]);
-                    PutUnsafe(*os_, hexDigits[(trail      ) & 15]);                    
+                    PutUnsafe(*os_, hexDigits[(trail      ) & 15]);
                 }
             }
             else if ((sizeof(Ch) == 1 || static_cast<unsigned>(c) < 256) && RAPIDJSON_UNLIKELY(escape[static_cast<unsigned char>(c)]))  {
@@ -439,7 +439,7 @@ protected:
                     PutUnsafe(*os_, hexDigits[static_cast<unsigned char>(c) & 0xF]);
                 }
             }
-            else if (RAPIDJSON_UNLIKELY(!(writeFlags & kWriteValidateEncodingFlag ? 
+            else if (RAPIDJSON_UNLIKELY(!(writeFlags & kWriteValidateEncodingFlag ?
                 Transcoder<SourceEncoding, TargetEncoding>::Validate(is, *os_) :
                 Transcoder<SourceEncoding, TargetEncoding>::TranscodeUnsafe(is, *os_))))
                 return false;
@@ -462,7 +462,7 @@ protected:
         GenericStringStream<SourceEncoding> is(json);
         while (RAPIDJSON_LIKELY(is.Tell() < length)) {
             RAPIDJSON_ASSERT(is.Peek() != '\0');
-            if (RAPIDJSON_UNLIKELY(!(writeFlags & kWriteValidateEncodingFlag ? 
+            if (RAPIDJSON_UNLIKELY(!(writeFlags & kWriteValidateEncodingFlag ?
                 Transcoder<SourceEncoding, TargetEncoding>::Validate(is, *os_) :
                 Transcoder<SourceEncoding, TargetEncoding>::TranscodeUnsafe(is, *os_))))
                 return false;
@@ -475,7 +475,7 @@ protected:
         if (RAPIDJSON_LIKELY(level_stack_.GetSize() != 0)) { // this value is not at root
             Level* level = level_stack_.template Top<Level>();
             if (level->valueCount > 0) {
-                if (level->inArray) 
+                if (level->inArray)
                     os_->Put(','); // add comma if it is not the first element in array
                 else  // in object
                     os_->Put((level->valueCount % 2 == 0) ? ',' : ':');
@@ -547,7 +547,9 @@ inline bool Writer<StringBuffer>::WriteDouble(double d) {
     if (internal::Double(d).IsNanOrInf()) {
         // Note: This code path can only be reached if (RAPIDJSON_WRITE_DEFAULT_FLAGS & kWriteNanAndInfFlag).
         if (!(kWriteDefaultFlags & kWriteNanAndInfFlag))
-            return false;
+// BENTLEY_CHANGES <<<<
+            return WriteNull();
+// BENTLEY_CHANGES >>>>
         if (internal::Double(d).IsNan()) {
             PutReserve(*os_, 3);
             PutUnsafe(*os_, 'N'); PutUnsafe(*os_, 'a'); PutUnsafe(*os_, 'N');
@@ -563,7 +565,7 @@ inline bool Writer<StringBuffer>::WriteDouble(double d) {
         PutUnsafe(*os_, 'i'); PutUnsafe(*os_, 'n'); PutUnsafe(*os_, 'i'); PutUnsafe(*os_, 't'); PutUnsafe(*os_, 'y');
         return true;
     }
-    
+
     char *buffer = os_->Push(25);
     char* end = internal::dtoa(d, buffer, maxDecimalPlaces_);
     os_->Pop(static_cast<size_t>(25 - (end - buffer)));


### PR DESCRIPTION
* ECSQL statement will treat inf/nan as NULL when binding to prevent them from entering an IModel
* For existing cases of INF as a property value we patch RapidJson to render INF/NAN as NULL when generating JSON string.

