### PR TITLE
Fixed evolution tests to run with newer files

### DIFF
--- a/iModelCore/iModelPlatform/Tests/DgnProject/Compatibility/CompatibilityRunner/PullNugets.py
+++ b/iModelCore/iModelPlatform/Tests/DgnProject/Compatibility/CompatibilityRunner/PullNugets.py
@@ -142,7 +142,7 @@ def main():
     imodel02MinimumNugetVersion = "2019.2.2.1"
     imodel02IgnoreNugetVersions = {"2019.4.20.1"}
 
-    # Profile version upgrade 2.0.0.6_4.0.0.4_3.1.0.2
+    # Profile version upgrade 2.0.0.5_4.0.0.3_3.1.0.2
     imodelNativeMinimumNugetVersion = "2023.3.23.1"
     imodelNativeIgnoreNugetVersions = {"2023.1.23.4", "2023.2.1.2", "2023.3.7.4"}
 

--- a/iModelCore/iModelPlatform/Tests/DgnProject/Compatibility/CompatibilityRunner/PullNugets.py
+++ b/iModelCore/iModelPlatform/Tests/DgnProject/Compatibility/CompatibilityRunner/PullNugets.py
@@ -142,9 +142,9 @@ def main():
     imodel02MinimumNugetVersion = "2019.2.2.1"
     imodel02IgnoreNugetVersions = {"2019.4.20.1"}
 
-    # Profile version upgrade 2.0.0.5_4.0.0.3_3.1.0.2
-    imodelNativeMinimumNugetVersion = "2023.3.7.4"
-    imodelNativeIgnoreNugetVersions = {"2023.1.23.4", "2023.2.1.2"}
+    # Profile version upgrade 2.0.0.6_4.0.0.4_3.1.0.2
+    imodelNativeMinimumNugetVersion = "2023.3.23.1"
+    imodelNativeIgnoreNugetVersions = {"2023.1.23.4", "2023.2.1.2", "2023.3.7.4"}
 
     # The current EC3.3 tests won't work because they need to have the latest version of the CoreCA schema.
     # ec33MinimumNugetVersion = "2019.4.1.1"

--- a/iModelCore/iModelPlatform/Tests/DgnProject/Compatibility/ECDbCompatibilityTests.cpp
+++ b/iModelCore/iModelPlatform/Tests/DgnProject/Compatibility/ECDbCompatibilityTests.cpp
@@ -958,7 +958,7 @@ TEST_F(ECDbCompatibilityTestFixture, EC31SchemaImport)
             ASSERT_TRUE(deserializationCtx != nullptr) << testDb.GetDescription();
             const BentleyStatus schemaImportStat = testDb.GetDb().Schemas().ImportSchemas(deserializationCtx->GetCache().GetSchemas());
 
