### PR TITLE
prevent heap corruption in mdlBspline_validateCurveKnots

### DIFF
--- a/iModelCore/GeomLibs/geom/src/bspline/bspmisc.cpp
+++ b/iModelCore/GeomLibs/geom/src/bspline/bspmisc.cpp
@@ -217,7 +217,7 @@ BsplineParam*   pParams         // <=> potentially modified only if poles given
             if (pKnots[i] - *pStart >= tol)
                 break;
 
-        for (i = numKnots - degree, nExcess1 = 0; i >= 0; i--, nExcess1++)
+        for (i = numKnots - pParams->order - 1, nExcess1 = 0; i >= 0; i--, nExcess1++)
             if (*pEnd - pKnots[i] >= tol)
                 break;
 


### PR DESCRIPTION
Fixes iTwin/imodel-native-internal#112

Add new test to verify fix (fails with old code).