### PR TITLE
Presentation: Logging improvements

### DIFF
--- a/iModelJsNodeAddon/IModelJsNative.cpp
+++ b/iModelJsNodeAddon/IModelJsNative.cpp
@@ -5042,6 +5042,8 @@ struct NativeECPresentationManager : BeObjectWrap<NativeECPresentationManager>
         std::shared_ptr<ECPresentationResult> resultPtr = std::make_shared<ECPresentationResult>(std::move(result));
         m_threadSafeFunc.BlockingCall([this, resultPtr, deferred = std::move(deferred)](Napi::Env, Napi::Function)
             {
+            // flush all our logs that accumulated while handling the request
+            s_jsLogger.FlushDeferred();
             deferred.Resolve(CreateReturnValue(*resultPtr, true));
             });
         }
@@ -5084,8 +5086,6 @@ struct NativeECPresentationManager : BeObjectWrap<NativeECPresentationManager>
 
         ECPresentationUtils::GetLogger().debugv("Received request: %s. Assigned GUID: %s. Request params: %s",
             requestId, requestGuid.c_str(), BeRapidJsonUtilities::ToString(params).c_str());
-
-        m_presentationManager->GetConnections().CreateConnection(db->GetDgnDb());
 
         auto diagnostics = ECPresentation::Diagnostics::Scope::ResetAndCreate(requestId, ECPresentationUtils::CreateDiagnosticsOptions(params));
         try

