### PR TITLE
Presentation: Avoid determining children for parent node

### DIFF
--- a/iModelCore/ECPresentation/Source/PresentationManagerImpl.cpp
+++ b/iModelCore/ECPresentation/Source/PresentationManagerImpl.cpp
@@ -980,16 +980,6 @@ void RulesDrivenECPresentationManagerImpl::FinalizeNode(RequestWithRulesetImplPa
 /*---------------------------------------------------------------------------------**//**
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/
-NavNodePtr RulesDrivenECPresentationManagerImpl::FinalizeNode(RequestWithRulesetImplParams const& params, NavNodeCR node) const
-    {
-    NavNodePtr clone = node.Clone();
-    FinalizeNode(params, *clone);
-    return clone;
-    }
-
-/*---------------------------------------------------------------------------------**//**
-* @bsimethod
-+---------------+---------------+---------------+---------------+---------------+------*/
 std::unique_ptr<INodeInstanceKeysProvider> RulesDrivenECPresentationManagerImpl::_CreateNodeInstanceKeysProvider(NodeInstanceKeysRequestImplParams const& params) const
     {
     auto scope = Diagnostics::Scope::Create("Create nodes instance keys provider");
@@ -1212,10 +1202,13 @@ NavNodeCPtr RulesDrivenECPresentationManagerImpl::_GetParent(NodeParentRequestIm
     VALID_HIERARCHY_CACHE_PRECONDITION(cache, nullptr);
 
     auto node = cache->GetPhysicalParentNode(params.GetNode().GetNodeId(), params.GetRulesetVariables(), params.GetInstanceFilter().get());
-    if (node.IsValid())
-        FinalizeNode(RequestWithRulesetImplParams::Create(params), *node);
+    if (node.IsNull())
+        return nullptr;
 
-    return node;
+    NavNodePtr clone = node->Clone();
+    clone->SetHasChildren(true);
+    FinalizeNode(RequestWithRulesetImplParams::Create(params), *clone);
+    return clone;
     }
 
 /*---------------------------------------------------------------------------------**//**
@@ -1235,7 +1228,7 @@ void RulesDrivenECPresentationManagerImpl::TraverseHierarchy(HierarchyRequestImp
     NavNodesDataSourceCPtr nodes = GetCachedDataSource(*context, nullptr);
     if (nodes.IsValid())
         {
-        for (NavNodePtr node : *nodes)
+        for (auto const& node : *nodes)
             TraverseHierarchy(CreateHierarchyRequestParams(params, node.get()), cache);
         }
     }

--- a/iModelCore/ECPresentation/Source/PresentationManagerImpl.h
+++ b/iModelCore/ECPresentation/Source/PresentationManagerImpl.h
@@ -235,7 +235,6 @@ private:
     SpecificationContentProviderPtr GetContentProvider(IConnectionCR, ICancelationTokenCP, ContentProviderKey const&, RulesetVariables const& variables) const;
     SpecificationContentProviderPtr GetContentProvider(ContentRequestImplParams const&) const;
     void FinalizeNode(RequestWithRulesetImplParams const&, NavNodeR) const;
-    NavNodePtr FinalizeNode(RequestWithRulesetImplParams const&, NavNodeCR) const;
 
 protected:
     // ECPresentationManager::Impl: General


### PR DESCRIPTION
We just got the parent of specific child node, so we know that the parent has children - no need to determine that.