### PR TITLE
Presentation: Add label to navigation property value

### DIFF
--- a/iModelCore/ECPresentation/PublicAPI/ECPresentation/Content.h
+++ b/iModelCore/ECPresentation/PublicAPI/ECPresentation/Content.h
@@ -1572,6 +1572,26 @@ public:
 };
 
 //=======================================================================================
+//! Holds the value of navigation property
+// @bsiclass
+//=======================================================================================
+struct NavigationPropertyValue
+{
+private:
+    LabelDefinitionCPtr m_label;
+    ECClassInstanceKey m_key;
+
+public:
+    NavigationPropertyValue() : m_label(nullptr) {}
+    NavigationPropertyValue(LabelDefinitionCPtr label, ECClassInstanceKeyCR key) : m_label(label), m_key(key) {}
+    bool IsValid() const {return m_label.IsValid() && m_key.IsValid();}
+    LabelDefinitionCR GetLabel() const {return *m_label;}
+    ECClassInstanceKeyCR GetKey() const {return m_key;}
+    ECPRESENTATION_EXPORT rapidjson::Document AsJson(ECPresentationSerializerContextR ctx, rapidjson::Document::AllocatorType* allocator = nullptr) const;
+    ECPRESENTATION_EXPORT rapidjson::Document AsJson(rapidjson::Document::AllocatorType* allocator = nullptr) const;
+};
+
+//=======================================================================================
 //! @ingroup GROUP_Presentation_Content
 // @bsiclass
 //=======================================================================================

--- a/iModelCore/ECPresentation/PublicAPI/ECPresentation/DefaultECPresentationSerializer.h
+++ b/iModelCore/ECPresentation/PublicAPI/ECPresentation/DefaultECPresentationSerializer.h
@@ -51,6 +51,7 @@ protected:
     ECPRESENTATION_EXPORT virtual rapidjson::Document _AsJson(ContextR, ContentDescriptor const& contentDescriptor, rapidjson::Document::AllocatorType*) const override;
 
     ECPRESENTATION_EXPORT virtual rapidjson::Document _AsJson(ContextR, ContentSetItem const& contentSetItem, int flags, rapidjson::Document::AllocatorType*) const override;
+    ECPRESENTATION_EXPORT virtual rapidjson::Document _AsJson(ContextR, NavigationPropertyValueCR, rapidjson::Document::AllocatorType*) const override;
     ECPRESENTATION_EXPORT virtual rapidjson::Document _AsJson(ContextR, DisplayValueGroupCR, rapidjson::Document::AllocatorType*) const override;
 
     ECPRESENTATION_EXPORT virtual rapidjson::Document _AsJson(ContextR, BeInt64Id const&, rapidjson::Document::AllocatorType*) const override;

--- a/iModelCore/ECPresentation/PublicAPI/ECPresentation/ECPresentationTypes.h
+++ b/iModelCore/ECPresentation/PublicAPI/ECPresentation/ECPresentationTypes.h
@@ -511,7 +511,7 @@ struct ECPresentationSerializerContext
 private:
     ECPresentation::UnitSystem m_unitSystem;
     IECPropertyFormatter const* m_propertyFormatter;
-	IECClassSerializer* m_classSerializer;
+    IECClassSerializer* m_classSerializer;
     bool m_omitDisplayValues;
 public:
     ECPresentationSerializerContext(): m_unitSystem(UnitSystem::Undefined), m_propertyFormatter(nullptr), m_classSerializer(nullptr), m_omitDisplayValues(false){}
@@ -521,8 +521,8 @@ public:
     UnitSystem GetUnitSystem() const {return m_unitSystem;}
     void SetPropertyFormatter(IECPropertyFormatter const* formatter) {m_propertyFormatter = formatter;}
     ECPresentation::IECPropertyFormatter const* GetPropertyFormatter() {return m_propertyFormatter;}
-	void SetClassSerializer(IECClassSerializer* serializer) {m_classSerializer = serializer;}
-	ECPresentation::IECClassSerializer* GetClassSerializer() {return m_classSerializer;}
+    void SetClassSerializer(IECClassSerializer* serializer) {m_classSerializer = serializer;}
+    ECPresentation::IECClassSerializer* GetClassSerializer() {return m_classSerializer;}
     void SetOmitDisplayValues(bool omitDisplayValues) {m_omitDisplayValues = omitDisplayValues;}
     bool ShouldOmitDisplayValues() const {return m_omitDisplayValues;}
 };

