### PR TITLE
Send element/model changed events from readonly briefcases 

### DIFF
--- a/iModelCore/BeSQLite/PublicAPI/BeSQLite/BeSQLite.h
+++ b/iModelCore/BeSQLite/PublicAPI/BeSQLite/BeSQLite.h
@@ -2578,8 +2578,7 @@ public:
 
         //! Sets a BusyRetry handler
         //! @param[in] retry A BusyRetry handler for the database connection. The BeSQLite::Db will hold a ref-counted-ptr to the retry object.
-        //!                  The default is to not attempt retries. Note, many BeSQLite applications (e.g. Bim) rely on a single non-shared connection
-        //!                  to the database and do not permit sharing.
+        //! The default is to not attempt retries.
         void SetBusyRetry(BusyRetry* retry) { m_busyRetry = retry; }
 
         //! Open the database as "immutable". This means that SQLite will not hold any locks on the file. Only use this if you're *sure* the

--- a/iModelCore/iModelPlatform/DgnCore/DgnDomain.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/DgnDomain.cpp
@@ -300,18 +300,17 @@ DgnDbStatus DgnDomain::RegisterHandler(Handler& handler, bool reregister)
 /*---------------------------------------------------------------------------------**//**
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/
-void DgnDomains::OnDbOpened()
-    {
-    if (m_dgndb.AreTxnsEnabled())
-        {
+void DgnDomains::OnDbOpened() {
+    if (m_dgndb.AreTxnsRequired()) {
         TxnManagerR txnManager = m_dgndb.Txns();
-        txnManager.EnableTracking(true);
+        if (!m_dgndb.IsReadonly())
+            txnManager.EnableTracking(true);
         txnManager.InitializeTableHandlers(); // Necessary to this after the domains are loaded so that the tables are already setup. The method calls SaveChanges().
-        }
+    }
 
     for (DgnDomainCP domain : m_domains)
         domain->_OnDgnDbOpened(m_dgndb);
-    }
+}
 
 /*---------------------------------------------------------------------------------**//**
 * @bsimethod

--- a/iModelCore/iModelPlatform/DgnCore/TxnManager.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/TxnManager.cpp
@@ -1640,7 +1640,10 @@ void TxnManager::ReplayExternalTxns(TxnId from) {
         ApplyTxnChanges(curr, TxnAction::Reinstate);
 
     m_curr = GetLastTxnId(); // this is where the other session ends
-    m_curr.Increment();
+    if (m_curr.GetValue() == 0)
+        m_curr = TxnId(SessionId(1),0);
+    else
+        m_curr.Increment();
 }
 
 /*---------------------------------------------------------------------------------**/ /**

--- a/iModelCore/iModelPlatform/DgnCore/TxnManager.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/TxnManager.cpp
@@ -287,17 +287,19 @@ bool TxnManager::HasPendingTxns() const {
     return stmt.Step() == BE_SQLITE_ROW;
 }
 
-/*---------------------------------------------------------------------------------**//**
- @bsimethod
-+---------------+---------------+---------------+---------------+---------------+------*/
-void TxnManager::Initialize() {
-    m_action = TxnAction::None;
+/** Get the highest used (not reversed) TxnId in the Txns table */
+TxnManager::TxnId TxnManager::GetLastTxnId() {
     Statement stmt(m_dgndb, "SELECT MAX(Id) FROM " DGN_TABLE_Txns " WHERE Deleted=0");
     DbResult result = stmt.Step();
     UNUSED_VARIABLE(result);
     BeAssert(result == BE_SQLITE_ROW);
 
-    TxnId last = stmt.GetValueInt64(0); // this is where we left off last session
+    return stmt.GetValueInt64(0);
+}
+
+void TxnManager::Initialize() {
+    m_action = TxnAction::None;
+    TxnId last = GetLastTxnId(); // this is where we left off last session
     m_curr = TxnId(SessionId(last.GetSession().GetValue()+1), 0); // increment the session id, reset to index to 0.
     m_reversedTxn.clear();
 }
@@ -322,12 +324,7 @@ TxnManager::TxnManager(DgnDbR dgndb) : m_dgndb(dgndb), m_stmts(20), m_rlt(*this)
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/
 DbResult TxnManager::InitializeTableHandlers() {
-    if (!m_isTracking) {
-        BeAssert(false && "Tracking must be enabled before initializing table handlers");
-        return BE_SQLITE_ERROR;
-    }
-
-    if (m_initTableHandlers || m_dgndb.IsReadonly())
+    if (m_initTableHandlers)
         return BE_SQLITE_OK;
 
     for (auto table : m_tables)
@@ -369,10 +366,7 @@ void TxnManager::BeginTrackingRelationship(ECN::ECClassCR relClass) {
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/
 void TxnManager::AddTxnTable(DgnDomain::TableHandler* tableHandler) {
-    if (m_dgndb.IsReadonly())
-        return;
-
-    // we can get called multiple times with the same tablehandler. Ignore all but the first one.
+    // we can get called multiple times with the same tableHandler. Ignore all but the first one.
     TxnTablePtr table = tableHandler->_Create(*this);
     if (m_tablesByName.Insert(table->_GetTableName(), table).second)
         m_tables.push_back(table.get()); // order matters for the calling sequence, so we have to store it both sorted by name and insertion order
@@ -1248,7 +1242,7 @@ DbResult TxnManager::ApplyChanges(ChangeStreamCR changeset, TxnAction action, bo
     }
 
 
-    if (true) {
+    if (!m_dgndb.IsReadonly()) {
         DisableTracking _v(*this);
         auto result = changeset.ApplyChanges(m_dgndb, rebase, invert); // this actually updates the database with the changes
         if (result != BE_SQLITE_OK) {
@@ -1494,7 +1488,7 @@ void TxnManager::ApplyTxnChanges(TxnId rowId, TxnAction action) {
     auto rc = ApplyChanges(changeset, action, false);
     BeAssert(!HasDataChanges());
 
-    if (BE_SQLITE_OK != rc)
+    if (BE_SQLITE_OK != rc || m_dgndb.IsReadonly())
         return;
 
     // Mark this row as deleted/undeleted depending on which way we just applied the changes.
@@ -1626,6 +1620,29 @@ DgnDbStatus TxnManager::ReverseAll() {
     return ReverseActions(TxnRange(startId, GetCurrentTxnId()));
 }
 
+/**
+ * For readonly connections, new Txns may be added from other writeable connections while this session is active.
+ * Since we always hold a SQLite transaction (the DefaultTxn) open, this session will not see any of
+ * those changes unless/until we explicitly close-and-restart the DefaultTxn.
+ *
+ * This method is called when the DefaultTxn is restarted and new Txns are discovered. It "replays" each new Txn in
+ * this session so that notifications for the changed elements/models can be sent for this connection as if the
+ * changes were just made. It calls `ApplyTxnChanges` but relies on the fact that the iModel is open for read and
+ * none of the changes are actually applied (they were applied in the connection where they were made.)
+ * This action is performed for "side effects" only. Of course since the connection is readonly, that's implied.
+ */
+void TxnManager::ReplayExternalTxns(TxnId from) {
+    if (!m_initTableHandlers || !m_dgndb.IsReadonly())
+        return; // this method can only be called on a readonly connection with the TxnManager active
+
+
+    for (TxnId curr = QueryNextTxnId(from); curr.IsValid(); curr = QueryNextTxnId(curr))
+        ApplyTxnChanges(curr, TxnAction::Reinstate);
+
+    m_curr = GetLastTxnId(); // this is where the other session ends
+    m_curr.Increment();
+}
+
 /*---------------------------------------------------------------------------------**/ /**
 * Reinstate ("redo") a range of transactions.
 * @bsimethod
@@ -1690,6 +1707,8 @@ void TxnManager::DeleteAllTxns() {
     m_dgndb.ExecuteSql("DELETE FROM " DGN_TABLE_Txns);
     if (m_dgndb.TableExists(DGN_TABLE_Rebase))
         m_dgndb.ExecuteSql("DELETE FROM " DGN_TABLE_Rebase);
+
+    m_dgndb.SaveChanges();
     Initialize();
 }
 

--- a/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/TxnManager.h
+++ b/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/TxnManager.h
@@ -593,6 +593,9 @@ public:
     //! All TxnIds with a value lower than this are from a previous session.
     TxnId GetSessionStartId() const {return TxnId(m_curr.GetSession(), 0);}
 
+    DGNPLATFORM_EXPORT TxnId GetLastTxnId();
+    DGNPLATFORM_EXPORT void ReplayExternalTxns(TxnId start);
+
     //! Given a TxnId, query for TxnId of the immediately previous committed Txn, if any.
     //! @param[in] currentTxnId The current TxnId.
     //! @return The previous TxnId. Will be invalid if currentTxnId is the first one.

--- a/iModelJsNodeAddon/IModelJsNative.cpp
+++ b/iModelJsNodeAddon/IModelJsNative.cpp
@@ -1007,6 +1007,15 @@ struct NativeDgnDb : BeObjectWrap<NativeDgnDb>, SQLiteOps
         OpenIModelDb(BeFileName(dbName), openParams);
     }
 
+    void RestartDefaultTxn(NapiInfoCR info) {
+        RequireDbIsOpen(info);
+        auto& db = GetDgnDb();
+        auto& txns = db.Txns();
+        auto last = txns.GetLastTxnId(); // save this before we restart
+        db.RestartDefaultTxn();
+        txns.ReplayExternalTxns(last); // if there were changes from other connections, replay their side effects for listeners
+    }
+
     void CreateIModel(NapiInfoCR info)  {
         REQUIRE_ARGUMENT_STRING(0, filename);
         REQUIRE_ARGUMENT_ANY_OBJ(1, props);


### PR DESCRIPTION
When there is a readonly connection to the same briefcase as a writeable briefcase, changes are not visible until a call to `restartDefaultTxn`. This PR adds logic to that method to read the new Txns and send the changed element/model events for the readonly connection as if they were made by it.

itwinjs-core: https://github.com/iTwin/itwinjs-core/tree/readonly-briefcases