### PR TITLE
Profile upgrade fails due to a data transformation is detected where there is none

### DIFF
--- a/iModelCore/ECDb/ECDb/SchemaManagerDispatcher.cpp
+++ b/iModelCore/ECDb/ECDb/SchemaManagerDispatcher.cpp
@@ -1157,10 +1157,6 @@ SchemaImportResult MainSchemaManager::MapSchemas(SchemaImportContext& ctx, bvect
         return failedToMap();
     }
 
-    if (BE_SQLITE_OK != UpgradeExistingECInstancesWithNewPropertiesMapToOverflowTable(m_ecdb, &ctx)){
-        return failedToMap();
-    }
-
     if (SUCCESS != ctx.RemapManager().UpgradeExistingECInstancesWithRemappedProperties(ctx)) {
         return failedToMap();
     }
@@ -1203,6 +1199,11 @@ SchemaImportResult MainSchemaManager::MapSchemas(SchemaImportContext& ctx, bvect
             return failedToMap();
         }
     }
+
+    if (BE_SQLITE_OK != UpgradeExistingECInstancesWithNewPropertiesMapToOverflowTable(m_ecdb, nullptr)){
+        return failedToMap();
+    }
+
     ClearCache();
     return  SchemaImportResult::OK;
 }

--- a/iModelCore/ECDb/Tests/NonPublished/DbMappingTests.cpp
+++ b/iModelCore/ECDb/Tests/NonPublished/DbMappingTests.cpp
@@ -4468,7 +4468,7 @@ TEST_F(DbMappingTestFixture, OverflowIssue)
                     <ECProperty propertyName="p6" typeName="long"/>
                     <ECProperty propertyName="p7" typeName="long"/>
                 </ECEntityClass>
-            </ECSchema>)xml"), SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade));
+            </ECSchema>)xml"), SchemaManager::SchemaImportOptions::None)) << "UpgradeECInstance for overflow table should not require SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade";
 
     m_ecdb.SaveChanges();
     ReopenECDb();

--- a/iModelJsNodeAddon/api_package/ts/assets/test/test-with-overflow.text
+++ b/iModelJsNodeAddon/api_package/ts/assets/test/test-with-overflow.text
@@ -1,0 +1,1 @@
+this is a test file for profile/schema upgrade

--- a/iModelJsNodeAddon/api_package/ts/src/test/DgnDb.test.ts
+++ b/iModelJsNodeAddon/api_package/ts/src/test/DgnDb.test.ts
@@ -4,6 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 import { DbResult, Id64Array, Id64String, IModelStatus, OpenMode } from "@itwin/core-bentley";
 import { BlobRange, DbBlobRequest, DbBlobResponse, DbQueryRequest, DbQueryResponse, DbRequestKind, DbResponseStatus, ProfileOptions } from "@itwin/core-common";
+import { DomainOptions } from "@itwin/core-common/lib/cjs/BriefcaseTypes";
 import { assert, expect } from "chai";
 import * as fs from "fs-extra";
 import * as os from "os";
@@ -339,7 +340,28 @@ describe("basic tests", () => {
     });
   });
 
-  it("schemaLockHeld flag", async () => {
+  it("profile/schema upgrade with schemaLockHeld flag", async () => {
+    /**
+     * This test verify if schemaLockHeld is true profile upgrade should not fail when imodel have overflow tables.
+     */
+    const originalFile = path.join(getAssetsDir(), "test-with-overflow.bim");
+    const testFile = path.join(getAssetsDir(), "test-with-overflow-upgrade.bim");
+    if (fs.existsSync(testFile)) {
+      fs.unlinkSync(testFile);
+    }
+
+    fs.copyFileSync(originalFile, testFile);
+
+    const dbForProfileUpgrade = openDgnDb(testFile, { profile: ProfileOptions.Upgrade, schemaLockHeld: true });
+    dbForProfileUpgrade.saveChanges();
+    dbForProfileUpgrade.closeIModel();
+
+    const dbForSchemaUpgrade = openDgnDb(testFile, { domain: DomainOptions.Upgrade, schemaLockHeld: true });
+    dbForSchemaUpgrade.saveChanges();
+    dbForSchemaUpgrade.closeIModel();
+  });
+
+  it("import schema with schemaLockHeld flag", async () => {
     let t = 0;
     const generateIntProp = (propCount: number, prefix: string = "P") => {
       let xml = "";


### PR DESCRIPTION
The issue happens if iModel has an overflow table. Schema import always runs instance upgrade on all classes that are mapped overflow table. 