-            if (ProfileState::Age::Newer == testDb.GetAge())
+            if (ProfileState::Age::Newer == testDb.GetAge() && !testDb.DoesECDbVersionAllowSchemaImport())
                 {
                 EXPECT_EQ(ERROR, schemaImportStat) << testDb.GetDescription();
                 continue;
@@ -1073,7 +1073,7 @@ TEST_F(ECDbCompatibilityTestFixture, EC31SchemaImportWithEC32Reference)
             ASSERT_TRUE(deserializationCtx != nullptr) << testDb.GetDescription();
             const BentleyStatus schemaImportStat = testDb.GetDb().Schemas().ImportSchemas(deserializationCtx->GetCache().GetSchemas());
 
-            if (ProfileState::Age::Newer == testDb.GetAge() || !testDb.SupportsFeature(ECDbFeature::EC32))
+            if ((ProfileState::Age::Newer == testDb.GetAge() && !testDb.DoesECDbVersionAllowSchemaImport()) || !testDb.SupportsFeature(ECDbFeature::EC32))
                 {
                 EXPECT_EQ(ERROR, schemaImportStat) << testDb.GetDescription();
                 continue;
@@ -1223,7 +1223,7 @@ TEST_F(ECDbCompatibilityTestFixture, EC31SchemaImportWithReadContextVariations)
                     FAIL() << "*ERROR* case not handled | " << testDb.GetDescription();
                 break;
             case ProfileState::Age::Newer:
-                EXPECT_EQ(ERROR, schemaImportStat) << scenario << " | " << testDb.GetDescription();
+                EXPECT_EQ(testDb.DoesECDbVersionAllowSchemaImport() ? SUCCESS : ERROR, schemaImportStat) << scenario << " | " << testDb.GetDescription();
                 break;
             default:
                 FAIL() << "Unhandled ProfileState::Age enum value | " << testDb.GetDescription();
@@ -1303,7 +1303,7 @@ TEST_F(ECDbCompatibilityTestFixture, EC32SchemaImport_Enums)
             ASSERT_TRUE(deserializationCtx != nullptr) << testDb.GetDescription();
             const BentleyStatus schemaImportStat = testDb.GetDb().Schemas().ImportSchemas(deserializationCtx->GetCache().GetSchemas());
 
-            if (ProfileState::Age::Newer == testDb.GetAge() || !testDb.SupportsFeature(ECDbFeature::NamedEnumerators))
+            if ((ProfileState::Age::Newer == testDb.GetAge() && !testDb.DoesECDbVersionAllowSchemaImport()) || !testDb.SupportsFeature(ECDbFeature::NamedEnumerators))
                 {
                 EXPECT_EQ(ERROR, schemaImportStat) << testDb.GetDescription();
                 continue;
@@ -1370,7 +1370,7 @@ TEST_F(ECDbCompatibilityTestFixture, EC32SchemaImport_Koqs)
             ASSERT_TRUE(deserializationCtx != nullptr) << testDb.GetDescription();
             const BentleyStatus schemaImportStat = testDb.GetDb().Schemas().ImportSchemas(deserializationCtx->GetCache().GetSchemas());
 
-            if (ProfileState::Age::Newer == testDb.GetAge() || !testDb.SupportsFeature(ECDbFeature::UnitsAndFormats))
+            if ((ProfileState::Age::Newer == testDb.GetAge() && !testDb.DoesECDbVersionAllowSchemaImport()) || !testDb.SupportsFeature(ECDbFeature::UnitsAndFormats))
                 {
                 EXPECT_EQ(ERROR, schemaImportStat) << testDb.GetDescription();
                 continue;
@@ -1462,7 +1462,7 @@ TEST_F(ECDbCompatibilityTestFixture, EC31SchemaUpgrade_Formats_API)
 
             ASSERT_TRUE(deserializationCtx != nullptr) << testDb.GetDescription();
             BentleyStatus schemaImportStat = testDb.GetDb().Schemas().ImportSchemas(deserializationCtx->GetCache().GetSchemas());
-            if (testDb.GetAge() == ProfileState::Age::Newer)
+            if (testDb.GetAge() == ProfileState::Age::Newer && !testDb.DoesECDbVersionAllowSchemaImport())
                 {
                 EXPECT_EQ(ERROR, schemaImportStat) << testDb.GetDescription();
                 continue;
@@ -1569,7 +1569,7 @@ TEST_F(ECDbCompatibilityTestFixture, EC31Enums_SchemaUpgrade)
             ASSERT_TRUE(deserializationCtx != nullptr) << testDb.GetDescription();
             const BentleyStatus schemaImportStat = testDb.GetDb().Schemas().ImportSchemas(deserializationCtx->GetCache().GetSchemas());
 
-            if (ProfileState::Age::Newer == testDb.GetAge())
+            if (ProfileState::Age::Newer == testDb.GetAge() && !testDb.DoesECDbVersionAllowSchemaImport())
                 {
                 EXPECT_EQ(ERROR, schemaImportStat) << testDb.GetDescription();
                 continue;
@@ -1702,7 +1702,7 @@ TEST_F(ECDbCompatibilityTestFixture, EC31Koqs_SchemaUpgrade)
             ASSERT_TRUE(deserializationCtx != nullptr) << testDb.GetDescription();
             const BentleyStatus schemaImportStat = testDb.GetDb().Schemas().ImportSchemas(deserializationCtx->GetCache().GetSchemas());
 
-            if (ProfileState::Age::Newer == testDb.GetAge())
+            if (ProfileState::Age::Newer == testDb.GetAge() && !testDb.DoesECDbVersionAllowSchemaImport())
                 {
                 EXPECT_EQ(ERROR, schemaImportStat) << testDb.GetDescription();
                 continue;
@@ -1841,7 +1841,7 @@ TEST_F(ECDbCompatibilityTestFixture, EC31ToEC32SchemaUpgrade_Enums)
             ASSERT_TRUE(deserializationCtx != nullptr) << testDb.GetDescription();
             const BentleyStatus schemaImportStat = testDb.GetDb().Schemas().ImportSchemas(deserializationCtx->GetCache().GetSchemas());
 
-            if (ProfileState::Age::Newer == testDb.GetAge() || !testDb.SupportsFeature(ECDbFeature::NamedEnumerators))
+            if ((ProfileState::Age::Newer == testDb.GetAge() && !testDb.DoesECDbVersionAllowSchemaImport()) || !testDb.SupportsFeature(ECDbFeature::NamedEnumerators))
                 {
                 EXPECT_EQ(ERROR, schemaImportStat) << testDb.GetDescription();
                 continue;
@@ -1974,7 +1974,7 @@ TEST_F(ECDbCompatibilityTestFixture, EC31ToEC32SchemaUpgrade_Koqs)
             ASSERT_TRUE(deserializationCtx != nullptr) << testDb.GetDescription();
             const BentleyStatus schemaImportStat = testDb.GetDb().Schemas().ImportSchemas(deserializationCtx->GetCache().GetSchemas());
 
-            if (ProfileState::Age::Newer == testDb.GetAge() || !testDb.SupportsFeature(ECDbFeature::UnitsAndFormats))
+            if ((ProfileState::Age::Newer == testDb.GetAge() && !testDb.DoesECDbVersionAllowSchemaImport()) || !testDb.SupportsFeature(ECDbFeature::UnitsAndFormats))
                 {
                 EXPECT_EQ(ERROR, schemaImportStat) << testDb.GetDescription();
                 continue;
@@ -2098,7 +2098,7 @@ TEST_F(ECDbCompatibilityTestFixture, EC32SchemaUpgrade_Enums)
             ASSERT_TRUE(deserializationCtx != nullptr) << testDb.GetDescription();
             const BentleyStatus schemaImportStat = testDb.GetDb().Schemas().ImportSchemas(deserializationCtx->GetCache().GetSchemas());
 
-            if (ProfileState::Age::Newer == testDb.GetAge() || !testDb.SupportsFeature(ECDbFeature::NamedEnumerators))
+            if ((ProfileState::Age::Newer == testDb.GetAge() && !testDb.DoesECDbVersionAllowSchemaImport()) || !testDb.SupportsFeature(ECDbFeature::NamedEnumerators))
                 {
                 EXPECT_EQ(ERROR, schemaImportStat) << testDb.GetDescription();
                 continue;
@@ -2230,7 +2230,7 @@ TEST_F(ECDbCompatibilityTestFixture, EC32SchemaUpgrade_Koqs)
             ASSERT_TRUE(deserializationCtx != nullptr) << testDb.GetDescription();
             const BentleyStatus schemaImportStat = testDb.GetDb().Schemas().ImportSchemas(deserializationCtx->GetCache().GetSchemas());
 
-            if (ProfileState::Age::Newer == testDb.GetAge() || !testDb.SupportsFeature(ECDbFeature::UnitsAndFormats))
+            if ((ProfileState::Age::Newer == testDb.GetAge() && !testDb.DoesECDbVersionAllowSchemaImport()) || !testDb.SupportsFeature(ECDbFeature::UnitsAndFormats))
                 {
                 EXPECT_EQ(ERROR, schemaImportStat) << testDb.GetDescription();
                 continue;

--- a/iModelCore/iModelPlatform/Tests/DgnProject/Compatibility/IModelCompatibilityTests.cpp
+++ b/iModelCore/iModelPlatform/Tests/DgnProject/Compatibility/IModelCompatibilityTests.cpp
@@ -1043,7 +1043,7 @@ TEST_F(IModelCompatibilityTestFixture, EC31SchemaImport)
             ASSERT_TRUE(deserializationCtx != nullptr) << testDb.GetDescription();
             const SchemaStatus schemaImportStat = testDb.GetDgnDb().ImportSchemas(deserializationCtx->GetCache().GetSchemas());
 
-            if (ProfileState::Age::Newer == testDb.GetECDbAge())
+            if (ProfileState::Age::Newer == testDb.GetECDbAge() && !testDb.DoesECDbVersionAllowSchemaImport())
                 {
                 EXPECT_EQ(SchemaStatus::SchemaImportFailed, schemaImportStat) << testDb.GetDescription();
                 continue;
@@ -1134,7 +1134,7 @@ TEST_F(IModelCompatibilityTestFixture, EC32SchemaImport_Enums)
             ASSERT_TRUE(deserializationCtx != nullptr) << testDb.GetDescription();
             const SchemaStatus schemaImportStat = testDb.GetDgnDb().ImportSchemas(deserializationCtx->GetCache().GetSchemas());
 
-            if (ProfileState::Age::Newer == testDb.GetECDbAge() || !testDb.SupportsFeature(ECDbFeature::NamedEnumerators))
+            if ((ProfileState::Age::Newer == testDb.GetECDbAge() && !testDb.DoesECDbVersionAllowSchemaImport()) || !testDb.SupportsFeature(ECDbFeature::NamedEnumerators))
                 {
                 EXPECT_EQ(SchemaStatus::SchemaImportFailed, schemaImportStat) << testDb.GetDescription();
                 continue;
@@ -1197,7 +1197,7 @@ TEST_F(IModelCompatibilityTestFixture, EC32SchemaImport_Koqs)
             ASSERT_TRUE(deserializationCtx != nullptr) << testDb.GetDescription();
             const SchemaStatus schemaImportStat = testDb.GetDgnDb().ImportSchemas(deserializationCtx->GetCache().GetSchemas());
 
-            if (ProfileState::Age::Newer == testDb.GetECDbAge() || !testDb.SupportsFeature(ECDbFeature::UnitsAndFormats))
+            if ((ProfileState::Age::Newer == testDb.GetECDbAge() && !testDb.DoesECDbVersionAllowSchemaImport()) || !testDb.SupportsFeature(ECDbFeature::UnitsAndFormats))
                 {
                 EXPECT_EQ(SchemaStatus::SchemaImportFailed, schemaImportStat) << testDb.GetDescription();
                 continue;
@@ -1284,7 +1284,7 @@ TEST_F(IModelCompatibilityTestFixture, EC31SchemaUpgrade_Formats_API)
 
             ASSERT_TRUE(deserializationCtx != nullptr) << testDb.GetDescription();
             SchemaStatus schemaImportStat = testDb.GetDgnDb().ImportSchemas(deserializationCtx->GetCache().GetSchemas());
-            if (testDb.GetECDbAge() == ProfileState::Age::Newer)
+            if (testDb.GetECDbAge() == ProfileState::Age::Newer && !testDb.DoesECDbVersionAllowSchemaImport())
                 {
                 EXPECT_EQ(SchemaStatus::SchemaImportFailed, schemaImportStat) << testDb.GetDescription();
                 continue;
@@ -1366,7 +1366,7 @@ TEST_F(IModelCompatibilityTestFixture, EC31Enum_SchemaUpgrade)
             ASSERT_TRUE(deserializationCtx != nullptr) << testDb.GetDescription();
             const SchemaStatus schemaImportStat = testDb.GetDgnDb().ImportSchemas(deserializationCtx->GetCache().GetSchemas());
 
-            if (ProfileState::Age::Newer == testDb.GetECDbAge())
+            if (ProfileState::Age::Newer == testDb.GetECDbAge() && !testDb.DoesECDbVersionAllowSchemaImport())
                 {
                 EXPECT_EQ(SchemaStatus::SchemaImportFailed, schemaImportStat) << testDb.GetDescription();
                 continue;
@@ -1455,7 +1455,7 @@ TEST_F(IModelCompatibilityTestFixture, EC31Koqs_SchemaUpgrade)
             ASSERT_TRUE(deserializationCtx != nullptr) << testDb.GetDescription();
             const SchemaStatus schemaImportStat = testDb.GetDgnDb().ImportSchemas(deserializationCtx->GetCache().GetSchemas());
 
-            if (ProfileState::Age::Newer == testDb.GetECDbAge())
+            if (ProfileState::Age::Newer == testDb.GetECDbAge() && !testDb.DoesECDbVersionAllowSchemaImport())
                 {
                 EXPECT_EQ(SchemaStatus::SchemaImportFailed, schemaImportStat) << testDb.GetDescription();
                 continue;
@@ -1548,7 +1548,7 @@ TEST_F(IModelCompatibilityTestFixture, EC31ToEC32SchemaUpgrade_Enums)
             ASSERT_TRUE(deserializationCtx != nullptr) << testDb.GetDescription();
             const SchemaStatus schemaImportStat = testDb.GetDgnDb().ImportSchemas(deserializationCtx->GetCache().GetSchemas());
 
-            if (ProfileState::Age::Newer == testDb.GetECDbAge() || !testDb.SupportsFeature(ECDbFeature::NamedEnumerators))
+            if ((ProfileState::Age::Newer == testDb.GetECDbAge() && !testDb.DoesECDbVersionAllowSchemaImport()) || !testDb.SupportsFeature(ECDbFeature::NamedEnumerators))
                 {
                 EXPECT_EQ(SchemaStatus::SchemaImportFailed, schemaImportStat) << testDb.GetDescription();
                 continue;
@@ -1636,7 +1636,7 @@ TEST_F(IModelCompatibilityTestFixture, EC31ToEC32SchemaUpgrade_Koqs)
             const SchemaStatus schemaImportStat = testDb.GetDgnDb().ImportSchemas(deserializationCtx->GetCache().GetSchemas());
 
             // If the ECDb version is newer or 
-            if (ProfileState::Age::Newer == testDb.GetECDbAge() || !testDb.SupportsFeature(ECDbFeature::UnitsAndFormats))
+            if ((ProfileState::Age::Newer == testDb.GetECDbAge() && !testDb.DoesECDbVersionAllowSchemaImport()) || !testDb.SupportsFeature(ECDbFeature::UnitsAndFormats))
                 {
                 EXPECT_EQ(SchemaStatus::SchemaImportFailed, schemaImportStat) << testDb.GetDescription();
                 continue;
@@ -1713,7 +1713,7 @@ TEST_F(IModelCompatibilityTestFixture, EC32SchemaUpgrade_Enums)
             ASSERT_TRUE(deserializationCtx != nullptr) << testDb.GetDescription();
             const SchemaStatus schemaImportStat = testDb.GetDgnDb().ImportSchemas(deserializationCtx->GetCache().GetSchemas());
 
-            if (ProfileState::Age::Newer == testDb.GetECDbAge() || !testDb.SupportsFeature(ECDbFeature::NamedEnumerators))
+            if ((ProfileState::Age::Newer == testDb.GetECDbAge() && !testDb.DoesECDbVersionAllowSchemaImport()) || !testDb.SupportsFeature(ECDbFeature::NamedEnumerators))
                 {
                 EXPECT_EQ(SchemaStatus::SchemaImportFailed, schemaImportStat) << testDb.GetDescription();
                 continue;
@@ -1799,7 +1799,7 @@ TEST_F(IModelCompatibilityTestFixture, EC32SchemaUpgrade_Koqs)
             ASSERT_TRUE(deserializationCtx != nullptr) << testDb.GetDescription();
             const SchemaStatus schemaImportStat = testDb.GetDgnDb().ImportSchemas(deserializationCtx->GetCache().GetSchemas());
 
-            if (ProfileState::Age::Newer == testDb.GetECDbAge() || !testDb.SupportsFeature(ECDbFeature::UnitsAndFormats))
+            if ((ProfileState::Age::Newer == testDb.GetECDbAge() && !testDb.DoesECDbVersionAllowSchemaImport()) || !testDb.SupportsFeature(ECDbFeature::UnitsAndFormats))
                 {
                 EXPECT_EQ(SchemaStatus::SchemaImportFailed, schemaImportStat) << testDb.GetDescription();
                 continue;
@@ -1849,7 +1849,7 @@ TEST_F(IModelCompatibilityTestFixture, AddDomain)
                 continue;
                 }
 
-            if (testFile.GetECDbAge() == ProfileState::Age::Newer)
+            if (testFile.GetECDbAge() == ProfileState::Age::Newer && !testDb.DoesECDbVersionAllowSchemaImport())
                 {
                 // schema import not possible to newer ECDb profile files
                 ASSERT_EQ(BE_SQLITE_ERROR_SchemaUpgradeFailed, openStat) << testDb.GetDescription();
@@ -1934,7 +1934,7 @@ TEST_F(IModelCompatibilityTestFixture, UpgradeDomainIModel)
                 continue;
                 }
 
-            if (testFile.GetECDbAge() == ProfileState::Age::Newer)
+            if (testFile.GetECDbAge() == ProfileState::Age::Newer && !testDb.DoesECDbVersionAllowSchemaImport())
                 {
                 // schema import not possible to newer ECDb profile files
                 ASSERT_EQ(BE_SQLITE_ERROR_SchemaUpgradeFailed, openStat) << testDb.GetDescription();

--- a/iModelCore/iModelPlatform/Tests/DgnProject/Compatibility/TestDb.cpp
+++ b/iModelCore/iModelPlatform/Tests/DgnProject/Compatibility/TestDb.cpp
@@ -858,6 +858,13 @@ BeSQLite::ProfileState::Age TestDb::GetECDbAge() const
     return comp > 0 ? ProfileState::Age::Newer : ProfileState::Age::Older;
     }
 
+bool TestDb::DoesECDbVersionAllowSchemaImport() const
+    {
+    if (const auto comparisonValue = GetDb().GetECDbProfileVersion().CompareTo(ECDb::CurrentECDbProfileVersion(), ProfileVersion::VERSION_MajorMinorSub1); comparisonValue > 0)
+        return false;
+    return true;
+    }
+
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //+---------------+---------------+---------------+---------------+---------------+------

--- a/iModelCore/iModelPlatform/Tests/DgnProject/Compatibility/TestDb.h
+++ b/iModelCore/iModelPlatform/Tests/DgnProject/Compatibility/TestDb.h
@@ -58,6 +58,7 @@ protected:
     ECDbR GetDb() const { return _GetDb(); }
     ECDb::OpenParams const& GetOpenParams() const { return _GetOpenParams(); }
     Utf8String GetDescription() const;
+    bool DoesECDbVersionAllowSchemaImport() const;
 
     bool SupportsFeature(ECDbFeature feature) const { return VersionSupportsFeature(GetDb().GetECDbProfileVersion(), feature); }
     static bool VersionSupportsFeature(ProfileVersion const&, ECDbFeature);


### PR DESCRIPTION
The imodel evolution tests had a check where they didn't allow schema imports into newer files irrespective of the profile version.

However, a change was made in 2020, where we now allow schema to be imported into newer files if the profile version only differs by the final sub2 component.
This caused the evolution tests to fail when run against newer files.

This PR has modified the tests to handle the version sub2 condition.
Also, change has been done to use a new test runner nuget, since the latest published one has the sub2 check and will start failing with the next profile upgrade.