### PR TITLE
Call `onDisconnect` and `onDisconnected` from Cache::Destroy

### DIFF
--- a/iModelCore/BeSQLite/PublicAPI/BeSQLite/CloudSqlite.h
+++ b/iModelCore/BeSQLite/PublicAPI/BeSQLite/CloudSqlite.h
@@ -93,7 +93,7 @@ struct CloudContainer {
     bool m_isPublic = false;
 
     CloudContainer() {}
-    ~CloudContainer() { Disconnect(false); }
+    ~CloudContainer() { Disconnect(false, false); }
     CloudContainer(Utf8StringCR storageType, Utf8StringCR baseUri, Utf8StringCR containerId, Utf8StringCR alias, Utf8StringCR accessToken) :
         m_storageType(storageType), m_baseUri(baseUri), m_containerId(containerId), m_alias(alias), m_accessToken(accessToken) {}
 
@@ -105,14 +105,16 @@ struct CloudContainer {
             m_containerDb.CloseDb();
     }
 
+    virtual void OnDisconnect(bool isDetach) {}
+    virtual void OnDisconnected(bool isDetach) {}
+
     BE_SQLITE_EXPORT CloudResult Connect(CloudCache&);
-    BE_SQLITE_EXPORT CloudResult Disconnect(bool fromCacheDtor);
+    BE_SQLITE_EXPORT CloudResult Disconnect(bool isDetach, bool fromCacheDtor);
     BE_SQLITE_EXPORT CloudResult PollManifest();
     BE_SQLITE_EXPORT CloudResult UploadChanges();
     BE_SQLITE_EXPORT CloudResult RevertChanges();
     BE_SQLITE_EXPORT CloudResult CopyDatabase(Utf8StringCR dbFrom, Utf8StringCR dbTo);
     BE_SQLITE_EXPORT CloudResult DeleteDatabase(Utf8StringCR dbName);
-    BE_SQLITE_EXPORT CloudResult Detach();
 };
 
 /**


### PR DESCRIPTION
The JavaScript callbacks for containers weren't being called when containers are automatically disconnected by `CloudCache.destroy`. The symptom was that tests that clear an interval timer in `onDisconnected` hang for 5 seconds on exit with the message:

```cmd
ERROR: Handle leak detected. Node was still running 5 seconds after tests completed.
```