### PR TITLE
Presentation: Set serialized responses as `Napi::Buffer` to avoid copying native string to `Napi::String`

### DIFF
--- a/iModelJsNodeAddon/IModelJsNative.cpp
+++ b/iModelJsNodeAddon/IModelJsNative.cpp
@@ -4967,7 +4967,30 @@ struct NativeECPresentationManager : BeObjectWrap<NativeECPresentationManager>
         SET_CONSTRUCTOR(t);
         }
 
-    static Napi::Value CreateReturnValue(Napi::Env env, ECPresentationResult const& result, bool serializeResponse = false)
+    /*---------------------------------------------------------------------------------**//**
+    * @bsimethod
+    +---------------+---------------+---------------+---------------+---------------+------*/
+    static void SetSerializedResponse(Napi::Env env, BeJsNapiObject obj, Utf8CP memberName, Utf8StringR serializedResponse)
+        {
+        if (serializedResponse.empty())
+            {
+            obj[memberName] = "null";
+            return;
+            }
+
+        Utf8StringP strP = new Utf8String();
+        strP->swap(serializedResponse);
+        Napi::Value val = Napi::Buffer<Utf8Char>::New(env, strP->data(), strP->size(), [](Napi::Env, Utf8Char*, void* ptr)
+            {
+            delete reinterpret_cast<Utf8StringP>(ptr);
+            }, strP);
+        obj.AsNapiValueRef()->m_napiVal.As<Napi::Object>().Set(memberName, val);
+        }
+
+    /*---------------------------------------------------------------------------------**//**
+    * @bsimethod
+    +---------------+---------------+---------------+---------------+---------------+------*/
+    static Napi::Value CreateReturnValue(Napi::Env env, ECPresentationResult& result, bool serializeResponse = false)
         {
         BeJsNapiObject retVal(env);
         if (result.IsError())
@@ -4977,11 +5000,10 @@ struct NativeECPresentationManager : BeObjectWrap<NativeECPresentationManager>
             }
         else
             {
-            // rapidjson response
-            if (serializeResponse) {
-                auto str = result.GetSerializedSuccessResponse();
-                retVal["result"] = str.empty() ? "null" : str; // see note about null values for BeJsValue::Stringify
-            } else
+            // success
+            if (serializeResponse)
+                SetSerializedResponse(env, retVal, "result", result.GetSerializedSuccessResponse());
+            else
                 retVal["result"].From(result.GetSuccessResponse());
             }
 
@@ -5032,7 +5054,7 @@ struct NativeECPresentationManager : BeObjectWrap<NativeECPresentationManager>
         BeAssert(m_presentationManager == nullptr);
         }
 
-    Napi::Value CreateReturnValue(ECPresentationResult const& result, bool serializeResponse = false)
+    Napi::Value CreateReturnValue(ECPresentationResult&& result, bool serializeResponse = false)
         {
         return CreateReturnValue(Env(), result, serializeResponse);
         }
@@ -5040,11 +5062,11 @@ struct NativeECPresentationManager : BeObjectWrap<NativeECPresentationManager>
     void ResolvePromise(Napi::Promise::Deferred const& deferred, ECPresentationResult&& result)
         {
         std::shared_ptr<ECPresentationResult> resultPtr = std::make_shared<ECPresentationResult>(std::move(result));
-        m_threadSafeFunc.BlockingCall([this, resultPtr, deferred = std::move(deferred)](Napi::Env, Napi::Function)
+        m_threadSafeFunc.BlockingCall([this, resultPtr, deferred = std::move(deferred)](Napi::Env env, Napi::Function)
             {
             // flush all our logs that accumulated while handling the request
             s_jsLogger.FlushDeferred();
-            deferred.Resolve(CreateReturnValue(*resultPtr, true));
+            deferred.Resolve(CreateReturnValue(env, *resultPtr, true));
             });
         }
 
@@ -5177,28 +5199,28 @@ struct NativeECPresentationManager : BeObjectWrap<NativeECPresentationManager>
         {
         REQUIRE_ARGUMENT_STRING_ARRAY(0, directories);
         ECPresentationResult result = ECPresentationUtils::SetupRulesetDirectories(*m_presentationManager, directories);
-        return CreateReturnValue(result);
+        return CreateReturnValue(std::move(result));
         }
 
     Napi::Value SetupSupplementalRulesetDirectories(NapiInfoCR info)
         {
         REQUIRE_ARGUMENT_STRING_ARRAY(0, directories);
         ECPresentationResult result = ECPresentationUtils::SetupSupplementalRulesetDirectories(*m_presentationManager, directories);
-        return CreateReturnValue(result);
+        return CreateReturnValue(std::move(result));
         }
 
     Napi::Value GetRulesets(NapiInfoCR info)
         {
         REQUIRE_ARGUMENT_STRING(0, rulesetId);
         ECPresentationResult result = ECPresentationUtils::GetRulesets(*m_ruleSetLocater, rulesetId);
-        return CreateReturnValue(result, true);
+        return CreateReturnValue(std::move(result), true);
         }
 
     Napi::Value AddRuleset(NapiInfoCR info)
         {
         REQUIRE_ARGUMENT_STRING(0, rulesetJsonString);
         ECPresentationResult result = ECPresentationUtils::AddRuleset(*m_ruleSetLocater, rulesetJsonString);
-        return CreateReturnValue(result);
+        return CreateReturnValue(std::move(result));
         }
 
     Napi::Value RemoveRuleset(NapiInfoCR info)
@@ -5206,13 +5228,13 @@ struct NativeECPresentationManager : BeObjectWrap<NativeECPresentationManager>
         REQUIRE_ARGUMENT_STRING(0, rulesetId);
         REQUIRE_ARGUMENT_STRING(1, hash);
         ECPresentationResult result = ECPresentationUtils::RemoveRuleset(*m_ruleSetLocater, rulesetId, hash);
-        return CreateReturnValue(result);
+        return CreateReturnValue(std::move(result));
         }
 
     Napi::Value ClearRulesets(NapiInfoCR info)
         {
         ECPresentationResult result = ECPresentationUtils::ClearRulesets(*m_ruleSetLocater);
-        return CreateReturnValue(result);
+        return CreateReturnValue(std::move(result));
         }
 
     Napi::Value GetRulesetVariableValue(NapiInfoCR info)
