### PR TITLE
Consume New Test Runner and Files

### DIFF
--- a/iModelCore/iModelPlatform/Tests/DgnProject/Compatibility/CompatibilityRunner/PullNugets.py
+++ b/iModelCore/iModelPlatform/Tests/DgnProject/Compatibility/CompatibilityRunner/PullNugets.py
@@ -143,7 +143,7 @@ def main():
     imodel02IgnoreNugetVersions = {"2019.4.20.1"}
 
     # Profile version upgrade 2.0.0.5_4.0.0.3_3.1.0.2
-    #imodelNativeMinimumNugetVersion = "2023.3.23.1"
+    imodelNativeMinimumNugetVersion = "2023.3.28.3"
     imodelNativeIgnoreNugetVersions = {"2023.1.23.4", "2023.2.1.2", "2023.3.7.4"}
 
     # The current EC3.3 tests won't work because they need to have the latest version of the CoreCA schema.
@@ -155,7 +155,7 @@ def main():
     pullAllNugets(nugetPathInSrc, nugetScript, "iModelEvolutionTestRunnerNuget_bim0200dev_x64", bim02devMinimumNugetVersion, bim02devIgnoreNugetVersions)
     pullAllNugets(nugetPathInSrc, nugetScript, "iModelEvolutionTestRunnerNuget_bim0200_x64", bim02MinimumNugetVersion, bim02IgnoreNugetVersions)
     pullAllNugets(nugetPathInSrc, nugetScript, "iModelEvolutionTestRunnerNuget_imodel02_x64", imodel02MinimumNugetVersion, imodel02IgnoreNugetVersions)
-    #pullAllNugets(nugetPathInSrc, nugetScript, "iModelEvolutionTestRunnerNuget_imodelNative_x64", imodelNativeMinimumNugetVersion, imodelNativeIgnoreNugetVersions)
+    pullAllNugets(nugetPathInSrc, nugetScript, "iModelEvolutionTestRunnerNuget_imodelNative_x64", imodelNativeMinimumNugetVersion, imodelNativeIgnoreNugetVersions)
     # pullAllNugets(nugetPathInSrc, nugetScript, "iModelEvolutionTestRunnerNuget_ec33_x64", ec33MinimumNugetVersion, ec33IgnoreNugetVersions)
     unzipNugets(nugetPathInSrc)
     # Test files can be downloaded in out folder directly
@@ -163,7 +163,7 @@ def main():
     pullAllNugets(testFileNugetPath, nugetScript, "iModelEvolutionTestFilesNuget_bim0200dev_x64", bim02devMinimumNugetVersion, bim02devIgnoreNugetVersions)
     pullAllNugets(testFileNugetPath, nugetScript, "iModelEvolutionTestFilesNuget_bim0200_x64", bim02MinimumNugetVersion, bim02IgnoreNugetVersions)
     pullAllNugets(testFileNugetPath, nugetScript, "iModelEvolutionTestFilesNuget_imodel02_x64", imodel02MinimumNugetVersion, imodel02IgnoreNugetVersions)
-    #pullAllNugets(testFileNugetPath, nugetScript, "iModelEvolutionTestFilesNuget_imodelNative_x64", imodelNativeMinimumNugetVersion, imodelNativeIgnoreNugetVersions)
+    pullAllNugets(testFileNugetPath, nugetScript, "iModelEvolutionTestFilesNuget_imodelNative_x64", imodelNativeMinimumNugetVersion, imodelNativeIgnoreNugetVersions)
     # pullAllNugets(testFileNugetPath, nugetScript, "iModelEvolutionTestFilesNuget_ec33_x64", ec33MinimumNugetVersion, ec33IgnoreNugetVersions)
     unzipNugets(testFileNugetPath)
     # Copy test files from all nugets into a single central folder


### PR DESCRIPTION
The new test runner contains the fix for the conflicting change pushed in the tests setup with last profile upgrade. For more details see PR: https://github.com/iTwin/imodel-native/commit/75b43e072dbfc928a2fdee0d644c61bf18b66090
