### PR TITLE
CloudSQLite: Change permissions of directories created by the cloudsqlite daemon

### DIFF
--- a/iModelCore/BeSQLite/SQLite/blockcachevfsd.c
+++ b/iModelCore/BeSQLite/SQLite/blockcachevfsd.c
@@ -1551,7 +1551,7 @@ static void bcvCreateDir(int *pRc, BcvCommon *p, const char *zCont){
       "%s" BCV_PATH_SEPARATOR "%s", p->zDir, zCont
   );
   if( *pRc==SQLITE_OK && stat(zDir, &buf)<0 ){
-    if( osMkdir(zDir, 0755)<0 && stat(zDir, &buf)<0 ){
+    if( osMkdir(zDir, 0770)<0 && stat(zDir, &buf)<0 ){
       *pRc = SQLITE_CANTOPEN;
     }
   }


### PR DESCRIPTION
Currently backends are owner of all files listed in below screenshot:
![MicrosoftTeams-image (2)](https://github.com/iTwin/imodel-native/assets/22119573/b6b7d2af-976e-4931-871a-22ad119351a9)

with this PR: They will instead be owners of only the files in the red rectangle. Orchestrator team will do necessary work on their end to make sure of that. 

When we get to a point where all backends are on 4.x, then we can further restrict permissions so that backends only need read access to the imodelblocks-* folders. This is because we had an earlier update from SQLite team which makes it so backends no longer need to write to those folders. 