@@ -5221,7 +5243,7 @@ struct NativeECPresentationManager : BeObjectWrap<NativeECPresentationManager>
         REQUIRE_ARGUMENT_STRING(1, variableId);
         REQUIRE_ARGUMENT_STRING(2, type);
         ECPresentationResult result = ECPresentationUtils::GetRulesetVariableValue(*m_presentationManager, rulesetId, variableId, type);
-        return CreateReturnValue(result);
+        return CreateReturnValue(std::move(result));
         }
 
     Napi::Value SetRulesetVariableValue(NapiInfoCR info)
@@ -5231,7 +5253,7 @@ struct NativeECPresentationManager : BeObjectWrap<NativeECPresentationManager>
         REQUIRE_ARGUMENT_STRING(2, variableType);
         REQUIRE_ARGUMENT_ANY_OBJ(3, value);
         ECPresentationResult result = ECPresentationUtils::SetRulesetVariableValue(*m_presentationManager, ruleSetId, variableId, variableType, value);
-        return CreateReturnValue(result);
+        return CreateReturnValue(std::move(result));
         }
 
     Napi::Value UnsetRulesetVariableValue(NapiInfoCR info)
@@ -5239,7 +5261,7 @@ struct NativeECPresentationManager : BeObjectWrap<NativeECPresentationManager>
         REQUIRE_ARGUMENT_STRING(0, ruleSetId);
         REQUIRE_ARGUMENT_STRING(1, variableId);
         ECPresentationResult result = ECPresentationUtils::UnsetRulesetVariableValue(*m_presentationManager, ruleSetId, variableId);
-        return CreateReturnValue(result);
+        return CreateReturnValue(std::move(result));
         }
 
     Napi::Value GetUpdateInfo(NapiInfoCR info)