--- a/iModelJsNodeAddon/presentation/ECPresentationUtils.cpp
+++ b/iModelJsNodeAddon/presentation/ECPresentationUtils.cpp
@@ -730,7 +730,7 @@ static ParseResult<Nullable<size_t>> ParseHierarchyLevelSizeLimitFromJson(RapidJ
 +---------------+---------------+---------------+---------------+---------------+------*/
 folly::Future<ECPresentationResult> ECPresentationUtils::GetRootNodesCount(ECPresentationManager& manager, ECDbR db, RapidJsonValueCR paramsJson)
     {
-    IConnectionCPtr connection = manager.GetConnections().GetConnection(db);
+    IConnectionCPtr connection = manager.GetConnections().CreateConnection(db);
     if (connection.IsNull())
         return folly::makeFutureWith([](){return ECPresentationResult(ECPresentationStatus::InvalidArgument, "db: not open");});
 
@@ -761,7 +761,7 @@ folly::Future<ECPresentationResult> ECPresentationUtils::GetRootNodesCount(ECPre
 +---------------+---------------+---------------+---------------+---------------+------*/
 folly::Future<ECPresentationResult> ECPresentationUtils::GetRootNodes(ECPresentationManager& manager, ECDbR db, RapidJsonValueCR paramsJson)
     {
-    IConnectionCPtr connection = manager.GetConnections().GetConnection(db);
+    IConnectionCPtr connection = manager.GetConnections().CreateConnection(db);
     if (connection.IsNull())
         return folly::makeFutureWith([](){return ECPresentationResult(ECPresentationStatus::InvalidArgument, "db: not open");});
 
@@ -821,7 +821,7 @@ static ParseResult<NavNodeKeyCPtr> ParseParentNodeKeyFromJson(IConnectionCR conn
 +---------------+---------------+---------------+---------------+---------------+------*/
 folly::Future<ECPresentationResult> ECPresentationUtils::GetChildrenCount(ECPresentationManager& manager, ECDbR db, RapidJsonValueCR paramsJson)
     {
-    IConnectionCPtr connection = manager.GetConnections().GetConnection(db);
+    IConnectionCPtr connection = manager.GetConnections().CreateConnection(db);
     if (connection.IsNull())
         return folly::makeFutureWith([](){return ECPresentationResult(ECPresentationStatus::InvalidArgument, "db: not open");});
 
@@ -857,7 +857,7 @@ folly::Future<ECPresentationResult> ECPresentationUtils::GetChildrenCount(ECPres
 +---------------+---------------+---------------+---------------+---------------+------*/
 folly::Future<ECPresentationResult> ECPresentationUtils::GetChildren(ECPresentationManager& manager, ECDbR db, RapidJsonValueCR paramsJson)
     {
-    IConnectionCPtr connection = manager.GetConnections().GetConnection(db);
+    IConnectionCPtr connection = manager.GetConnections().CreateConnection(db);
     if (connection.IsNull())
         return folly::makeFutureWith([](){return ECPresentationResult(ECPresentationStatus::InvalidArgument, "db: not open");});
 
@@ -898,7 +898,7 @@ folly::Future<ECPresentationResult> ECPresentationUtils::GetChildren(ECPresentat
 +---------------+---------------+---------------+---------------+---------------+------*/
 folly::Future<ECPresentationResult> ECPresentationUtils::GetHierarchyLevelDescriptor(ECPresentationManager& manager, ECDbR db, RapidJsonValueCR paramsJson)
     {
-    IConnectionCPtr connection = manager.GetConnections().GetConnection(db);
+    IConnectionCPtr connection = manager.GetConnections().CreateConnection(db);
     if (connection.IsNull())
         return ECPresentationResult(ECPresentationStatus::InvalidArgument, "db: not open");
 
@@ -973,7 +973,7 @@ static ParseResult<bvector<bvector<ECInstanceKey>>> ParseECInstanceKeyPathsFromJ
 +---------------+---------------+---------------+---------------+---------------+------*/
 folly::Future<ECPresentationResult> ECPresentationUtils::GetNodesPaths(ECPresentationManager& manager, ECDbR db, RapidJsonValueCR paramsJson)
     {
-    IConnectionCPtr connection = manager.GetConnections().GetConnection(db);
+    IConnectionCPtr connection = manager.GetConnections().CreateConnection(db);
     if (connection.IsNull())
         return folly::makeFutureWith([](){return ECPresentationResult(ECPresentationStatus::InvalidArgument, "db: not open");});
 
@@ -1019,6 +1019,10 @@ static ParseResult<Utf8String> ParseFilterTextFromJson(RapidJsonValueCR json)
 +---------------+---------------+---------------+---------------+---------------+------*/
 folly::Future<ECPresentationResult> ECPresentationUtils::GetFilteredNodesPaths(ECPresentationManager& manager, ECDbR db, RapidJsonValueCR paramsJson)
     {
+    IConnectionCPtr connection = manager.GetConnections().CreateConnection(db);
+    if (connection.IsNull())
+        return folly::makeFutureWith([](){return ECPresentationResult(ECPresentationStatus::InvalidArgument, "db: not open");});
+
     auto rulesetParams = ParseRulesetParamsFromJson(paramsJson);
     if (rulesetParams.HasError())
         return ECPresentationResult(ECPresentationStatus::InvalidArgument, rulesetParams.GetError());
@@ -1127,7 +1131,7 @@ static std::unique_ptr<IContentFieldMatcher> CreateFieldMatcherFromJson(RapidJso
 +---------------+---------------+---------------+---------------+---------------+------*/
 folly::Future<ECPresentationResult> ECPresentationUtils::GetContentSources(ECPresentationManager& manager, ECDbR db, RapidJsonValueCR paramsJson)
     {
-    IConnectionCPtr connection = manager.GetConnections().GetConnection(db);
+    IConnectionCPtr connection = manager.GetConnections().CreateConnection(db);
     if (connection.IsNull())
         return folly::makeFutureWith([](){return ECPresentationResult(ECPresentationStatus::InvalidArgument, "db: not open");});
 
@@ -1494,7 +1498,7 @@ public:
 +---------------+---------------+---------------+---------------+---------------+------*/
 folly::Future<ECPresentationResult> ECPresentationUtils::GetContentDescriptor(ECPresentationManager& manager, ECDbR db, RapidJsonValueCR paramsJson)
     {
-    IConnectionCPtr connection = manager.GetConnections().GetConnection(db);
+    IConnectionCPtr connection = manager.GetConnections().CreateConnection(db);
     if (connection.IsNull())
         return folly::makeFutureWith([](){return ECPresentationResult(ECPresentationStatus::InvalidArgument, "db: not open");});
 
@@ -1536,7 +1540,7 @@ folly::Future<ECPresentationResult> ECPresentationUtils::GetContentDescriptor(EC
 +---------------+---------------+---------------+---------------+---------------+------*/
 folly::Future<ECPresentationResult> ECPresentationUtils::GetContent(ECPresentationManager& manager, ECDbR db, RapidJsonValueCR paramsJson)
     {
-    IConnectionCPtr connection = manager.GetConnections().GetConnection(db);
+    IConnectionCPtr connection = manager.GetConnections().CreateConnection(db);
     if (connection.IsNull())
         return folly::makeFutureWith([](){return ECPresentationResult(ECPresentationStatus::InvalidArgument, "db: not open");});
 
@@ -1591,7 +1595,7 @@ folly::Future<ECPresentationResult> ECPresentationUtils::GetContent(ECPresentati
 +---------------+---------------+---------------+---------------+---------------+------*/
 folly::Future<ECPresentationResult> ECPresentationUtils::GetContentSetSize(ECPresentationManager& manager, ECDbR db, RapidJsonValueCR paramsJson)
     {
-    IConnectionCPtr connection = manager.GetConnections().GetConnection(db);
+    IConnectionCPtr connection = manager.GetConnections().CreateConnection(db);
     if (connection.IsNull())
         return folly::makeFutureWith([](){return ECPresentationResult(ECPresentationStatus::InvalidArgument, "db: not open");});
 
@@ -1635,7 +1639,7 @@ folly::Future<ECPresentationResult> ECPresentationUtils::GetContentSetSize(ECPre
 +---------------+---------------+---------------+---------------+---------------+------*/
 folly::Future<ECPresentationResult> ECPresentationUtils::GetPagedDistinctValues(ECPresentationManager& manager, ECDbR db, RapidJsonValueCR paramsJson)
     {
-    IConnectionCPtr connection = manager.GetConnections().GetConnection(db);
+    IConnectionCPtr connection = manager.GetConnections().CreateConnection(db);
     if (connection.IsNull())
         return folly::makeFutureWith([](){return ECPresentationResult(ECPresentationStatus::InvalidArgument, "db: not open");});
 
@@ -1696,7 +1700,7 @@ folly::Future<ECPresentationResult> ECPresentationUtils::GetPagedDistinctValues(
 +---------------+---------------+---------------+---------------+---------------+------*/
 folly::Future<ECPresentationResult> ECPresentationUtils::GetDisplayLabel(ECPresentationManager& manager, ECDbR db, RapidJsonValueCR paramsJson)
     {
-    IConnectionCPtr connection = manager.GetConnections().GetConnection(db);
+    IConnectionCPtr connection = manager.GetConnections().CreateConnection(db);
     if (connection.IsNull())
         return folly::makeFutureWith([](){return ECPresentationResult(ECPresentationStatus::InvalidArgument, "db: not open");});
 
@@ -1779,7 +1783,7 @@ static ParseResult<int> ParseResultSetSizeFromJson(RapidJsonValueCR json)
 +---------------+---------------+---------------+---------------+---------------+------*/
 folly::Future<ECPresentationResult> ECPresentationUtils::CompareHierarchies(ECPresentationManager& manager, ECDbR db, RapidJsonValueCR paramsJson)
     {
-    IConnectionCPtr connection = manager.GetConnections().GetConnection(db);
+    IConnectionCPtr connection = manager.GetConnections().CreateConnection(db);
     if (connection.IsNull())
         return folly::makeFutureWith([](){return ECPresentationResult(ECPresentationStatus::InvalidArgument, "db: not open");});
 


### PR DESCRIPTION
- Before sending the response flush logs that accumulated while handling the request.
- Call `CreateConnection` within a diagnostics scope, otherwise some logs get lost.