### PR TITLE
Make application fail when SQLite hits a fatal error

### DIFF
--- a/iModelCore/BeSQLite/PublicAPI/BeSQLite/BeSQLite.h
+++ b/iModelCore/BeSQLite/PublicAPI/BeSQLite/BeSQLite.h
@@ -716,8 +716,6 @@ public:
     static int GetBaseDbResult(DbResult val) {return 0xff & val;}
     static bool TestBaseDbResult(DbResult val1, DbResult val2) {return GetBaseDbResult(val1) == GetBaseDbResult(val2);}
     static bool IsConstraintDbResult(DbResult val1) {return GetBaseDbResult(val1) == BE_SQLITE_CONSTRAINT;}
-    BE_SQLITE_EXPORT static bool s_throwExceptionOnUnexpectedAutoCommit;
-
 };
 
 //=======================================================================================

--- a/iModelCore/BeSQLite/Tests/NonPublished/BeSQLite_Test.cpp
+++ b/iModelCore/BeSQLite/Tests/NonPublished/BeSQLite_Test.cpp
@@ -348,12 +348,6 @@ TEST_F(BeSQliteTestFixture, HandleSqliteFullFailure) {
         EXPECT_EQ(BE_SQLITE_ROW, stmt.Step());
         return stmt.GetValueInt(0);
     };
-    auto getMaxPageCount = [](DbCR db)  -> int{
-        Statement stmt;
-        EXPECT_EQ(BE_SQLITE_OK, stmt.Prepare(db, "PRAGMA max_page_count"));
-        EXPECT_EQ(BE_SQLITE_ROW, stmt.Step());
-        return stmt.GetValueInt(0);
-    };
     auto setMaxPageCount = [](DbCR db, int count)  -> int{
         Statement stmt;
         EXPECT_EQ(BE_SQLITE_OK, stmt.Prepare(db, SqlPrintfString("PRAGMA max_page_count=%d", count).GetUtf8CP()));

--- a/iModelJsNodeAddon/IModelJsNative.cpp
+++ b/iModelJsNodeAddon/IModelJsNative.cpp
@@ -2261,6 +2261,13 @@ struct NativeDgnDb : BeObjectWrap<NativeDgnDb>, SQLiteOps
         return JsInterop::ConcurrentQueryResetConfig(Env(), GetDgnDb());
     }
 
+    Napi::Value TriggerAutoCommitFailure(NapiInfoCR info) {
+        RequireDbIsOpen(info);
+        OPTIONAL_ARGUMENT_BOOL(0, reThrowJsException, false);
+        const auto rc = JsInterop::TriggerAutoCommitFailure(Env(), GetDgnDb(), reThrowJsException);
+        return Napi::Number::New(Env(), rc);;
+    }
+
     void ConcurrentQueryShutdown(NapiInfoCR info) {
         RequireDbIsOpen(info);;
         ConcurrentQueryMgr::Shutdown(GetDgnDb());
@@ -2422,6 +2429,7 @@ struct NativeDgnDb : BeObjectWrap<NativeDgnDb>, SQLiteOps
             InstanceMethod("startCreateChangeset", &NativeDgnDb::StartCreateChangeset),
             InstanceMethod("startProfiler", &NativeDgnDb::StartProfiler),
             InstanceMethod("stopProfiler", &NativeDgnDb::StopProfiler),
+            InstanceMethod("triggerAutoCommitFailure", &NativeDgnDb::TriggerAutoCommitFailure),
             InstanceMethod("updateElement", &NativeDgnDb::UpdateElement),
             InstanceMethod("updateElementAspect", &NativeDgnDb::UpdateElementAspect),
             InstanceMethod("updateElementGeometryCache", &NativeDgnDb::UpdateElementGeometryCache),

--- a/iModelJsNodeAddon/IModelJsNative.h
+++ b/iModelJsNodeAddon/IModelJsNative.h
@@ -458,6 +458,8 @@ private:
     static void InitializeSolidKernel();
     static void AddFallbackSchemaLocaters(ECDbR db, ECSchemaReadContextPtr schemaContext);
 public:
+    static DbResult TriggerAutoCommitFailure(Napi::Env env, DbR db, bool reThrowAsJsException);
+
     static void HandleAssertion(WCharCP msg, WCharCP file, unsigned line, BeAssertFunctions::AssertType type);
     static void GetECValuesCollectionAsJson(BeJsValue json, ECN::ECValuesCollectionCR);
     static ECN::ECClassCP GetClassFromInstance(BeSQLite::EC::ECDbCR ecdb, BeJsConst jsonInstance);

--- a/iModelJsNodeAddon/api_package/ts/src/NativeLibrary.ts
+++ b/iModelJsNodeAddon/api_package/ts/src/NativeLibrary.ts
@@ -591,6 +591,7 @@ export declare namespace IModelJsNative {
     public startCreateChangeset(): ChangesetFileProps;
     public startProfiler(scopeName?: string, scenarioName?: string, overrideFile?: boolean, computeExecutionPlan?: boolean): DbResult;
     public stopProfiler(): { rc: DbResult, elapsedTime?: number, scopeId?: number, fileName?: string };
+    public triggerAutoCommitFailure(rethrowAsJsException?: boolean): DbResult;
     public updateElement(elemProps: ElementProps): void;
     public updateElementAspect(aspectProps: ElementAspectProps): void;
     public updateElementGeometryCache(props: object): Promise<any>;

--- a/iModelJsNodeAddon/api_package/ts/src/test/DgnDb.test.ts
+++ b/iModelJsNodeAddon/api_package/ts/src/test/DgnDb.test.ts
@@ -361,6 +361,17 @@ describe("basic tests", () => {
     dbForSchemaUpgrade.closeIModel();
   });
 
+  it("trigger auto commit", () => {
+    const testFile = dbFileName.replace("test.bim", "auto-commit.bim");
+    if (fs.existsSync(testFile)) {
+      fs.unlinkSync(testFile);
+    }
+    fs.copyFileSync(dbFileName, testFile);
+    const db = openDgnDb(testFile);
+    db.saveChanges();
+    assert.throws(() => db.triggerAutoCommitFailure(true), "sqlite initiated autocommit due to a fatal error");
+  });
+
   it("import schema with schemaLockHeld flag", async () => {
     let t = 0;
     const generateIntProp = (propCount: number, prefix: string = "P") => {


### PR DESCRIPTION
This change is to avoid corrupt changeset being pushed to Hub. Currently, we have undefined behavior where the application after hitting critical error continues to run and push an invalid changeset to the hub. 

* throw `std::runtime exception` when SQLite hits a fatal error.
* `DgnDbNative.triggerAutoCommitFailure()` allow triggering auto commit for testing and verifying we throw a c++ exception.