### PR TITLE
Presentation: Failure to produce content when query contains classes with names from SQLite reserved keywords

### DIFF
--- a/iModelCore/ECPresentation/Source/Hierarchies/NavigationQueryContracts.cpp
+++ b/iModelCore/ECPresentation/Source/Hierarchies/NavigationQueryContracts.cpp
@@ -262,7 +262,7 @@ PresentationQueryBuilderPtr ECClassGroupingNodesQueryContract::CreateInstanceKey
     auto query = ComplexQueryBuilder::Create();
     query->SelectAll();
     query->From(*GetInstanceKeysSelectQuery().Clone());
-    query->Where(Utf8PrintfString("[%s] IS (%s%s)", ECClassIdFieldName, isPolymorphic ? "" : "ONLY ", ecClass.GetFullName()).c_str(), BoundQueryValuesList());
+    query->Where(Utf8PrintfString("[%s] IS (%s%s)", ECClassIdFieldName, isPolymorphic ? "" : "ONLY ", ecClass.GetECSqlName().c_str()).c_str(), BoundQueryValuesList());
     return query;
     }
 

--- a/iModelCore/ECPresentation/Source/Shared/ECSchemaHelper.cpp
+++ b/iModelCore/ECPresentation/Source/Shared/ECSchemaHelper.cpp
@@ -2188,7 +2188,7 @@ Nullable<uint64_t> ECSchemaHelper::QueryTargetsCount(RelatedClassPathCR path, In
         targetCountsQuery->Join(relatedInstancePath);
 
     if (!targetClass.IsSelectPolymorphic())
-        targetCountsQuery->Where(Utf8PrintfString("[%s].[ECClassId] IS (ONLY %s)", targetClass.GetAlias().c_str(), targetClass.GetClass().GetFullName()).c_str(), BoundQueryValuesList());
+        targetCountsQuery->Where(Utf8PrintfString("[%s].[ECClassId] IS (ONLY %s)", targetClass.GetAlias().c_str(), targetClass.GetClass().GetECSqlName().c_str()).c_str(), BoundQueryValuesList());
 
     if (sourceInstanceFilter)
         QueryBuilderHelpers::ApplyInstanceFilter(*targetCountsQuery, *sourceInstanceFilter);


### PR DESCRIPTION
Closes: https://github.com/iTwin/imodel-native/issues/299
itwinjs-core: https://github.com/iTwin/itwinjs-core/tree/presentation/query-contains-names-from-sqlite-keywords