### PR TITLE
Presentation: Hierarchy filtering perf. improvements

### DIFF
--- a/iModelCore/ECPresentation/PublicAPI/ECPresentation/ECPresentationManagerRequestParams.h
+++ b/iModelCore/ECPresentation/PublicAPI/ECPresentation/ECPresentationManagerRequestParams.h
@@ -165,29 +165,6 @@ public:
 //=======================================================================================
 // @bsiclass
 //=======================================================================================
-struct NodeParentRequestParams : RequestWithRulesetParams
-{
-private:
-    NavNodeCPtr m_node;
-    std::shared_ptr<InstanceFilterDefinition const> m_instanceFilter;
-public:
-    NodeParentRequestParams(RequestWithRulesetParams const& rulesetParams, NavNodeCR node)
-        : RequestWithRulesetParams(rulesetParams), m_node(&node)
-        {}
-    NodeParentRequestParams(RequestWithRulesetParams&& rulesetParams, NavNodeCR node)
-        : RequestWithRulesetParams(std::move(rulesetParams)), m_node(&node)
-        {}
-    NodeParentRequestParams(Utf8String rulesetId, RulesetVariables rulesetVariables, NavNodeCR node)
-        : RequestWithRulesetParams(rulesetId, rulesetVariables), m_node(&node)
-        {}
-    NavNodeCR GetNode() const {return *m_node;}
-    std::shared_ptr<InstanceFilterDefinition const> GetInstanceFilter() const {return m_instanceFilter;}
-    void SetInstanceFilter(std::shared_ptr<InstanceFilterDefinition const> value) {m_instanceFilter = value;}
-};
-
-//=======================================================================================
-// @bsiclass
-//=======================================================================================
 struct NodePathFromInstanceKeyPathRequestParams : HierarchyRequestParams
 {
 private:

--- a/iModelCore/ECPresentation/PublicAPI/ECPresentation/NavNode.h
+++ b/iModelCore/ECPresentation/PublicAPI/ECPresentation/NavNode.h
@@ -139,6 +139,7 @@ public:
     //! Does the node support hierarchy level filtering.
     ECPRESENTATION_EXPORT bool SupportsFiltering() const;
     void SetSupportsFiltering(bool value) {m_supportsFiltering = value;}
+    bool IsFilteringSupportDetermined() const {return m_supportsFiltering.IsValid();}
 
     //! Get extended data injected into this node by API user
     ECPRESENTATION_EXPORT RapidJsonAccessor GetUsersExtendedData() const;

--- a/iModelCore/ECPresentation/Source/Hierarchies/NavNodeProviders.cpp
+++ b/iModelCore/ECPresentation/Source/Hierarchies/NavNodeProviders.cpp
@@ -808,6 +808,8 @@ void NodesFinalizer::DetermineChildren(NavNodeR node) const
 void NodesFinalizer::DetermineFilteringSupport(NavNodeR node) const
     {
     auto scope = Diagnostics::Scope::Create(Utf8PrintfString("Determine filtering support for %s", DiagnosticsHelpers::CreateNodeIdentifier(node).c_str()));
+    if (node.IsFilteringSupportDetermined())
+        return;
 
     NavNodesProviderContextPtr childrenContext = CreateContextForChildHierarchyLevel(*m_context, node);
     // we consider that this provider depends on a variable if we need the variable to determine

--- a/iModelCore/ECPresentation/Source/Hierarchies/NavNodeProviders.cpp
+++ b/iModelCore/ECPresentation/Source/Hierarchies/NavNodeProviders.cpp
@@ -234,6 +234,7 @@ NavNodesProviderContext::~NavNodesProviderContext()
 +---------------+---------------+---------------+---------------+---------------+------*/
 void NavNodesProviderContext::Init()
     {
+    m_ancestorContext = nullptr;
     m_isRootNodeContext = false;
     m_rootNodeRule = nullptr;
     m_isChildNodeContext = false;
@@ -270,6 +271,30 @@ bvector<RulesetVariableEntry> NavNodesProviderContext::GetRelatedRulesetVariable
     for (Utf8StringCR id : ids)
         idsWithValues.push_back(RulesetVariableEntry(id, GetRulesetVariables().GetJsonValue(id.c_str())));
     return idsWithValues;
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+bset<ArtifactsCapturer*> NavNodesProviderContext::GetArtifactsCapturers(bool onlyDirect) const
+    {
+    bset<ArtifactsCapturer*> result;
+    ContainerHelpers::Push(result, m_artifactsCapturers);
+    if (m_ancestorContext && !onlyDirect)
+        ContainerHelpers::MovePush(result, m_ancestorContext->GetArtifactsCapturers(false));
+    return result;
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+OptimizationFlagsContainer NavNodesProviderContext::GetMergedOptimizationFlags() const
+    {
+    OptimizationFlagsContainer merged;
+    merged.Merge(m_optFlags);
+    if (m_ancestorContext)
+        merged.Merge(m_ancestorContext->GetMergedOptimizationFlags());
+    return merged;
     }
 
 /*---------------------------------------------------------------------------------**//**
@@ -452,8 +477,7 @@ void NavNodesProvider::InitializeNodes()
 static NavNodesProviderContextPtr CreateContextForChildHierarchyLevel(NavNodesProviderContextCR ancestorContext, NavNodeCR parentNode)
     {
     NavNodesProviderContextPtr ctx = NavNodesProviderContext::Create(ancestorContext);
-    ctx->SetArtifactsCapturers(ancestorContext.GetArtifactsCapturers());
-    ctx->GetOptimizationFlags().SetParentContainer(&ancestorContext.GetOptimizationFlags());
+    ctx->SetAncestorContext(&ancestorContext);
     ctx->SetChildNodeContext(nullptr, parentNode);
     if (NodeVisibility::Virtual == ancestorContext.GetNodesCache().GetNodeVisibility(parentNode.GetNodeId(), ctx->GetRulesetVariables(), ctx->GetInstanceFilter()))
         ctx->SetPhysicalParentNode(ancestorContext.GetNodesCache().GetPhysicalParentNode(parentNode.GetNodeId(), ctx->GetRulesetVariables(), ctx->GetInstanceFilter()).get());
@@ -471,10 +495,9 @@ static NavNodesProviderContextPtr CreateContextForChildHierarchyLevel(NavNodesPr
 static NavNodesProviderContextPtr CreateContextForSameHierarchyLevel(NavNodesProviderContextCR baseContext, bset<Utf8String> const& usedVariableIds, bool copyNodesContext)
     {
     NavNodesProviderContextPtr ctx = NavNodesProviderContext::Create(baseContext);
+    ctx->SetAncestorContext(&baseContext);
     ctx->SetProvidersIndexAllocator(baseContext.GetProvidersIndexAllocator());
     ctx->SetMayHaveArtifacts(baseContext.MayHaveArtifacts());
-    ctx->SetArtifactsCapturers(baseContext.GetArtifactsCapturers());
-    ctx->GetOptimizationFlags().SetParentContainer(&baseContext.GetOptimizationFlags());
     ctx->InitUsedVariablesListener(usedVariableIds, &baseContext.GetUsedVariablesListener());
     ctx->SetRemovalId(baseContext.GetRemovalId());
 
@@ -635,7 +658,7 @@ CountInfo NavNodesProvider::GetTotalNodesCount() const
             m_cachedNodesCount = (size_t)cachedTotalNodesCount.Value();
             DIAGNOSTICS_DEV_LOG(DiagnosticsCategory::Hierarchies, LOG_TRACE, Utf8PrintfString("Nodes count found in persistent cache: %" PRIu64, m_cachedNodesCount.Value()));
             }
-        else if (GetContext().GetOptimizationFlags().GetMaxNodesToLoad() == 1)
+        else if (GetContext().GetMergedOptimizationFlags().GetMaxNodesToLoad() == 1)
             {
             // max nodes to load set to 1 means we're just checking whether provider returns any nodes - no need to
             // count anything...
@@ -902,14 +925,45 @@ bool NodesFinalizer::HasSimilarNodeInHierarchy(NavNodeCR node) const
     return HasSimilarNodeInHierarchy(node, -1);
     }
 
+/*=================================================================================**//**
+* @bsiclass
++===============+===============+===============+===============+===============+======*/
+struct NodesCreatingMultiNavNodesProvider::CreateNodeProviderContext
+{
+private:
+    NavNodeR m_node;
+    NavNodesProviderContextCR m_nodeContext;
+    NavNodesProviderPtr m_childrenProvider;
+public:
+    CreateNodeProviderContext(NavNodeR node, NavNodesProviderContextCR ctx) : m_node(node), m_nodeContext(ctx) {}
+    NavNodeR GetNode() {return m_node;}
+    NavNodesProviderContextCR GetNodeContext() const {return m_nodeContext;}
+    NavNodesProviderPtr GetChildrenProvider() const {return m_childrenProvider;}
+    void SetChildrenProvider(NavNodesProviderPtr provider) {m_childrenProvider = provider;}
+};
+
 /*---------------------------------------------------------------------------------**//**
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/
-void NodesCreatingMultiNavNodesProvider::EvaluateChildrenArtifacts(NavNodeR parentNode) const
+static NavNodesProviderPtr GetOrCreateChildrenProvider(NodesCreatingMultiNavNodesProvider::CreateNodeProviderContext& ctx)
     {
-    auto scope = Diagnostics::Scope::Create(Utf8PrintfString("%s: Evaluate children artifacts for %s", GetName(), DiagnosticsHelpers::CreateNodeIdentifier(parentNode).c_str()));
+    if (ctx.GetChildrenProvider().IsNull())
+        {
+        NavNodesProviderContextPtr childrenContext = CreateContextForChildHierarchyLevel(ctx.GetNodeContext(), ctx.GetNode());
+        NavNodesProviderPtr childrenProvider = ctx.GetNodeContext().CreateHierarchyLevelProvider(*childrenContext, &ctx.GetNode());
+        ctx.SetChildrenProvider(childrenProvider);
+        }
+    return ctx.GetChildrenProvider();
+    }
 
-    NavNodeExtendedData ext(parentNode);
+/*---------------------------------------------------------------------------------**//**
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+void NodesCreatingMultiNavNodesProvider::EvaluateChildrenArtifacts(CreateNodeProviderContext& nodeProviderContext) const
+    {
+    auto scope = Diagnostics::Scope::Create(Utf8PrintfString("%s: Evaluate children artifacts for %s", GetName(), DiagnosticsHelpers::CreateNodeIdentifier(nodeProviderContext.GetNode()).c_str()));
+
+    NavNodeExtendedData ext(nodeProviderContext.GetNode());
 
     if (!NeedsChildrenArtifactsDetermined(ext))
         return;
@@ -917,9 +971,8 @@ void NodesCreatingMultiNavNodesProvider::EvaluateChildrenArtifacts(NavNodeR pare
     if (ext.GetJson().HasMember(NAVNODE_EXTENDEDDATA_ChildrenArtifacts))
         return;
 
-    NavNodesProviderContextPtr childrenContext = CreateContextForChildHierarchyLevel(GetContext(), parentNode);
-    ChildrenArtifactsCaptureContext captureChildrenArtifacts(*childrenContext, parentNode);
-    NavNodesProviderPtr childrenProvider = GetContext().CreateHierarchyLevelProvider(*childrenContext, &parentNode);
+    auto childrenProvider = GetOrCreateChildrenProvider(nodeProviderContext);
+    ChildrenArtifactsCaptureContext captureChildrenArtifacts(childrenProvider->GetContextR(), nodeProviderContext.GetNode());
     DisabledFullNodesLoadContext disableFullLoad(*childrenProvider);
     DisabledPostProcessingContext disablePostProcessing(*childrenProvider);
     for (auto const node : *childrenProvider)
@@ -936,13 +989,14 @@ void NodesCreatingMultiNavNodesProvider::EvaluateThisNodeArtifacts(NavNodeCR nod
     if (!GetContext().MayHaveArtifacts())
         return;
 
-    if (GetContext().GetArtifactsCapturers().empty())
+    auto capturers = GetContext().GetArtifactsCapturers();
+    if (capturers.empty())
         return;
 
     NodeArtifacts artifacts = CustomizationHelper::EvaluateArtifacts(GetContext(), node);
     if (!artifacts.empty())
         {
-        for (ArtifactsCapturer* capturer : GetContext().GetArtifactsCapturers())
+        for (ArtifactsCapturer* capturer : capturers)
             capturer->AddArtifact(artifacts);
         }
     }
@@ -1000,8 +1054,9 @@ static bool ContainsOnlyNullOrEmptyStringValues(RapidJsonValueCR jsonArr)
 /*---------------------------------------------------------------------------------**//**
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/
-bool NodesCreatingMultiNavNodesProvider::ShouldReturnChildNodes(NavNodeR node) const
+bool NodesCreatingMultiNavNodesProvider::ShouldReturnChildNodes(CreateNodeProviderContext& nodeProviderContext) const
     {
+    NavNodeR node = nodeProviderContext.GetNode();
     auto scope = Diagnostics::Scope::Create(Utf8PrintfString("%s: Should return %s child nodes?", GetName(), DiagnosticsHelpers::CreateNodeIdentifier(node).c_str()));
 
     NavNodeExtendedData extendedData(node);
@@ -1043,7 +1098,7 @@ bool NodesCreatingMultiNavNodesProvider::ShouldReturnChildNodes(NavNodeR node) c
     // if the node has only one child and also has "hide if only one child" flag, we want to display that child
     if (extendedData.HideIfOnlyOneChild())
         {
-        NavNodesProviderPtr childrenProvider = GetContext().CreateHierarchyLevelProvider(*CreateContextForChildHierarchyLevel(GetContext(), node), &node);
+        NavNodesProviderPtr childrenProvider = GetOrCreateChildrenProvider(nodeProviderContext);
         MaxNodesToLoadContext maxNodesToLoad(*childrenProvider, 2);
         size_t childrenCount = childrenProvider->GetNodesCount();
         hasChildren = (childrenCount > 0) ? HASCHILDREN_True : HASCHILDREN_False;
@@ -1315,12 +1370,12 @@ void CachingNavNodesProviderBase<TProvider>::UpdateInitializedNodesState(DataSou
 /*---------------------------------------------------------------------------------**//**
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/
-NavNodesProviderPtr NodesCreatingMultiNavNodesProvider::CreateProvider(NavNodeR node) const
+NavNodesProviderPtr NodesCreatingMultiNavNodesProvider::CreateProvider(CreateNodeProviderContext& nodeProviderContext) const
     {
+    NavNodeR node = nodeProviderContext.GetNode();
     auto scope = Diagnostics::Scope::Create(Utf8PrintfString("%s: Create provider for %s", GetName(), DiagnosticsHelpers::CreateNodeIdentifier(node).c_str()));
 
     auto nodeContext = CreateContextForSameHierarchyLevel(GetContext(), GetContext().GetRelatedVariablesIds(), true);
-    auto childrenProviderContext = CreateContextForChildHierarchyLevel(GetContext(), node);
 
     NavNodeExtendedData extendedData(node);
     if (extendedData.IsNodeInitialized())
@@ -1328,7 +1383,7 @@ NavNodesProviderPtr NodesCreatingMultiNavNodesProvider::CreateProvider(NavNodeR 
         if (NodeVisibility::Virtual == GetContext().GetNodesCache().GetNodeVisibility(node.GetNodeId(), GetContext().GetRulesetVariables(), GetContext().GetInstanceFilter()))
             {
             DIAGNOSTICS_DEV_LOG(DiagnosticsCategory::Hierarchies, LOG_TRACE, "Node is already initialized and is virtual - returning children data provider for it.");
-            return GetContext().CreateHierarchyLevelProvider(*childrenProviderContext, &node);
+            return GetOrCreateChildrenProvider(nodeProviderContext);
             }
 
         DIAGNOSTICS_DEV_LOG(DiagnosticsCategory::Hierarchies, LOG_TRACE, "Node is already initialized and is not virtual - returning single node data provider for it.");
@@ -1340,10 +1395,11 @@ NavNodesProviderPtr NodesCreatingMultiNavNodesProvider::CreateProvider(NavNodeR 
     extendedData.SetNodeInitialized(true);
 
     // the specification may want to return node's children instead of the node itself
-    if (ShouldReturnChildNodes(node))
+    if (ShouldReturnChildNodes(nodeProviderContext))
         {
         DIAGNOSTICS_DEV_LOG(DiagnosticsCategory::Hierarchies, LOG_TRACE, "Should return node's children - marking virtual and returning children data provider.");
         GetContext().GetNodesCache().MakeVirtual(node.GetNodeId(), GetContext().GetRulesetVariables(), GetContext().GetInstanceFilter(), GetContext().GetResultSetSizeLimit());
+        auto childrenProviderContext = CreateContextForChildHierarchyLevel(GetContext(), node);
         childrenProviderContext->SetPhysicalParentNode(GetContext().GetNodesCache().GetPhysicalParentNode(node.GetNodeId(), GetContext().GetRulesetVariables(), GetContext().GetInstanceFilter()).get());
         return GetContext().CreateHierarchyLevelProvider(*childrenProviderContext, &node);
         }
@@ -2481,10 +2537,12 @@ NodesInitializationState NodesCreatingMultiNavNodesProvider::_InitializeNodes()
             }
 
         ++handledNodesCount;
+
+        CreateNodeProviderContext nodeProviderContext(*node, GetContext());
         if (!NavNodeExtendedData(*node).IsNodeInitialized())
             {
             GetContext().GetHierarchyLevelLocker().Lock();
-            EvaluateChildrenArtifacts(*node);
+            EvaluateChildrenArtifacts(nodeProviderContext);
             EvaluateThisNodeArtifacts(*node);
             }
 
@@ -2494,19 +2552,20 @@ NodesInitializationState NodesCreatingMultiNavNodesProvider::_InitializeNodes()
             provider = GetNodeProviders().at(providerIndex);
         if (provider.IsNull())
             {
-            provider = CreateProvider(*node);
+            provider = CreateProvider(nodeProviderContext);
             GetNodeProvidersR().push_back(provider);
             }
         pageOptionsSetter.Accept(*provider);
 
         providerIndex++;
 
-        if (!RequiresFullLoad() && GetContext().GetOptimizationFlags().GetMaxNodesToLoad() != 0)
+        auto optimizations = GetContext().GetMergedOptimizationFlags();
+        if (!RequiresFullLoad() && optimizations.GetMaxNodesToLoad() != 0)
             {
             // count nodes if optimization flags has max nodes count set
-            MaxNodesToLoadContext maxNodesToLoad(*provider, GetContext().GetOptimizationFlags().GetMaxNodesToLoad());
+            MaxNodesToLoadContext maxNodesToLoad(*provider, optimizations.GetMaxNodesToLoad());
             loadedNodesCount += provider->GetNodesCount();
-            if (GetContext().GetOptimizationFlags().GetMaxNodesToLoad() <= loadedNodesCount)
+            if (optimizations.GetMaxNodesToLoad() <= loadedNodesCount)
                 {
                 // found what we're looking for - no need to handle other nodes
                 DIAGNOSTICS_DEV_LOG(DiagnosticsCategory::Hierarchies, LOG_TRACE, Utf8PrintfString("Found provider with nodes while looking for children. Break at %" PRIu64 " after handling %" PRIu64 " / %" PRIu64 " nodes.",
@@ -2645,7 +2704,8 @@ CountInfo MultiNavNodesProvider::_GetTotalNodesCount() const
         isAccurate &= nestedCount.IsAccurate();
         count += nestedCount.GetCount();
 
-        if (!requiresFullLoad && GetContext().GetOptimizationFlags().GetMaxNodesToLoad() != 0 && GetContext().GetOptimizationFlags().GetMaxNodesToLoad() <= count)
+        auto optimizations = GetContext().GetMergedOptimizationFlags();
+        if (!requiresFullLoad && optimizations.GetMaxNodesToLoad() != 0 && optimizations.GetMaxNodesToLoad() <= count)
             return CountInfo(count, isAccurate && i == (m_providers.size() - 1));
         }
     return CountInfo(count, isAccurate);
@@ -2926,8 +2986,7 @@ NavNodesProviderPtr DisplayLabelGroupingNodesPostProcessor::_PostProcessProvider
 
     // return children of the grouping node
     auto childrenContext = CreateContextForChildHierarchyLevel(context, *node);
-    childrenContext->GetOptimizationFlags().From(OptimizationFlagsContainer());
-    childrenContext->GetOptimizationFlags().SetParentContainer(context.GetOptimizationFlags().GetParentContainer());
+    childrenContext->SetAncestorContext(context.GetAncestorContext());
     return context.CreateHierarchyLevelProvider(*childrenContext, (*iter).get());
     }
 
@@ -2985,7 +3044,7 @@ protected:
 
     Iterator _CreateFrontIterator() const override
         {
-        if (GetContext().GetOptimizationFlags().IsPostProcessingDisabled())
+        if (GetContext().GetMergedOptimizationFlags().IsPostProcessingDisabled())
             return T_Super::_CreateFrontIterator();
 
         InitSortedNodes();
@@ -2994,7 +3053,7 @@ protected:
 
     Iterator _CreateBackIterator() const override
         {
-        if (GetContext().GetOptimizationFlags().IsPostProcessingDisabled())
+        if (GetContext().GetMergedOptimizationFlags().IsPostProcessingDisabled())
             return T_Super::_CreateBackIterator();
 
         InitSortedNodes();
@@ -3118,7 +3177,7 @@ NavNodesProviderPtr DisplayLabelSortingPostProcessor::_PostProcessProvider(NavNo
     auto scope = Diagnostics::Scope::Create("Display label sorting post-processor: Post-process");
 
     NavNodesProviderContextCR context = processedProvider.GetContext();
-    if (context.GetOptimizationFlags().IsPostProcessingDisabled())
+    if (context.GetMergedOptimizationFlags().IsPostProcessingDisabled())
         {
         DIAGNOSTICS_DEV_LOG(DiagnosticsCategory::Hierarchies, LOG_TRACE, "Post-processing disabled");
         return nullptr;
@@ -3193,7 +3252,6 @@ NavNodesProviderPtr DisplayLabelSortingPostProcessor::_PostProcessProvider(NavNo
         }
 
     auto mergedProviderContext = CreateContextForSameHierarchyLevel(context, true);
-    mergedProviderContext->GetOptimizationFlags().SetParentContainer(nullptr);
     bvector<std::pair<NavNodesProviderPtr, bvector<uint64_t>>> mergedProviders;
     for (auto const& entry : providers)
         {
@@ -3258,7 +3316,7 @@ NavNodePtr NodesFinalizingProvider::NodesFinalizingIteratorImpl::_GetCurrent() c
 +---------------+---------------+---------------+---------------+---------------+------*/
 NavNodePtr NodesFinalizingProvider::FinalizeNode(NavNodeR node) const
     {
-    if (GetContext().GetOptimizationFlags().IsFullNodesLoadDisabled())
+    if (GetContext().GetMergedOptimizationFlags().IsFullNodesLoadDisabled())
         {
         DIAGNOSTICS_DEV_LOG(DiagnosticsCategory::Hierarchies, LOG_TRACE, "Full load disabled - return.");
         return &node;
@@ -3442,7 +3500,7 @@ NavNodesProviderPtr SameLabelGroupingNodesPostProcessorDeprecated::_PostProcess(
     {
     auto scope = Diagnostics::Scope::Create("Same label grouping nodes post-processor: Post-process");
 
-    if (processedProvider.GetContext().GetOptimizationFlags().IsPostProcessingDisabled())
+    if (processedProvider.GetContext().GetMergedOptimizationFlags().IsPostProcessingDisabled())
         {
         DIAGNOSTICS_DEV_LOG(DiagnosticsCategory::Hierarchies, LOG_TRACE, "Post-processing disabled");
         return nullptr;
@@ -3508,7 +3566,7 @@ NavNodesProviderPtr SameLabelGroupingNodesPostProcessorDeprecated::_PostProcess(
     DIAGNOSTICS_DEV_LOG(DiagnosticsCategory::Hierarchies, LOG_TRACE, "Cached merged provider");
     mergedDatasourceIdentifier = mergedDatasourceInfo.GetIdentifier();
 
-    MaxNodesToLoadContext disableMaxNodesToLoad(processedProvider, 0);
+    MaxNodesToLoadContext disableMaxNodesToLoad(processedProvider, (size_t)0);
     DisabledFullNodesLoadContext disableFullNodesLoad(processedProvider);
 
     size_t mergedNodesCount = 0;
@@ -3579,10 +3637,17 @@ NavNodesProviderPtr SameLabelGroupingNodesPostProcessorDeprecated::_PostProcess(
 /*---------------------------------------------------------------------------------**//**
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/
-static NavNodesProviderContextPtr CreatePostProcessingProviderContext(NavNodesProviderContextCR baseContext)
+static NavNodesProviderContextPtr CreatePostProcessingProviderContext(NavNodesProviderContextR baseContext)
     {
     NavNodesProviderContextPtr context = CreateContextForSameHierarchyLevel(baseContext, baseContext.GetRelatedVariablesIds(), true);
     context->SetVirtualParentNode(baseContext.GetVirtualParentNode().get());
+
+    context->SetAncestorContext(baseContext.GetAncestorContext());
+    baseContext.SetAncestorContext(context.get());
+
+    context->GetOptimizationFlags().From(baseContext.GetOptimizationFlags());
+    baseContext.GetOptimizationFlags().Reset();
+
     return context;
     }
 
@@ -3590,11 +3655,8 @@ static NavNodesProviderContextPtr CreatePostProcessingProviderContext(NavNodesPr
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/
 PostProcessingNodesProviderDeprecated::PostProcessingNodesProviderDeprecated(NavNodesProviderR wrappedProvider)
-    : MultiNavNodesProvider(*CreatePostProcessingProviderContext(wrappedProvider.GetContext())), m_wrappedProvider(&wrappedProvider), m_isPostProcessed(false)
+    : MultiNavNodesProvider(*CreatePostProcessingProviderContext(wrappedProvider.GetContextR())), m_wrappedProvider(&wrappedProvider), m_isPostProcessed(false)
     {
-    GetContextR().GetOptimizationFlags().From(wrappedProvider.GetContext().GetOptimizationFlags());
-    wrappedProvider.GetContextR().GetOptimizationFlags().From(OptimizationFlagsContainer());
-    wrappedProvider.GetContextR().GetOptimizationFlags().SetParentContainer(&GetContext().GetOptimizationFlags());
     }
 
 /*---------------------------------------------------------------------------------**//**
@@ -3880,7 +3942,7 @@ bool SQLiteCacheNodesProvider::_HasNodes() const
 
     // attempting to get nodes count from here may get us into infinite recursion if
     // this optimization flag is not reset
-    MaxNodesToLoadContext getValidCountContext(*this, 0);
+    MaxNodesToLoadContext getValidCountContext(*this, (size_t)0);
     return GetNodesCount() > 0;
     }
 

--- a/iModelCore/ECPresentation/Source/Hierarchies/NavNodesCache.h
+++ b/iModelCore/ECPresentation/Source/Hierarchies/NavNodesCache.h
@@ -456,7 +456,7 @@ protected:
     SqliteCacheDirectNodeIteratorBase(NavNodesProviderContextCR context, Db& db, StatementCache& statements, BeMutex& cacheMutex)
         : m_context(&context), m_db(db), m_statements(statements), m_cacheMutex(cacheMutex), m_pageSize(0), m_currNodeIndex(0)
         {
-        m_pageSize = m_context->GetOptimizationFlags().GetMaxNodesToLoad();
+        m_pageSize = m_context->GetMergedOptimizationFlags().GetMaxNodesToLoad();
         if (m_pageSize == 0 && m_context->HasPageOptions() && m_context->GetPageOptions()->HasSize())
             m_pageSize = m_context->GetPageOptions()->GetSize();
         }

--- a/iModelCore/ECPresentation/Source/Hierarchies/NodePathsHelper.h
+++ b/iModelCore/ECPresentation/Source/Hierarchies/NodePathsHelper.h
@@ -16,7 +16,8 @@ struct NodePathsHelper
 private:
     NodePathsHelper() {}
 public:
-    static bvector<NodesPathElement> CreateHierarchy(bvector<NavNodeCPtr> const& nodes, std::function<NavNodeCPtr(NavNodeCR)> const& parentGetter, Utf8StringCR matchText);
+    ECPRESENTATION_EXPORT static bvector<NodesPathElement> CreateHierarchy(bvector<NavNodeCPtr> const& nodes, std::function<NavNodeCPtr(NavNodeCR)> const& parentGetter, ICancelationTokenCP = nullptr);
+    static void CountHierarchyFilterOccurences(bvector<NodesPathElement>&, Utf8StringCR lowerCaseText, ICancelationTokenCP = nullptr);
     static bvector<NodesPathElement> MergePaths(std::vector<NodesPathElement>& paths, Nullable<size_t> const& markedIndex);
     static NodesPathElement CreateNodePath(ECPresentationManager::Impl&, NodePathFromInstanceKeyPathRequestImplParams const&);
 };

--- a/iModelCore/ECPresentation/Source/PresentationManagerImpl.cpp
+++ b/iModelCore/ECPresentation/Source/PresentationManagerImpl.cpp
@@ -19,6 +19,7 @@
 #include "Hierarchies/HierarchiesComparer.h"
 #include "Hierarchies/HierarchiesFiltering.h"
 #include "Hierarchies/NavNodesCacheWrapper.h"
+#include "Hierarchies/NodePathsHelper.h"
 #include "PresentationManagerImpl.h"
 #include "UpdateHandler.h"
 
@@ -1194,26 +1195,6 @@ ContentDescriptorCPtr RulesDrivenECPresentationManagerImpl::_GetNodesDescriptor(
 /*---------------------------------------------------------------------------------**//**
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/
-NavNodeCPtr RulesDrivenECPresentationManagerImpl::_GetParent(NodeParentRequestImplParams const& params)
-    {
-    auto scope = Diagnostics::Scope::Create(Utf8PrintfString("Get parent for node %s", DiagnosticsHelpers::CreateNodeIdentifier(params.GetNode()).c_str()));
-
-    std::shared_ptr<NodesCache> cache = m_nodesCachesManager->GetPersistentCache(params.GetConnection().GetId());
-    VALID_HIERARCHY_CACHE_PRECONDITION(cache, nullptr);
-
-    auto node = cache->GetPhysicalParentNode(params.GetNode().GetNodeId(), params.GetRulesetVariables(), params.GetInstanceFilter().get());
-    if (node.IsNull())
-        return nullptr;
-
-    NavNodePtr clone = node->Clone();
-    clone->SetHasChildren(true);
-    FinalizeNode(RequestWithRulesetImplParams::Create(params), *clone);
-    return clone;
-    }
-
-/*---------------------------------------------------------------------------------**//**
-* @bsimethod
-+---------------+---------------+---------------+---------------+---------------+------*/
 void RulesDrivenECPresentationManagerImpl::TraverseHierarchy(HierarchyRequestImplParams const& params, std::shared_ptr<INavNodesCache> cache) const
     {
     ThrowIfCancelled(params.GetCancellationToken());
@@ -1259,7 +1240,7 @@ bvector<NavNodeCPtr> RulesDrivenECPresentationManagerImpl::_GetFilteredNodes(Nod
         if (rootNodes.IsValid())
             {
             for (auto const& node : *rootNodes)
-                ;
+                ThrowIfCancelled(params.GetCancellationToken());
             }
         }
 
@@ -1293,6 +1274,7 @@ bvector<NavNodeCPtr> RulesDrivenECPresentationManagerImpl::_GetFilteredNodes(Nod
     DisabledFullNodesLoadContext disableFinalize(*filteredProvider);
     for (NavNodePtr node : *filteredProvider)
         {
+        ThrowIfCancelled(params.GetCancellationToken());
         NOT_NULL_PRECONDITION(node, "RulesDrivenECPresentationManagerImpl::_GetFilteredNodes");
 
         // we don't support hierarchy level filtering on top of filtered hierarchies - set the value before finalizing
@@ -1303,6 +1285,42 @@ bvector<NavNodeCPtr> RulesDrivenECPresentationManagerImpl::_GetFilteredNodes(Nod
         }
 
     return result;
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+bvector<NodesPathElement> RulesDrivenECPresentationManagerImpl::_CreateNodesHierarchy(CreateNodesHierarchyRequestImplParams const& params)
+    {
+    auto scope = Diagnostics::Scope::Create("Create nodes hierarchy");
+
+    std::shared_ptr<NodesCache> cache = m_nodesCachesManager->GetPersistentCache(params.GetConnection().GetId());
+    VALID_HIERARCHY_CACHE_PRECONDITION(cache, nullptr);
+
+    NavNodesProviderContextPtr context = CreateNodesProviderContext(CreateHierarchyRequestParams(params), cache);
+    if (context.IsNull())
+        {
+        DIAGNOSTICS_LOG(DiagnosticsCategory::Hierarchies, LOG_TRACE, LOG_WARNING, "Failed to create nodes context. Returning empty list.");
+        return {};
+        }
+
+    NodesFinalizer finalizer(*context);
+
+    auto parentGetter = [&](NavNodeCR child) -> NavNodeCPtr
+        {
+        auto parentNode = cache->GetPhysicalParentNode(child.GetNodeId(), context->GetRulesetVariables(), nullptr);
+        if (parentNode.IsNull())
+            return nullptr;
+
+        // no need to determine children for it since we know it's a "parent"
+        NavNodePtr clone = parentNode->Clone();
+        clone->SetHasChildren(true);
+        clone->SetSupportsFiltering(false);
+        finalizer.Finalize(*clone);
+
+        return clone;
+        };
+    return NodePathsHelper::CreateHierarchy(params.GetNodes(), parentGetter, params.GetCancellationToken());
     }
 
 /*=================================================================================**//**

--- a/iModelCore/ECPresentation/Source/PresentationManagerImpl.cpp
+++ b/iModelCore/ECPresentation/Source/PresentationManagerImpl.cpp
@@ -1240,7 +1240,10 @@ bvector<NavNodeCPtr> RulesDrivenECPresentationManagerImpl::_GetFilteredNodes(Nod
         if (rootNodes.IsValid())
             {
             for (auto const& node : *rootNodes)
+                {
+                (void)node;
                 ThrowIfCancelled(params.GetCancellationToken());
+                }
             }
         }
 

--- a/iModelCore/ECPresentation/Source/PresentationManagerImpl.h
+++ b/iModelCore/ECPresentation/Source/PresentationManagerImpl.h
@@ -84,12 +84,33 @@ public:
 };
 typedef ImplTaskParams<NodeInstanceKeysRequestParams> NodeInstanceKeysRequestImplParams;
 
+//=======================================================================================
+// @bsiclass
+//=======================================================================================
+struct CreateNodesHierarchyRequestParams : RequestWithRulesetParams
+{
+private:
+    bvector<NavNodeCPtr> m_nodes;
+public:
+    CreateNodesHierarchyRequestParams(RequestWithRulesetParams const& rulesetParams, bvector<NavNodeCPtr> nodes)
+        : RequestWithRulesetParams(rulesetParams), m_nodes(nodes)
+        {}
+    CreateNodesHierarchyRequestParams(RequestWithRulesetParams&& rulesetParams, bvector<NavNodeCPtr> nodes)
+        : RequestWithRulesetParams(std::move(rulesetParams)), m_nodes(nodes)
+        {}
+    CreateNodesHierarchyRequestParams(Utf8String rulesetId, RulesetVariables rulesetVariables, bvector<NavNodeCPtr> nodes)
+        : RequestWithRulesetParams(rulesetId, rulesetVariables), m_nodes(nodes)
+        {}
+    bvector<NavNodeCPtr> const& GetNodes() const {return m_nodes;}
+    void SetNodes(bvector<NavNodeCPtr> value) {m_nodes = value;}
+};
+typedef ImplTaskParams<CreateNodesHierarchyRequestParams> CreateNodesHierarchyRequestImplParams;
+
 typedef ImplTaskParams<RequestWithRulesetParams> RequestWithRulesetImplParams;
 
 typedef ImplTaskParams<HierarchyRequestParams> HierarchyRequestImplParams;
 typedef ImplTaskParams<HierarchyLevelDescriptorRequestParams> HierarchyLevelDescriptorRequestImplParams;
 typedef ImplTaskParams<NodeByInstanceKeyRequestParams> NodeByInstanceKeyRequestImplParams;
-typedef ImplTaskParams<NodeParentRequestParams> NodeParentRequestImplParams;
 typedef ImplTaskParams<NodePathFromInstanceKeyPathRequestParams> NodePathFromInstanceKeyPathRequestImplParams;
 typedef ImplTaskParams<NodePathsFromInstanceKeyPathsRequestParams> NodePathsFromInstanceKeyPathsRequestImplParams;
 typedef ImplTaskParams<NodePathsFromFilterTextRequestParams> NodePathsFromFilterTextRequestImplParams;
@@ -143,9 +164,9 @@ protected:
     virtual NavNodesDataSourcePtr _GetNodes(WithPageOptions<HierarchyRequestImplParams> const&) = 0;
     virtual size_t _GetNodesCount(HierarchyRequestImplParams const&) = 0;
     virtual ContentDescriptorCPtr _GetNodesDescriptor(HierarchyLevelDescriptorRequestImplParams const&) = 0;
-    virtual NavNodeCPtr _GetParent(NodeParentRequestImplParams const&) = 0;
     virtual bvector<NavNodeCPtr> _GetFilteredNodes(NodePathsFromFilterTextRequestImplParams const&) = 0;
     virtual HierarchyComparePositionPtr _CompareHierarchies(HierarchyCompareRequestImplParams const&) = 0;
+    virtual bvector<NodesPathElement> _CreateNodesHierarchy(CreateNodesHierarchyRequestImplParams const&) = 0;
 /** @} */
 
 /** @name Content */
@@ -177,9 +198,9 @@ public:
     NavNodesDataSourcePtr GetNodes(WithPageOptions<HierarchyRequestImplParams> const& params) {return _GetNodes(params);}
     size_t GetNodesCount(HierarchyRequestImplParams const& params) {return _GetNodesCount(params);}
     ContentDescriptorCPtr GetNodesDescriptor(HierarchyLevelDescriptorRequestImplParams const& params) {return _GetNodesDescriptor(params);}
-    NavNodeCPtr GetParent(NodeParentRequestImplParams const& params) {return _GetParent(params);}
     bvector<NavNodeCPtr> GetFilteredNodes(NodePathsFromFilterTextRequestImplParams const& params) {return _GetFilteredNodes(params);}
     HierarchyComparePositionPtr CompareHierarchies(HierarchyCompareRequestImplParams const& params) {return _CompareHierarchies(params);}
+    bvector<NodesPathElement> CreateNodesHierarchy(CreateNodesHierarchyRequestImplParams const& params) {return _CreateNodesHierarchy(params);}
 /** @} */
 
 /** @name Content */
@@ -266,9 +287,9 @@ protected:
     ECPRESENTATION_EXPORT NavNodesDataSourcePtr _GetNodes(WithPageOptions<HierarchyRequestImplParams> const&) override;
     ECPRESENTATION_EXPORT size_t _GetNodesCount(HierarchyRequestImplParams const&) override;
     ECPRESENTATION_EXPORT ContentDescriptorCPtr _GetNodesDescriptor(HierarchyLevelDescriptorRequestImplParams const&) override;
-    ECPRESENTATION_EXPORT NavNodeCPtr _GetParent(NodeParentRequestImplParams const&) override;
     ECPRESENTATION_EXPORT bvector<NavNodeCPtr> _GetFilteredNodes(NodePathsFromFilterTextRequestImplParams const&) override;
     ECPRESENTATION_EXPORT HierarchyComparePositionPtr _CompareHierarchies(HierarchyCompareRequestImplParams const&) override;
+    ECPRESENTATION_EXPORT bvector<NodesPathElement> _CreateNodesHierarchy(CreateNodesHierarchyRequestImplParams const&) override;
 
     // ECPresentationManager::Impl: Content
     ECPRESENTATION_EXPORT bvector<SelectClassInfo> _GetContentClasses(ContentClassesRequestImplParams const&) override;

--- a/iModelCore/ECPresentation/Tests/NonPublished/Helpers/StubRulesDrivenECPresentationManagerImpl.h
+++ b/iModelCore/ECPresentation/Tests/NonPublished/Helpers/StubRulesDrivenECPresentationManagerImpl.h
@@ -5,6 +5,7 @@
 #pragma once
 #include <UnitTests/ECPresentation/ECPresentationTest.h>
 #include "RulesDrivenECPresentationManagerImplBase.h"
+#include "../../../Source/Hierarchies/NodePathsHelper.h"
 
 BEGIN_ECPRESENTATIONTESTS_NAMESPACE
 
@@ -120,10 +121,13 @@ protected:
         {
         return nullptr;
         }
-    NavNodeCPtr _GetParent(NodeParentRequestImplParams const& params) override
+    bvector<NodesPathElement> _CreateNodesHierarchy(CreateNodesHierarchyRequestImplParams const& params) override
         {
-        auto iter = m_parentship.find(&params.GetNode());
-        return (m_parentship.end() != iter) ? iter->second : nullptr;
+        return NodePathsHelper::CreateHierarchy(params.GetNodes(), [&](NavNodeCR child)
+            {
+            auto iter = m_parentship.find(&child);
+            return iter != m_parentship.end() ? iter->second : nullptr;
+            }, params.GetCancellationToken());
         }
     bvector<NavNodeCPtr> _GetFilteredNodes(NodePathsFromFilterTextRequestImplParams const& params) override
         {

--- a/iModelCore/ECPresentation/Tests/NonPublished/Helpers/TestRulesDrivenECPresentationManagerImpl.h
+++ b/iModelCore/ECPresentation/Tests/NonPublished/Helpers/TestRulesDrivenECPresentationManagerImpl.h
@@ -19,7 +19,7 @@ struct TestRulesDrivenECPresentationManagerImpl : RulesDrivenECPresentationManag
 {
     typedef std::function<NavNodesDataSourcePtr(WithPageOptions<HierarchyRequestImplParams> const&)> Handler_GetNodes;
     typedef std::function<size_t(HierarchyRequestImplParams const&)> Handler_GetNodesCount;
-    typedef std::function<NavNodeCPtr(NodeParentRequestImplParams const&)> Handler_GetParent;
+    typedef std::function<bvector<NodesPathElement>(CreateNodesHierarchyRequestImplParams const&)> Handler_CreateNodesHierarchy;
     typedef std::function<bvector<NavNodeCPtr>(NodePathsFromFilterTextRequestImplParams const&)> Handler_GetFilteredNodes;
     typedef std::function<HierarchyComparePositionPtr(HierarchyCompareRequestImplParams const&)> Handler_CompareHierarchies;
 
@@ -37,7 +37,7 @@ struct TestRulesDrivenECPresentationManagerImpl : RulesDrivenECPresentationManag
 private:
     Handler_GetNodes m_nodesHandler;
     Handler_GetNodesCount m_nodesCountHandler;
-    Handler_GetParent m_getParentHandler;
+    Handler_CreateNodesHierarchy m_createNodesHierarchyHandler;
     Handler_GetFilteredNodes m_filteredNodesHandler;
 
     Handler_GetContentClasses m_contentClassesHandler;
@@ -70,11 +70,11 @@ protected:
         {
         return nullptr;
         }
-    NavNodeCPtr _GetParent(NodeParentRequestImplParams const& params) override
+    bvector<NodesPathElement> _CreateNodesHierarchy(CreateNodesHierarchyRequestImplParams const& params) override
         {
-        if (m_getParentHandler)
-            return m_getParentHandler(params);
-        return nullptr;
+        if (m_createNodesHierarchyHandler)
+            return m_createNodesHierarchyHandler(params);
+        return {};
         }
     bvector<NavNodeCPtr> _GetFilteredNodes(NodePathsFromFilterTextRequestImplParams const& params) override
         {
@@ -133,7 +133,7 @@ public:
 
     void SetNodesHandler(Handler_GetNodes handler) {m_nodesHandler = handler;}
     void SetNodesCountHandler(Handler_GetNodesCount handler) {m_nodesCountHandler = handler;}
-    void SetGetParentHandler(Handler_GetParent handler) {m_getParentHandler = handler;}
+    void SetCreateNodesHierarchyHandler(Handler_CreateNodesHierarchy handler) {m_createNodesHierarchyHandler = handler;}
     void SetGetFilteredNodesHandler(Handler_GetFilteredNodes handler) {m_filteredNodesHandler = handler;}
 
     void SetContentClassesHandler(Handler_GetContentClasses handler) {m_contentClassesHandler = handler;}

--- a/iModelCore/ECPresentation/Tests/NonPublished/Unit/Hierarchies/NodesProviderTests.cpp
+++ b/iModelCore/ECPresentation/Tests/NonPublished/Unit/Hierarchies/NodesProviderTests.cpp
@@ -462,8 +462,8 @@ TEST_F(MultiNavNodesProviderTests, RelatedRulesetVariables_CollectsRulesetVariab
     }
 
 #define EXPECT_OPTIMIZATION_FLAGS_ENABLED() \
-    EXPECT_TRUE(GetContext().GetOptimizationFlags().IsFullNodesLoadDisabled()); \
-    EXPECT_TRUE(GetContext().GetOptimizationFlags().IsPostProcessingDisabled());
+    EXPECT_TRUE(GetContext().GetMergedOptimizationFlags().IsFullNodesLoadDisabled()); \
+    EXPECT_TRUE(GetContext().GetMergedOptimizationFlags().IsPostProcessingDisabled());
 
 /*=================================================================================**//**
 * @bsiclass
@@ -506,7 +506,7 @@ public:
     static RefCountedPtr<OptimizationFlagsTestingProvider> Create(NavNodesProviderContextR context, NavNodeP node)
         {
         auto myContext = NavNodesProviderContext::Create(context);
-        myContext->GetOptimizationFlags().SetParentContainer(&context.GetOptimizationFlags());
+        myContext->SetAncestorContext(&context);
         return new OptimizationFlagsTestingProvider(*myContext, node);
         }
 };


### PR DESCRIPTION
Filtered models tree filtering performance on a specific test iModel (17 GB, lots of Subjects & Models, 1281 nodes in filtered hierarchy):

| | 4.0.12 | before this PR | after this PR |
| --- | --- | --- | --- |
| Initial filter | 59.453 s | 47.179 s | 44.385 s |
| Subsequent filters | 3.671 s | 2.277 s | 1.429 s |

Not sure if we can squeeze anything more from this...

itwinjs-core PR: https://github.com/iTwin/itwinjs-core/pull/5767
itwinjs-core: https://github.com/iTwin/itwinjs-core/tree/presentation/update-snapshots-after-filtering-changes