### PR TITLE
Ignore subcategory for non-element geometry

### DIFF
--- a/iModelCore/iModelPlatform/DgnCore/SnapContext.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/SnapContext.cpp
@@ -2367,7 +2367,7 @@ void SnapContext::DoSnap(BeJsValue out, BeJsConst in, DgnDbR db, ICancellableR c
         if (nullptr != source)
             status = helper.GetClosestCurve(*source, haveSubCategory ? &subCategoryId : nullptr, haveGeomClass ? &geomClass : nullptr, haveGeomClass ? nullptr : &viewFlags, &cancel);
         else
-            status = helper.GetClosestCurve(foundNonElemGeom->second, db, haveSubCategory ? &subCategoryId : nullptr, haveGeomClass ? &geomClass : nullptr, haveGeomClass ? nullptr : &viewFlags, &cancel);
+            status = helper.GetClosestCurve(foundNonElemGeom->second, db, nullptr, nullptr, &viewFlags, &cancel);
 
         if (SnapStatus::Success != status)
             {


### PR DESCRIPTION
As the geometry stream is created from json as if it were a part, in order to not require a category, and parts don't support subcategory changes, it could result in decoration geometry that wasn't snappable. The supplier of the non-element geometry should only include geometry for the appropriate subcategory according to the HitDetail so there isn't any need for filtering on the backend.