--- a/iModelCore/ECPresentation/PublicAPI/ECPresentation/ECPresentationTypes.h
+++ b/iModelCore/ECPresentation/PublicAPI/ECPresentation/ECPresentationTypes.h
@@ -41,6 +41,7 @@ ECPRESENTATION_REFCOUNTED_PTR(ContentDescriptor)
 ECPRESENTATION_TYPEDEFS(IPropertyCategorySupplier)
 ECPRESENTATION_TYPEDEFS(SelectionInfo)
 ECPRESENTATION_REFCOUNTED_PTR(SelectionInfo)
+ECPRESENTATION_TYPEDEFS(NavigationPropertyValue)
 ECPRESENTATION_TYPEDEFS(DisplayValueGroup)
 ECPRESENTATION_REFCOUNTED_PTR(DisplayValueGroup)
 ECPRESENTATION_TYPEDEFS(IContentFieldMatcher)
@@ -511,16 +512,19 @@ private:
     ECPresentation::UnitSystem m_unitSystem;
     IECPropertyFormatter const* m_propertyFormatter;
 	IECClassSerializer* m_classSerializer;
+    bool m_omitDisplayValues;
 public:
-    ECPresentationSerializerContext(): m_unitSystem(UnitSystem::Undefined), m_propertyFormatter(nullptr), m_classSerializer(nullptr) {}
-    ECPresentationSerializerContext(UnitSystem unitSystem, IECPropertyFormatter const* formatter, IECClassSerializer* serializer = nullptr) : m_unitSystem(unitSystem), m_propertyFormatter(formatter), m_classSerializer(serializer) {}
+    ECPresentationSerializerContext(): m_unitSystem(UnitSystem::Undefined), m_propertyFormatter(nullptr), m_classSerializer(nullptr), m_omitDisplayValues(false){}
+    ECPresentationSerializerContext(UnitSystem unitSystem, IECPropertyFormatter const* formatter, IECClassSerializer* serializer = nullptr) : m_unitSystem(unitSystem), m_propertyFormatter(formatter), m_classSerializer(serializer), m_omitDisplayValues(false) {}
 
     void SetUnitSystem(UnitSystem unitSystem) {m_unitSystem = unitSystem;}
     UnitSystem GetUnitSystem() const {return m_unitSystem;}
     void SetPropertyFormatter(IECPropertyFormatter const* formatter) {m_propertyFormatter = formatter;}
     ECPresentation::IECPropertyFormatter const* GetPropertyFormatter() {return m_propertyFormatter;}
-	void SetClassSerializer(IECClassSerializer* serializer) { m_classSerializer = serializer; }
-	ECPresentation::IECClassSerializer* GetClassSerializer() { return m_classSerializer; }
+	void SetClassSerializer(IECClassSerializer* serializer) {m_classSerializer = serializer;}
+	ECPresentation::IECClassSerializer* GetClassSerializer() {return m_classSerializer;}
+    void SetOmitDisplayValues(bool omitDisplayValues) {m_omitDisplayValues = omitDisplayValues;}
+    bool ShouldOmitDisplayValues() const {return m_omitDisplayValues;}
 };
 typedef ECPresentationSerializerContext& ECPresentationSerializerContextR;
 

--- a/iModelCore/ECPresentation/PublicAPI/ECPresentation/IECPresentationSerializer.h
+++ b/iModelCore/ECPresentation/PublicAPI/ECPresentation/IECPresentationSerializer.h
@@ -57,6 +57,7 @@ protected:
     virtual rapidjson::Document _AsJson(ContextR, ContentDescriptor const&, rapidjson::Document::AllocatorType*) const = 0;
 
     virtual rapidjson::Document _AsJson(ContextR, ContentSetItem const&, int, rapidjson::Document::AllocatorType*) const = 0;
+    virtual rapidjson::Document _AsJson(ContextR, NavigationPropertyValueCR, rapidjson::Document::AllocatorType*) const = 0;
     virtual rapidjson::Document _AsJson(ContextR, DisplayValueGroupCR, rapidjson::Document::AllocatorType*) const = 0;
 
     virtual rapidjson::Document _AsJson(ContextR, BeInt64Id const&, rapidjson::Document::AllocatorType*) const = 0;
@@ -150,6 +151,7 @@ public:
     rapidjson::Document AsJson(ContextR ctx, ContentDescriptor::Field::NestedContentTypeDescription const& nestedContentTypeDescription, rapidjson::Document::AllocatorType* allocator = nullptr) const;
 
     rapidjson::Document AsJson(ContextR ctx, ContentSetItem const& contentSetItem, int flags = ContentSetItem::SERIALIZE_All, rapidjson::Document::AllocatorType* allocator = nullptr) const {return _AsJson(ctx, contentSetItem, flags, allocator);}
