### PR TITLE
Presentation: Include diagnostics in error responses

### DIFF
--- a/iModelJsNodeAddon/presentation/ECPresentationUtils.cpp
+++ b/iModelJsNodeAddon/presentation/ECPresentationUtils.cpp
@@ -13,33 +13,33 @@ USING_NAMESPACE_BENTLEY_ECPRESENTATION
 /*---------------------------------------------------------------------------------**//**
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/
-ECPresentationResult ECPresentationUtils::CreateResultFromException(folly::exception_wrapper const& ew)
+ECPresentationResult ECPresentationUtils::CreateResultFromException(folly::exception_wrapper const& ew, rapidjson::Document&& diagnostics)
     {
     if (!ew)
-        return ECPresentationResult(ECPresentationStatus::Error, "Invalid exception");
+        return ECPresentationResult(ECPresentationStatus::Error, "Invalid exception", std::move(diagnostics));
     try
         {
         ew.throwException();
         }
     catch (CancellationException const&)
         {
-        return ECPresentationResult(ECPresentationStatus::Canceled, "");
+        return ECPresentationResult(ECPresentationStatus::Canceled, "", std::move(diagnostics));
         }
     catch (InvalidArgumentException const& e)
         {
-        return ECPresentationResult(ECPresentationStatus::InvalidArgument, Utf8String(e.what()));
+        return ECPresentationResult(ECPresentationStatus::InvalidArgument, Utf8String(e.what()), std::move(diagnostics));
         }
     catch (ResultSetTooLargeError const& e)
         {
-        return ECPresentationResult(ECPresentationStatus::ResultSetTooLarge, Utf8String(e.what()));
+        return ECPresentationResult(ECPresentationStatus::ResultSetTooLarge, Utf8String(e.what()), std::move(diagnostics));
         }
     catch (std::runtime_error const& e)
         {
-        return ECPresentationResult(ECPresentationStatus::Error, Utf8String(e.what()));
+        return ECPresentationResult(ECPresentationStatus::Error, Utf8String(e.what()), std::move(diagnostics));
         }
     catch (...)
         {
-        return ECPresentationResult(ECPresentationStatus::Error, "Unknown exception");
+        return ECPresentationResult(ECPresentationStatus::Error, "Unknown exception", std::move(diagnostics));
         }
     }
 

--- a/iModelJsNodeAddon/presentation/ECPresentationUtils.h
+++ b/iModelJsNodeAddon/presentation/ECPresentationUtils.h
@@ -97,7 +97,7 @@ struct ECPresentationUtils
     static NativeLogging::CategoryLogger GetLogger();
 
     static ECPresentation::Diagnostics::Options CreateDiagnosticsOptions(RapidJsonValueCR);
-    static ECPresentationResult CreateResultFromException(folly::exception_wrapper const&);
+    static ECPresentationResult CreateResultFromException(folly::exception_wrapper const&, rapidjson::Document&& diagnostics = rapidjson::Document());
 
     static ECPresentationManager* CreatePresentationManager(Dgn::PlatformLib::Host::IKnownLocationsAdmin&, IJsonLocalState&,
         std::shared_ptr<IUpdateRecordsHandler>, BeJsConst props);


### PR DESCRIPTION
When looking into https://github.com/iTwin/presentation-performance-tests/issues/68, found that we're not reporting diagnostics when the request fails. Which is when they're actually important...

itwinjs-core PR: https://github.com/iTwin/itwinjs-core/pull/5375
itwinjs-core: https://github.com/iTwin/itwinjs-core/tree/presentation/report-diagnostics-with-error-responses

