### PR TITLE
Made BeVersion.FromString validation less strict

### DIFF
--- a/iModelCore/Bentley/PublicAPI/Bentley/BeVersion.h
+++ b/iModelCore/Bentley/PublicAPI/Bentley/BeVersion.h
@@ -89,7 +89,7 @@ public:
     //! Parses version string into a BeVersion.
     //! @param[in] versionStr Version string
     //! @param[in] format Format string. <b>Only %d is permitted as format specifier for the version digits.</b>
-    //! @return Success if 4 versions were parsed, Error otherwise
+    //! @return Success if at least one digit was matched, Error otherwise
     BentleyStatus FromString(Utf8CP versionStr, Utf8CP format = VERSION_PARSE_FORMAT)
         {
         int major = 0, minor = 0, sub1 = 0, sub2 = 0;

--- a/iModelCore/Bentley/PublicAPI/Bentley/BeVersion.h
+++ b/iModelCore/Bentley/PublicAPI/Bentley/BeVersion.h
@@ -94,13 +94,17 @@ public:
         {
         int major = 0, minor = 0, sub1 = 0, sub2 = 0;
         int result = Utf8String::Sscanf_safe(versionStr, format, &major, &minor, &sub1, &sub2);
-        if (result != 4)
-            return BentleyStatus::ERROR;
-        m_major = (uint16_t) (0xFFFF & major);
-        m_minor = (uint16_t) (0xFFFF & minor);
-        m_sub1 = (uint16_t) (0xFFFF & sub1);
-        m_sub2 = (uint16_t) (0xFFFF & sub2);
-        return BentleyStatus::SUCCESS;
+        if (result >= 1)
+            m_major = (uint16_t) (0xFFFF & major);
+        if (result >= 2)
+            m_minor = (uint16_t) (0xFFFF & minor);
+        if (result >= 3)
+            m_sub1 = (uint16_t) (0xFFFF & sub1);
+        if (result >= 4)
+            m_sub2 = (uint16_t) (0xFFFF & sub2);
+
+        //Even with a custom version string, we still require to match at least one digit.
+        return (result >= 1 ? BentleyStatus::SUCCESS : BentleyStatus::ERROR);
         }
     };
 

--- a/iModelCore/Bentley/Tests/NonPublished/VersionTests.cpp
+++ b/iModelCore/Bentley/Tests/NonPublished/VersionTests.cpp
@@ -257,3 +257,54 @@ TEST_F (VersionTests, OperatorGreaterOrEqual_Less_False)
     EXPECT_FALSE (BeVersion (1, 1, 1, 2) >= BeVersion (1, 1, 2, 1));
     EXPECT_FALSE (BeVersion (1, 1, 1, 1) >= BeVersion (1, 1, 1, 2));
     }
+
+/*---------------------------------------------------------------------------------**//**
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+TEST_F (VersionTests, FromString_NormalInput)
+    {
+    BeVersion version;
+    EXPECT_EQ (BentleyStatus::SUCCESS, version.FromString("{\"major\":3,\"minor\":1,\"sub1\":0,\"sub2\":2}"));
+    EXPECT_EQ (3, version.GetMajor());
+    EXPECT_EQ (1, version.GetMinor());
+    EXPECT_EQ (0, version.GetSub1());
+    EXPECT_EQ (2, version.GetSub2());
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+TEST_F (VersionTests, FromString_InvalidString)
+    {
+    BeVersion version;
+    EXPECT_EQ (BentleyStatus::ERROR, version.FromString("***THIS_IS_NO_VERSION***"));
+    EXPECT_EQ (0, version.GetMajor());
+    EXPECT_EQ (0, version.GetMinor());
+    EXPECT_EQ (0, version.GetSub1());
+    EXPECT_EQ (0, version.GetSub2());
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+TEST_F (VersionTests, FromString_LessDigits)
+    {
+    BeVersion version;
+    EXPECT_EQ (BentleyStatus::ERROR, version.FromString("02.05.01"));
+    EXPECT_EQ (2, version.GetMajor());
+    EXPECT_EQ (5, version.GetMinor());
+    EXPECT_EQ (1, version.GetSub1());
+    EXPECT_EQ (0, version.GetSub2());
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+TEST_F (VersionTests, FromString_WSClientCustomFormat)
+    {
+    BeVersion version("Bentley-WSG/5.1.2", "Bentley-WSG/%d.%d.%d.%d");
+    EXPECT_EQ (5, version.GetMajor());
+    EXPECT_EQ (1, version.GetMinor());
+    EXPECT_EQ (2, version.GetSub1());
+    EXPECT_EQ (0, version.GetSub2());
+    }

--- a/iModelCore/Bentley/Tests/NonPublished/VersionTests.cpp
+++ b/iModelCore/Bentley/Tests/NonPublished/VersionTests.cpp
@@ -264,7 +264,7 @@ TEST_F (VersionTests, OperatorGreaterOrEqual_Less_False)
 TEST_F (VersionTests, FromString_NormalInput)
     {
     BeVersion version;
-    EXPECT_EQ (BentleyStatus::SUCCESS, version.FromString("{\"major\":3,\"minor\":1,\"sub1\":0,\"sub2\":2}"));
+    EXPECT_EQ (BentleyStatus::SUCCESS, version.FromString("3.1.0.2"));
     EXPECT_EQ (3, version.GetMajor());
     EXPECT_EQ (1, version.GetMinor());
     EXPECT_EQ (0, version.GetSub1());
@@ -290,7 +290,7 @@ TEST_F (VersionTests, FromString_InvalidString)
 TEST_F (VersionTests, FromString_LessDigits)
     {
     BeVersion version;
-    EXPECT_EQ (BentleyStatus::ERROR, version.FromString("02.05.01"));
+    EXPECT_EQ (BentleyStatus::SUCCESS, version.FromString("02.05.01"));
     EXPECT_EQ (2, version.GetMajor());
     EXPECT_EQ (5, version.GetMinor());
     EXPECT_EQ (1, version.GetSub1());
@@ -307,4 +307,17 @@ TEST_F (VersionTests, FromString_WSClientCustomFormat)
     EXPECT_EQ (1, version.GetMinor());
     EXPECT_EQ (2, version.GetSub1());
     EXPECT_EQ (0, version.GetSub2());
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+TEST_F (VersionTests, FromString_ECDbCustomFormat)
+    {
+    BeVersion version;
+    EXPECT_EQ (BentleyStatus::SUCCESS, version.FromString("{\"major\":3,\"minor\":1,\"sub1\":0,\"sub2\":2}", "{\"major\":%d,\"minor\":%d,\"sub1\":%d,\"sub2\":%d}"));
+    EXPECT_EQ (3, version.GetMajor());
+    EXPECT_EQ (1, version.GetMinor());
+    EXPECT_EQ (0, version.GetSub1());
+    EXPECT_EQ (2, version.GetSub2());
     }


### PR DESCRIPTION
The validation was added in [PR#301](https://github.com/iTwin/imodel-native/pull/301) a day ago, before we did not validate the string at all.
But it turns out people use the method with and without custom format strings with less than 4 digits.
These changes should fix that scenario.
Also added tests.