### PR TITLE
Configurations to consume JpegTurbo and LibXml2 Components in iTwinNativeThirdParty

### DIFF
--- a/iModelCore/libsrc/libjpegturbo/BeLibJpegTurbo.mke
+++ b/iModelCore/libsrc/libjpegturbo/BeLibJpegTurbo.mke
@@ -502,3 +502,10 @@ CreateBuildContext:
 $(BuildContext)Delivery/jpeg-turbo-license.txt : $(turboJpegSrcDir)LICENSE.md
     $(LinkFirstDepToFirstTarget)
 
+%if defined(iTwinNativeThirdParty)
+    # If Windows platform, need to add nasm notice.
+    %if $(TARGET_PROCESSOR_ARCHITECTURE)=="x86" || $(TARGET_PROCESSOR_ARCHITECTURE)=="x64"
+        $(BuildContext)Delivery/nasm-license.txt : $(nasmBaseDir)LICENSE
+            $(LinkFirstDepToFirstTarget)
+    %endif
+%endif

--- a/iModelCore/libsrc/libxml2/BeLibxml2.mke
+++ b/iModelCore/libsrc/libxml2/BeLibxml2.mke
@@ -23,7 +23,13 @@ GCC_NOSTRICT = 1
 
 %include mdl.mki
 
-appName = iTwinLibxml2$(VC_Version)
+%if defined(iTwinNativeThirdParty)
+  dllPrefix = Be
+%else
+  dllPrefix = iTwin
+%endif
+
+appName = $(dllPrefix)Libxml2$(VC_Version)
 baseDir = $(_MakeFilePath)vendor/
 o = $(OutputRootDir)build/BeLibxml2/
 CCompPDBName = $(appName)
@@ -248,7 +254,7 @@ DLM_NO_BENTLEY_LIB = 1
     LINKER_LIBRARIES = ws2_32.lib
 %endif
 
-LINKER_LIBRARIES + $(BuildContext)SubParts/Libs/$(shlibprefix)iTwinIcu4c$(libext)
+LINKER_LIBRARIES + $(BuildContext)SubParts/Libs/$(shlibprefix)$(dllPrefix)Icu4c$(libext)
 
 DLM_CONTEXT_LOCATION = $(BuildContext)Delivery/
 DLM_LIB_CONTEXT_LOCATION = $(BuildContext)Delivery/


### PR DESCRIPTION
This upgrade allow us to consume relevant configurations of `JpegTurbo` and `LibXml2` components in iTwinNativeThirdParty. The reason of doing this upgrade is that now we want to consume the duplicate/similar components from a central location.