+    rapidjson::Document AsJson(ContextR ctx, NavigationPropertyValueCR value, rapidjson::Document::AllocatorType* allocator = nullptr) const {return _AsJson(ctx, value, allocator);}
     rapidjson::Document AsJson(ContextR ctx, DisplayValueGroupCR value, rapidjson::Document::AllocatorType* allocator = nullptr) const {return _AsJson(ctx, value, allocator);}
 
     rapidjson::Document AsJson(ContextR ctx, NavNodeKey const& navNodeKey, rapidjson::Document::AllocatorType* allocator = nullptr) const;

--- a/iModelCore/ECPresentation/Source/Content/Content.cpp
+++ b/iModelCore/ECPresentation/Source/Content/Content.cpp
@@ -1492,6 +1492,23 @@ rapidjson::Document Content::AsJson(rapidjson::Document::AllocatorType* allocato
 /*---------------------------------------------------------------------------------**//**
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/
+rapidjson::Document NavigationPropertyValue::AsJson(ECPresentationSerializerContextR ctx, rapidjson::Document::AllocatorType* allocator) const
+    {
+    return ECPresentationManager::GetSerializer().AsJson(ctx, *this, allocator);
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+rapidjson::Document NavigationPropertyValue::AsJson(rapidjson::Document::AllocatorType* allocator) const
+    {
+    ECPresentationSerializerContext ctx;
+    return AsJson(ctx, allocator);
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
 rapidjson::Document DisplayValueGroup::AsJson(ECPresentationSerializerContextR ctx, rapidjson::Document::AllocatorType* allocator) const
     {
     return ECPresentationManager::GetSerializer().AsJson(ctx, *this, allocator);

--- a/iModelCore/ECPresentation/Source/Content/ContentItemBuilder.h
+++ b/iModelCore/ECPresentation/Source/Content/ContentItemBuilder.h
@@ -31,7 +31,7 @@ private:
 
 public:
     ContentValuesFormatter(IECPropertyFormatter const* formatter, ECPresentation::UnitSystem unitSystem)
-        : m_propertyFormatter(formatter), m_unitSystem(unitSystem)
+        : m_propertyFormatter(formatter), m_unitSystem(unitSystem)       
         {}
     rapidjson::Document GetFormattedValue(ECPropertyCR prop, IECSqlValue const& value, rapidjson::MemoryPoolAllocator<>* allocator) const;
     void LocalizeString(Utf8StringR) const;
@@ -195,7 +195,7 @@ struct ContentValueHelpers
 private:
     ContentValueHelpers() {}
 public:
-    static bpair<LabelDefinitionCPtr, ECInstanceKey> ParseNavigationPropertyValue(IECSqlValue const& value);
+    static NavigationPropertyValue ParseNavigationPropertyValue(IECSqlValue const& value, SchemaManagerCR schemas);
 };
 
 END_BENTLEY_ECPRESENTATION_NAMESPACE

--- a/iModelCore/ECPresentation/Source/Content/ContentItemBuilder.h
+++ b/iModelCore/ECPresentation/Source/Content/ContentItemBuilder.h
@@ -31,7 +31,7 @@ private:
 
 public:
     ContentValuesFormatter(IECPropertyFormatter const* formatter, ECPresentation::UnitSystem unitSystem)
-        : m_propertyFormatter(formatter), m_unitSystem(unitSystem)       
+        : m_propertyFormatter(formatter), m_unitSystem(unitSystem)
         {}
     rapidjson::Document GetFormattedValue(ECPropertyCR prop, IECSqlValue const& value, rapidjson::MemoryPoolAllocator<>* allocator) const;
     void LocalizeString(Utf8StringR) const;

--- a/iModelCore/ECPresentation/Source/Content/ContentProviders.cpp
+++ b/iModelCore/ECPresentation/Source/Content/ContentProviders.cpp
@@ -393,10 +393,13 @@ void ContentProvider::LoadNestedContentFieldValue(ContentSetItemR item, ContentD
                 int serializationFlags = GetSerializationFlags(isRelatedContent, true, ContentRequest::Values);
 
                 contentValues.SetArray();
+                contentDisplayValues.SetArray();
                 for (size_t i = 0; i < targetSetitems.size(); ++i)
+                    {
                     contentValues.PushBack(targetSetitems[i]->AsJson(serializationFlags, &contentValues.GetAllocator()), contentValues.GetAllocator());
+                    contentDisplayValues.PushBack(targetSetitems[i]->AsJson((int)ContentSetItem::SERIALIZE_DisplayValues, &contentDisplayValues.GetAllocator()), contentDisplayValues.GetAllocator());
+                    }
 
-                contentDisplayValues.CopyFrom(contentValues, contentDisplayValues.GetAllocator());
                 DIAGNOSTICS_DEV_LOG(DiagnosticsCategory::Content, LOG_TRACE, "Loaded related content values.");
                 }
             }

--- a/iModelCore/ECPresentation/Source/Content/ContentQueryResultsReader.cpp
+++ b/iModelCore/ECPresentation/Source/Content/ContentQueryResultsReader.cpp
@@ -378,18 +378,17 @@ DisplayValueGroupR DistinctValuesAccumulator::GetOrCreateDisplayValueGroup(Utf8S
 +---------------+---------------+---------------+---------------+---------------+------*/
 void DistinctValuesAccumulator::ReadNavigationPropertyRecord(ContentDescriptor::ECPropertiesField const& propertiesField, ECSqlStatementCR statement)
     {
-    auto value = ContentValueHelpers::ParseNavigationPropertyValue(statement.GetValue(0));
-    if (value.first.IsNull())
+    auto value = ContentValueHelpers::ParseNavigationPropertyValue(statement.GetValue(0), m_schemaManager);
+    if (!value.IsValid())
         {
         DisplayValueGroupR group = GetOrCreateDisplayValueGroup("");
         group.GetRawValues().emplace_back(rapidjson::kNullType);
         }
     else
         {
-        DisplayValueGroupR group = GetOrCreateDisplayValueGroup(value.first->GetDisplayValue());
+        DisplayValueGroupR group = GetOrCreateDisplayValueGroup(value.GetLabel().GetDisplayValue());
         ECPresentationSerializerContext ctx;
-        ECClassInstanceKey classInstanceKey(m_schemaManager.GetClass(value.second.GetClassId()), value.second.GetInstanceId());
-        group.GetRawValues().push_back(ECPresentationManager::GetSerializer().AsJson(ctx, classInstanceKey, &group.GetRawValuesAllocator()));
+        group.GetRawValues().push_back(ECPresentationManager::GetSerializer().AsJson(ctx, value.GetKey(), &group.GetRawValuesAllocator()));
         }
     }
 

--- a/iModelCore/ECPresentation/Source/Serialization/DefaultECPresentationSerializer.cpp
+++ b/iModelCore/ECPresentation/Source/Serialization/DefaultECPresentationSerializer.cpp
@@ -670,6 +670,20 @@ rapidjson::Document DefaultECPresentationSerializer::_AsJson(ContextR ctx, Conte
 /*---------------------------------------------------------------------------------**//**
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/
+rapidjson::Document DefaultECPresentationSerializer::_AsJson(ContextR ctx, NavigationPropertyValueCR value,
+    rapidjson::Document::AllocatorType* allocator) const
+    {
+    if (!value.IsValid())
+        return rapidjson::Document(allocator);
+
+    rapidjson::Document json = AsJson(ctx, value.GetKey(), allocator);
+    json.AddMember("Label", AsJson(ctx, value.GetLabel(), &json.GetAllocator()), json.GetAllocator());
+    return json;
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
 rapidjson::Document DefaultECPresentationSerializer::_AsJson(ContextR ctx, DisplayValueGroupCR value,
     rapidjson::Document::AllocatorType* allocator) const
     {

--- a/iModelCore/ECPresentation/Tests/NonPublished/Integration/Content/ContentIntegrationTests.h
+++ b/iModelCore/ECPresentation/Tests/NonPublished/Integration/Content/ContentIntegrationTests.h
@@ -68,6 +68,12 @@ struct RulesDrivenECPresentationManagerContentTests : PresentationManagerIntegra
         return fullContent;
         }
 
+    Utf8String GetNavigationPropertyTargetLabel(Utf8CP label = nullptr)
+        {
+        LabelDefinitionCPtr labelDefinition = LabelDefinition::Create(label ? label : CommonStrings::LABEL_NOTSPECIFIED);
+        return BeRapidJsonUtilities::ToString(labelDefinition->AsJson());
+        }
+
     static void ValidateFieldCategoriesHierarchy(ContentDescriptor::Field const&, bvector<Utf8String> const& expectedCategoriesHierarchyLeafToRoot);
     static bvector<ECPropertyCP> CreateNProperties(ECEntityClassR ecClass, int numberOfProperties);
 };

--- a/iModelCore/ECPresentation/Tests/NonPublished/Integration/Content/Content_RelatedPropertiesTests.cpp
+++ b/iModelCore/ECPresentation/Tests/NonPublished/Integration/Content/Content_RelatedPropertiesTests.cpp
@@ -260,7 +260,7 @@ TEST_F(RulesDrivenECPresentationManagerContentTests, ContentModifierAppliesRelat
     expectedValues.Parse(Utf8PrintfString(R"({
         "%s": "InstanceA",
         "%s": null,
-        "%s": {"ECClassId": "%s", "ECInstanceId": "%s"},
+        "%s": {"ECClassId": "%s", "ECInstanceId": "%s", "Label": %s},
         "%s": [{
             "PrimaryKeys": [{"ECClassId": "%s", "ECInstanceId": "%s"}],
             "Values": {
@@ -274,7 +274,7 @@ TEST_F(RulesDrivenECPresentationManagerContentTests, ContentModifierAppliesRelat
     })",
         descriptor->GetVisibleFields()[0]->GetUniqueName().c_str(),
         descriptor->GetVisibleFields()[1]->GetUniqueName().c_str(),
-        descriptor->GetVisibleFields()[2]->GetUniqueName().c_str(), instanceB->GetClass().GetId().ToString().c_str(), instanceB->GetInstanceId().c_str(),
+        descriptor->GetVisibleFields()[2]->GetUniqueName().c_str(), instanceB->GetClass().GetId().ToString().c_str(), instanceB->GetInstanceId().c_str(), GetNavigationPropertyTargetLabel().c_str(),
         descriptor->GetVisibleFields()[3]->GetUniqueName().c_str(),
         classB->GetId().ToString().c_str(), instanceB->GetInstanceId().c_str(),
         descriptor->GetVisibleFields()[3]->AsNestedContentField()->AsRelatedContentField()->GetFields().front()->GetUniqueName().c_str(),
@@ -1238,7 +1238,7 @@ TEST_F(RulesDrivenECPresentationManagerContentTests, LoadsXToManyRelatedInstance
         "%s": [{
             "PrimaryKeys": [{"ECClassId": "%s", "ECInstanceId": "%s"}],
             "Values": {
-                "%s": {"ECClassId": "%s", "ECInstanceId": "%s"}
+                "%s": {"ECClassId": "%s", "ECInstanceId": "%s", "Label": %s}
                 },
             "DisplayValues": {
                 "%s": "%s"
@@ -1248,7 +1248,7 @@ TEST_F(RulesDrivenECPresentationManagerContentTests, LoadsXToManyRelatedInstance
         "%s": [{
             "PrimaryKeys": [{"ECClassId": "%s", "ECInstanceId": "%s"}],
             "Values": {
-                "%s": {"ECClassId": "%s", "ECInstanceId": "%s"},
+                "%s": {"ECClassId": "%s", "ECInstanceId": "%s", "Label": %s},
                 "%s": 1,
                 "%s": "111",
                 "%s": [2, 1],
@@ -1279,7 +1279,7 @@ TEST_F(RulesDrivenECPresentationManagerContentTests, LoadsXToManyRelatedInstance
             },{
             "PrimaryKeys": [{"ECClassId": "%s", "ECInstanceId": "%s"}],
             "Values": {
-                "%s": {"ECClassId": "%s", "ECInstanceId": "%s"},
+                "%s": {"ECClassId": "%s", "ECInstanceId": "%s", "Label": %s},
                 "%s": 2,
                 "%s": "222",
                 "%s": [3],
@@ -1318,18 +1318,18 @@ TEST_F(RulesDrivenECPresentationManagerContentTests, LoadsXToManyRelatedInstance
         FIELD_NAME(parentClass, "ParentProperty"),
         NESTED_CONTENT_FIELD_NAME(parentClass, childClass1),
         childClass1->GetId().ToString().c_str(), child1->GetInstanceId().c_str(),
-        FIELD_NAME(childClass1, "Parent"), parent->GetClass().GetId().ToString().c_str(), parent->GetInstanceId().c_str(),
+        FIELD_NAME(childClass1, "Parent"), parent->GetClass().GetId().ToString().c_str(), parent->GetInstanceId().c_str(), GetNavigationPropertyTargetLabel().c_str(),
         FIELD_NAME(childClass1, "Parent"), CommonStrings::LABEL_NOTSPECIFIED,
         NESTED_CONTENT_FIELD_NAME(parentClass, childClass2),
         childClass2->GetId().ToString().c_str(), child2->GetInstanceId().c_str(),
-        FIELD_NAME(childClass2, "Parent"), parent->GetClass().GetId().ToString().c_str(), parent->GetInstanceId().c_str(),
+        FIELD_NAME(childClass2, "Parent"), parent->GetClass().GetId().ToString().c_str(), parent->GetInstanceId().c_str(), GetNavigationPropertyTargetLabel().c_str(),
         FIELD_NAME(childClass2, "IntProperty"), FIELD_NAME(childClass2, "StringProperty"), FIELD_NAME(childClass2, "ArrayProperty"),
         FIELD_NAME(childClass2, "StructProperty"), FIELD_NAME(childClass2, "StructArrayProperty"),
         FIELD_NAME(childClass2, "Parent"), CommonStrings::LABEL_NOTSPECIFIED,
         FIELD_NAME(childClass2, "IntProperty"), FIELD_NAME(childClass2, "StringProperty"), FIELD_NAME(childClass2, "ArrayProperty"),
         FIELD_NAME(childClass2, "StructProperty"), FIELD_NAME(childClass2, "StructArrayProperty"),
         childClass2->GetId().ToString().c_str(), child3->GetInstanceId().c_str(),
-        FIELD_NAME(childClass2, "Parent"), parent->GetClass().GetId().ToString().c_str(),  parent->GetInstanceId().c_str(),
+        FIELD_NAME(childClass2, "Parent"), parent->GetClass().GetId().ToString().c_str(),  parent->GetInstanceId().c_str(), GetNavigationPropertyTargetLabel().c_str(),
         FIELD_NAME(childClass2, "IntProperty"), FIELD_NAME(childClass2, "StringProperty"), FIELD_NAME(childClass2, "ArrayProperty"),
         FIELD_NAME(childClass2, "StructProperty"), FIELD_NAME(childClass2, "StructArrayProperty"),
         FIELD_NAME(childClass2, "Parent"), CommonStrings::LABEL_NOTSPECIFIED,
@@ -1756,12 +1756,12 @@ TEST_F(RulesDrivenECPresentationManagerContentTests, LoadsXToManyRelatedNestedIn
             "PrimaryKeys": [{"ECClassId": "%s", "ECInstanceId": "%s"}],
             "Values": {
                 "%s": null,
-                "%s": {"ECClassId": "%s", "ECInstanceId": "%s"},
+                "%s": {"ECClassId": "%s", "ECInstanceId": "%s", "Label": %s},
                 "%s": [{
                     "PrimaryKeys": [{"ECClassId": "%s", "ECInstanceId": "%s"}],
                     "Values": {
                         "%s": null,
-                        "%s": {"ECClassId": "%s", "ECInstanceId": "%s"}
+                        "%s": {"ECClassId": "%s", "ECInstanceId": "%s", "Label": %s}
                         },
                     "DisplayValues": {
                         "%s": null,
@@ -1786,11 +1786,11 @@ TEST_F(RulesDrivenECPresentationManagerContentTests, LoadsXToManyRelatedNestedIn
         FIELD_NAME(classA, "PropertyA"), NESTED_CONTENT_FIELD_NAME(classA, classB),
         classB->GetId().ToString().c_str(), instanceB->GetInstanceId().c_str(),
         FIELD_NAME(classB, "PropertyB"),
-        FIELD_NAME(classB, "A"), instanceA->GetClass().GetId().ToString().c_str(), instanceA->GetInstanceId().c_str(),
+        FIELD_NAME(classB, "A"), instanceA->GetClass().GetId().ToString().c_str(), instanceA->GetInstanceId().c_str(), GetNavigationPropertyTargetLabel().c_str(),
         NESTED_CONTENT_FIELD_NAME(classB, classC),
         classC->GetId().ToString().c_str(), instanceC->GetInstanceId().c_str(),
         FIELD_NAME(classC, "PropertyC"),
-        FIELD_NAME(classC, "B"), instanceB->GetClass().GetId().ToString().c_str(), instanceB->GetInstanceId().c_str(),
+        FIELD_NAME(classC, "B"), instanceB->GetClass().GetId().ToString().c_str(), instanceB->GetInstanceId().c_str(), GetNavigationPropertyTargetLabel().c_str(),
         FIELD_NAME(classC, "PropertyC"), FIELD_NAME(classC, "B"), CommonStrings::LABEL_NOTSPECIFIED,
         FIELD_NAME(classB, "PropertyB"), FIELD_NAME(classB, "A"), CommonStrings::LABEL_NOTSPECIFIED,
         NESTED_CONTENT_FIELD_NAME(classB, classC),
@@ -1889,7 +1889,7 @@ TEST_F(RulesDrivenECPresentationManagerContentTests, LoadsXToManyRelatedNestedIn
                     "PrimaryKeys": [{"ECClassId": "%s", "ECInstanceId": "%s"}],
                     "Values": {
                         "%s": null,
-                        "%s": {"ECClassId": "%s", "ECInstanceId": "%s"}
+                        "%s": {"ECClassId": "%s", "ECInstanceId": "%s", "Label": %s}
                         },
                     "DisplayValues": {
                         "%s": null,
@@ -1913,7 +1913,7 @@ TEST_F(RulesDrivenECPresentationManagerContentTests, LoadsXToManyRelatedNestedIn
         NESTED_CONTENT_FIELD_NAME(classA, classB), classB->GetId().ToString().c_str(), instanceB->GetInstanceId().c_str(),
         NESTED_CONTENT_FIELD_NAME(classB, classC), classC->GetId().ToString().c_str(), instanceC->GetInstanceId().c_str(),
         FIELD_NAME(classC, "PropertyC"),
-        FIELD_NAME(classC, "B"), instanceB->GetClass().GetId().ToString().c_str(), instanceB->GetInstanceId().c_str(),
+        FIELD_NAME(classC, "B"), instanceB->GetClass().GetId().ToString().c_str(), instanceB->GetInstanceId().c_str(), GetNavigationPropertyTargetLabel().c_str(),
         FIELD_NAME(classC, "PropertyC"), FIELD_NAME(classC, "B"), CommonStrings::LABEL_NOTSPECIFIED,
         NESTED_CONTENT_FIELD_NAME(classB, classC),
         FIELD_NAME(classC, "PropertyC"), FIELD_NAME(classC, "B"), CommonStrings::LABEL_NOTSPECIFIED

--- a/iModelJsNodeAddon/IModelJsNative.cpp
+++ b/iModelJsNodeAddon/IModelJsNative.cpp
@@ -4985,7 +4985,7 @@ struct NativeECPresentationManager : BeObjectWrap<NativeECPresentationManager>
             // rapidjson response
             if (serializeResponse) {
                 auto str = result.GetSerializedSuccessResponse();
-                retVal["result"] = str.empty() ? "\"null\"" : str; // see note about null values for BeJsValue::Stringify
+                retVal["result"] = str.empty() ? "null" : str; // see note about null values for BeJsValue::Stringify
             } else
                 retVal["result"].From(result.GetSuccessResponse());
             }

--- a/iModelJsNodeAddon/presentation/ECPresentationSerializer.cpp
+++ b/iModelJsNodeAddon/presentation/ECPresentationSerializer.cpp
@@ -680,7 +680,7 @@ rapidjson::Document IModelJsECPresentationSerializer::_AsJson(ContextR ctx, Cont
             }
         }
 
-    if (0 != (ContentSetItem::SerializationFlags::SERIALIZE_DisplayValues & flags))
+    if (!ctx.ShouldOmitDisplayValues() && 0 != (ContentSetItem::SerializationFlags::SERIALIZE_DisplayValues & flags))
         {
         json.AddMember("displayValues", rapidjson::Value(contentSetItem.GetDisplayValues(), json.GetAllocator()), json.GetAllocator());
         for (auto const& nestedContentEntry : contentSetItem.GetNestedContent())
@@ -690,6 +690,10 @@ rapidjson::Document IModelJsECPresentationSerializer::_AsJson(ContextR ctx, Cont
                 nestedValuesJson.PushBack(nestedItem->AsJson(ctx, (int)ContentSetItem::SERIALIZE_DisplayValues, &json.GetAllocator()), json.GetAllocator());
             json["displayValues"].AddMember(rapidjson::Value(nestedContentEntry.first.c_str(), json.GetAllocator()), nestedValuesJson, json.GetAllocator());
             }
+        }
+    else if (ctx.ShouldOmitDisplayValues() && 0 != (ContentSetItem::SerializationFlags::SERIALIZE_DisplayValues & flags))
+        {
+        json.AddMember("displayValues", rapidjson::Value(rapidjson::kObjectType), json.GetAllocator());
         }
 
     if (contentSetItem.GetClass() != nullptr && 0 != (ContentSetItem::SerializationFlags::SERIALIZE_ClassInfo & flags))
@@ -748,6 +752,19 @@ rapidjson::Document IModelJsECPresentationSerializer::_AsJson(ContextR ctx, Cont
         }
 #endif
 
+    return json;
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+rapidjson::Document IModelJsECPresentationSerializer::_AsJson(ContextR ctx, NavigationPropertyValueCR value, rapidjson::Document::AllocatorType* allocator) const
+    {
+    if (!value.IsValid())
+        return rapidjson::Document(allocator);
+
+    rapidjson::Document json = AsJson(ctx, value.GetKey(), allocator);
+    json.AddMember("label", AsJson(ctx, value.GetLabel(), &json.GetAllocator()), json.GetAllocator());
     return json;
     }
 

--- a/iModelJsNodeAddon/presentation/ECPresentationSerializer.cpp
+++ b/iModelJsNodeAddon/presentation/ECPresentationSerializer.cpp
@@ -680,20 +680,23 @@ rapidjson::Document IModelJsECPresentationSerializer::_AsJson(ContextR ctx, Cont
             }
         }
 
-    if (!ctx.ShouldOmitDisplayValues() && 0 != (ContentSetItem::SerializationFlags::SERIALIZE_DisplayValues & flags))
+    if (0 != (ContentSetItem::SerializationFlags::SERIALIZE_DisplayValues & flags))
         {
-        json.AddMember("displayValues", rapidjson::Value(contentSetItem.GetDisplayValues(), json.GetAllocator()), json.GetAllocator());
-        for (auto const& nestedContentEntry : contentSetItem.GetNestedContent())
+        if (ctx.ShouldOmitDisplayValues())
             {
-            rapidjson::Value nestedValuesJson(rapidjson::kArrayType);
-            for (auto const& nestedItem : nestedContentEntry.second)
-                nestedValuesJson.PushBack(nestedItem->AsJson(ctx, (int)ContentSetItem::SERIALIZE_DisplayValues, &json.GetAllocator()), json.GetAllocator());
-            json["displayValues"].AddMember(rapidjson::Value(nestedContentEntry.first.c_str(), json.GetAllocator()), nestedValuesJson, json.GetAllocator());
+            json.AddMember("displayValues", rapidjson::Value(rapidjson::kObjectType), json.GetAllocator());
             }
-        }
-    else if (ctx.ShouldOmitDisplayValues() && 0 != (ContentSetItem::SerializationFlags::SERIALIZE_DisplayValues & flags))
-        {
-        json.AddMember("displayValues", rapidjson::Value(rapidjson::kObjectType), json.GetAllocator());
+        else 
+            {
+            json.AddMember("displayValues", rapidjson::Value(contentSetItem.GetDisplayValues(), json.GetAllocator()), json.GetAllocator());
+            for (auto const& nestedContentEntry : contentSetItem.GetNestedContent())
+                {
+                rapidjson::Value nestedValuesJson(rapidjson::kArrayType);
+                for (auto const& nestedItem : nestedContentEntry.second)
+                    nestedValuesJson.PushBack(nestedItem->AsJson(ctx, (int)ContentSetItem::SERIALIZE_DisplayValues, &json.GetAllocator()), json.GetAllocator());
+                json["displayValues"].AddMember(rapidjson::Value(nestedContentEntry.first.c_str(), json.GetAllocator()), nestedValuesJson, json.GetAllocator());
+                }
+            }
         }
 
     if (contentSetItem.GetClass() != nullptr && 0 != (ContentSetItem::SerializationFlags::SERIALIZE_ClassInfo & flags))

--- a/iModelJsNodeAddon/presentation/ECPresentationSerializer.h
+++ b/iModelJsNodeAddon/presentation/ECPresentationSerializer.h
@@ -48,6 +48,7 @@ protected:
     rapidjson::Document _AsJson(ContextR, Content const& content, rapidjson::Document::AllocatorType* allocator) const override;
     rapidjson::Document _AsJson(ContextR, ContentDescriptor const& contentDescriptor, rapidjson::Document::AllocatorType* allocator) const override;
     rapidjson::Document _AsJson(ContextR, ContentSetItem const& contentSetItem, int flags, rapidjson::Document::AllocatorType* allocator) const override;
+    rapidjson::Document _AsJson(ContextR, NavigationPropertyValueCR, rapidjson::Document::AllocatorType*) const override;
     rapidjson::Document _AsJson(ContextR, DisplayValueGroupCR, rapidjson::Document::AllocatorType*) const override;
     rapidjson::Document _AsJson(ContextR, ContentDescriptor::Category const& category, rapidjson::Document::AllocatorType* allocator) const override;
     rapidjson::Document _AsJson(ContextR, ContentDescriptor::Property const& property, rapidjson::Document::AllocatorType* allocator) const override;


### PR DESCRIPTION
Added instance label to raw navigation property value. This is necessary for formatting content values on frontend.
Added ability to omit formatted display values from Content response.

itwinjs-core: https://github.com/iTwin/itwinjs-core/tree/presentation/values_formatting
TS changes: https://github.com/iTwin/itwinjs-core/pull/5303

Part of https://github.com/iTwin/itwinjs-core/issues/5029