### PR TITLE
Presentation: Avoid joining relationship if navigation property is available

### DIFF
--- a/iModelCore/ECPresentation/Source/Shared/Queries/PresentationQuery.cpp
+++ b/iModelCore/ECPresentation/Source/Shared/Queries/PresentationQuery.cpp
@@ -1324,7 +1324,7 @@ static QueryClauseAndBindings CreateJoinsClause(bvector<std::shared_ptr<JoinClau
                         joinedClassName = classWithRelationshipJoin->m_join.GetAlias();
                     joinClause.append(" ON ").append(Utf8PrintfString(joinedClassJoinClause.c_str(), joinedClassName.c_str(), classWithRelationshipJoin->m_using.GetAlias().c_str()));
                     joinClause.append(andJoinFilterClause);
-                    joinedRelationships.Insert(joinedClassName, relationshipJoinInfo);
+                    joinedRelationships.Insert(joinedClassName, joinedClassInfo);
                     prev = joinedClassInfo;
                     }
                 }


### PR DESCRIPTION
Closes: https://github.com/iTwin/imodel-native/issues/247

`ComplexQueryBuilderTests.ToString_OuterJoin_MultiClauses_WithRelationshipWithoutNavigationPropertiesAndWithMultiNavigationPropertiesInside` test describes the fix.

Before the fix we would have had this query string.
Before:
```
FROM ONLY [alias_schema_name].[A] [this]
LEFT JOIN (
    SELECT [rel_ab_alias].*
    FROM [alias_schema_name].[A_Has_B] [rel_ab_alias]
    INNER JOIN [alias_schema_name].[B] [b_alias] ON [b_alias].[ECInstanceId] = [rel_ab_alias].[TargetECInstanceId]
) [rel_ab_alias] ON [this].[ECInstanceId] = [rel_ab_alias].[SourceECInstanceId]
LEFT JOIN [alias_schema_name].[B] [b_alias] ON [b_alias].[ECInstanceId] = [rel_ab_alias].[TargetECInstanceId]
LEFT JOIN [alias_schema_name].[C] [c_alias] ON [c_alias].[ECInstanceId] = [b_alias].[C].[Id]
LEFT JOIN (
    SELECT [rel_bd_alias].*
    FROM [alias_schema_name].[B_Has_D] [rel_bd_alias]
    INNER JOIN [alias_schema_name].[D] [d_alias] ON [d_alias].[ECInstanceId] = [rel_bd_alias].[TargetECInstanceId]
) [rel_bd_alias] ON [rel_ab_alias].[TargetECInstanceId] = [rel_bd_alias].[SourceECInstanceId]
LEFT JOIN [alias_schema_name].[D] [d_alias] ON [d_alias].[ECInstanceId] = [rel_bd_alias].[TargetECInstanceId]
```
After:
```
FROM ONLY [alias_schema_name].[A] [this]
LEFT JOIN (
    SELECT [rel_ab_alias].*
    FROM [alias_schema_name].[A_Has_B] [rel_ab_alias]
    INNER JOIN [alias_schema_name].[B] [b_alias] ON [b_alias].[ECInstanceId] = [rel_ab_alias].[TargetECInstanceId]
) [rel_ab_alias] ON [this].[ECInstanceId] = [rel_ab_alias].[SourceECInstanceId]
LEFT JOIN [alias_schema_name].[B] [b_alias] ON [b_alias].[ECInstanceId] = [rel_ab_alias].[TargetECInstanceId]
LEFT JOIN [alias_schema_name].[C] [c_alias] ON [c_alias].[ECInstanceId] = [b_alias].[C].[Id]
LEFT JOIN [alias_schema_name].[D] [d_alias] ON [d_alias].[ECInstanceId] = [b_alias].[D].[Id]
```