--- a/iModelJsNodeAddon/IModelJsNative.cpp
+++ b/iModelJsNodeAddon/IModelJsNative.cpp
@@ -5062,7 +5062,7 @@ struct NativeECPresentationManager : BeObjectWrap<NativeECPresentationManager>
     void ResolvePromise(Napi::Promise::Deferred const& deferred, ECPresentationResult&& result)
         {
         std::shared_ptr<ECPresentationResult> resultPtr = std::make_shared<ECPresentationResult>(std::move(result));
-        m_threadSafeFunc.BlockingCall([this, resultPtr, deferred = std::move(deferred)](Napi::Env env, Napi::Function)
+        m_threadSafeFunc.BlockingCall([resultPtr, deferred = std::move(deferred)](Napi::Env env, Napi::Function)
             {
             // flush all our logs that accumulated while handling the request
             s_jsLogger.FlushDeferred();

--- a/iModelJsNodeAddon/api_package/ts/src/NativeLibrary.ts
+++ b/iModelJsNodeAddon/api_package/ts/src/NativeLibrary.ts
@@ -1200,7 +1200,7 @@ export declare namespace IModelJsNative {
     public addRuleset(serializedRuleset: string): ECPresentationManagerResponse<string>;
     public removeRuleset(rulesetId: string, hash: string): ECPresentationManagerResponse<boolean>;
     public clearRulesets(): ECPresentationManagerResponse<void>;
-    public handleRequest(db: DgnDb, options: string): { result: Promise<ECPresentationManagerResponse<string>>, cancel: () => void };
+    public handleRequest(db: DgnDb, options: string): { result: Promise<ECPresentationManagerResponse<Buffer>>, cancel: () => void };
     public getUpdateInfo(): ECPresentationManagerResponse<any>;
     public dispose(): void;
   }

--- a/iModelJsNodeAddon/presentation/ECPresentationUtils.cpp
+++ b/iModelJsNodeAddon/presentation/ECPresentationUtils.cpp
@@ -259,17 +259,18 @@ static std::map<std::pair<Utf8String, ECPresentation::UnitSystem>, std::shared_p
 /*---------------------------------------------------------------------------------**//**
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/
-Utf8StringCR ECPresentationResult::GetSerializedSuccessResponse() const
+void ECPresentationResult::SerializeSuccessResponse() const
     {
-    static Utf8String const s_empty;
     if (IsError())
-        return s_empty;
-
-    if (m_serializedSuccessResponse.empty())
         {
-        m_serializedSuccessResponse = m_successResponse.Stringify();
+        m_serializedSuccessResponse.clear();
+        return;
         }
-    return m_serializedSuccessResponse;
+
+    if (!m_serializedSuccessResponse.empty())
+        return;
+
+    m_serializedSuccessResponse = m_successResponse.Stringify();
     }
 
 /*---------------------------------------------------------------------------------**//**

--- a/iModelJsNodeAddon/presentation/ECPresentationUtils.h
+++ b/iModelJsNodeAddon/presentation/ECPresentationUtils.h
@@ -39,6 +39,9 @@ private:
     rapidjson::Document m_diagnostics;
     mutable Utf8String m_serializedSuccessResponse;
 
+private:
+    void SerializeSuccessResponse() const;
+
 public:
     //! Don't allow copying
     ECPresentationResult(ECPresentationResult const& other) = delete;
@@ -47,18 +50,18 @@ public:
     //! Create a success result with response
     ECPresentationResult(BeJsDocument&& successResponse, bool serializeResponse, rapidjson::Document&& diagnostics = rapidjson::Document())
         : m_status(ECPresentationStatus::Success), m_successResponse(std::move(successResponse)), m_diagnostics(std::move(diagnostics))
-    {
+        {
         if (serializeResponse)
-            GetSerializedSuccessResponse();
-    }
+            SerializeSuccessResponse();
+        }
     //! Create a success result with response
     ECPresentationResult(BeJsConst successResponse, bool serializeResponse, rapidjson::Document&& diagnostics = rapidjson::Document())
         : m_status(ECPresentationStatus::Success), m_diagnostics(std::move(diagnostics))
-    {
+        {
         m_successResponse.From(successResponse);
         if (serializeResponse)
-            GetSerializedSuccessResponse();
-    }
+            SerializeSuccessResponse();
+        }
     //! Create an error result
     ECPresentationResult(ECPresentationStatus errorCode, Utf8String message, rapidjson::Document&& diagnostics = rapidjson::Document())
         : m_status(errorCode), m_errorMessage(message), m_diagnostics(std::move(diagnostics))
@@ -85,7 +88,8 @@ public:
     Utf8StringCR GetErrorMessage() const {return m_errorMessage;}
     rapidjson::Document const& GetDiagnostics() const {return m_diagnostics;}
     BeJsConst GetSuccessResponse() const {return m_successResponse;}
-    Utf8StringCR GetSerializedSuccessResponse() const;
+    Utf8StringCR GetSerializedSuccessResponse() const {SerializeSuccessResponse(); return m_serializedSuccessResponse;}
+    Utf8StringR GetSerializedSuccessResponse() {SerializeSuccessResponse(); return m_serializedSuccessResponse;}
 };
 
 //=======================================================================================


### PR DESCRIPTION
Related to https://github.com/iTwin/imodel-native/issues/275. 

The change doesn't fix the problem altogether, but makes the request:
- fail instead of crashing the whole backend,
- require less peak memory,
- slightly quicker as we don't need to copy the string which may sometimes be massive (100+ MB).

The consolidated descriptor request will still fail for the iModel mentioned in the Sentry report due to massive amount of duplicated aspects in the iModel. The request is to load all properties of all aspects and the response is 700+ MB serialized JSON string. Node supports up to 512 MB strings and fails. 

itwinjs-core PR: https://github.com/iTwin/itwinjs-core/pull/5534
itwinjs-core: https://github.com/iTwin/itwinjs-core/tree/presentation/accept-buffer-responses-from-addon