### PR TITLE
Presentation: Diagnostic errors logged when using ContentModifier without a class attribute

### DIFF
--- a/iModelCore/ECPresentation/PublicAPI/ECPresentation/Rules/ContentModifier.h
+++ b/iModelCore/ECPresentation/PublicAPI/ECPresentation/Rules/ContentModifier.h
@@ -95,6 +95,7 @@ public:
 
     Utf8StringCR GetSchemaName() const {return m_schemaName;}
     Utf8StringCR GetClassName() const {return m_className;}
+    bool HasClassSpecified() const {return !m_schemaName.empty() || !m_className.empty();}
 
     RequiredSchemaSpecificationsList const& GetRequiredSchemaSpecifications() const {return m_requiredSchemas;}
     ECPRESENTATION_EXPORT void ClearRequiredSchemaSpecifications();

--- a/iModelCore/ECPresentation/Source/Content/ContentDescriptorBuilder.cpp
+++ b/iModelCore/ECPresentation/Source/Content/ContentDescriptorBuilder.cpp
@@ -1177,6 +1177,13 @@ private:
         size_t count = 0;
         for (ContentModifierCP modifier : GetContext().GetRulesPreprocessor().GetContentModifiers())
             {
+            if (!modifier->HasClassSpecified())
+                {
+                DIAGNOSTICS_DEV_LOG(DiagnosticsCategory::Content, LOG_DEBUG, Utf8PrintfString("ECClass was not specified in %s.",
+                    DiagnosticsHelpers::CreateRuleIdentifier(*modifier).c_str()));
+                continue;
+                }
+
             ECClassCP modifierClass = GetContext().GetSchemaHelper().GetECClass(modifier->GetSchemaName().c_str(), modifier->GetClassName().c_str());
             if (ecClass.Is(modifierClass) && (appender.IsDirectPropertiesAppender() || modifier->ShouldApplyOnNestedContent()))
                 {

--- a/iModelCore/ECPresentation/Source/Content/ContentSpecificationsHandler.cpp
+++ b/iModelCore/ECPresentation/Source/Content/ContentSpecificationsHandler.cpp
@@ -273,6 +273,13 @@ bvector<std::unique_ptr<FlattenedRelatedPropertiesSpecification>> FlattenedRelat
     bvector<std::unique_ptr<FlattenedRelatedPropertiesSpecification>> specs;
     for (ContentModifierCP modifier : modifiers)
         {
+        if (!modifier->HasClassSpecified())
+            {
+            DIAGNOSTICS_DEV_LOG(DiagnosticsCategory::Content, LOG_DEBUG, Utf8PrintfString("ECClass was not specified in %s.",
+                    DiagnosticsHelpers::CreateRuleIdentifier(*modifier).c_str()));
+            continue;
+            }
+
         ECClassCP modifierClass = helper.GetECClass(modifier->GetSchemaName().c_str(), modifier->GetClassName().c_str());
         if (modifierClass == nullptr)
             {
@@ -308,6 +315,13 @@ static bvector<std::unique_ptr<FlattenedRelatedPropertiesSpecification>> CreateF
             {
             if (nullptr == modifier || !modifier->ShouldApplyOnNestedContent())
                 continue;
+
+            if (!modifier->HasClassSpecified())
+                {
+                DIAGNOSTICS_DEV_LOG(DiagnosticsCategory::Content, LOG_DEBUG, Utf8PrintfString("ECClass was not specified in %s.",
+                    DiagnosticsHelpers::CreateRuleIdentifier(*modifier).c_str()));
+                continue;
+                }
 
             ECClassCP modifierClass = helper.GetECClass(modifier->GetSchemaName().c_str(), modifier->GetClassName().c_str());
             if (nullptr == modifierClass)
@@ -934,6 +948,13 @@ bvector<RuleApplicationInfo> const& ContentSpecificationsHandler::GetCustomizati
         auto infos = new bvector<RuleApplicationInfo>();
         for (ContentModifierCP modifier : GetContext().GetRulesPreprocessor().GetContentModifiers())
             {
+            if (!modifier->HasClassSpecified())
+                {
+                DIAGNOSTICS_DEV_LOG(DiagnosticsCategory::Content, LOG_DEBUG, Utf8PrintfString("ECClass was not specified in %s.",
+                    DiagnosticsHelpers::CreateRuleIdentifier(*modifier).c_str()));
+                continue;
+                }
+
             ECClassCP ecClass = GetContext().GetSchemaHelper().GetECClass(modifier->GetSchemaName().c_str(), modifier->GetClassName().c_str());
             if (nullptr == ecClass)
                 {


### PR DESCRIPTION
Closes: https://github.com/iTwin/imodel-native/issues/318
itwinjs-core: https://github.com/iTwin/itwinjs-core/tree/presentation/fix-diagnostic-errors