### PR TITLE
Revert "Let clients of the daemon work with readonly perms to cloudca…

### DIFF
--- a/iModelCore/BeSQLite/SQLite/bcv_int.h
+++ b/iModelCore/BeSQLite/SQLite/bcv_int.h
@@ -19,7 +19,6 @@ typedef sqlite3_int64 i64;
 typedef sqlite3_uint64 u64;
 typedef unsigned char u8;
 typedef unsigned int u32;
-typedef unsigned short u16;
 
 #ifdef __WIN32__
 # include <winsock2.h>
@@ -404,8 +403,6 @@ void bcvfsUnusedAdd(BcvCommon *p, CacheEntry *pEntry);
 void bcvfsLruAddIf(BcvCommon *p, CacheEntry *pEntry);
 int bcvfsNameToBlockid(Manifest *p, const char *zName, u8 *aBlk);
 u8 *bcvEmptyKV(int *pRc, int *pnData);
-
-int bcvfsCreateLocalDb(BcvCommon*, const char*, const char*, sqlite3_file**);
 
 /*
 ** Below here should be eventually moved back to blockcachevfsd. 

--- a/iModelCore/BeSQLite/SQLite/blockcachevfs.c
+++ b/iModelCore/BeSQLite/SQLite/blockcachevfs.c
@@ -176,7 +176,6 @@ struct BcvfsFile {
   Manifest *pMan;                 /* When transaction is open, manifest */
   ManifestDb *pManDb;             /* When transaction is open, manifest-db */
   u32 lockMask;                   /* Mask of shm-locks currently held */
-  int eLock;                      /* Legacy lock held */
   int bHoldCkpt;                  /* True to not release CHECKPOINTER lock */
 
   BcvKVStore kv;
@@ -1728,7 +1727,7 @@ static int bcvfsProxyRead(
   u32 iCache = 0;
   i64 iCacheOffset = 0;
 
-  if( pFile->eLock==0 ){
+  if( pFile->lockMask==0 ){
     assert( iAmt==100 );
     memset(pBuf, 0, iAmt);
     return SQLITE_OK;
@@ -1933,7 +1932,7 @@ static void bcvfsFileCacheFreeIf(BcvfsFile *pFile){
 
 static int bcvfsLock(sqlite3_file *pFd, int eLock){
   BcvfsFile *pFile = (BcvfsFile*)pFd;
-  pFile->eLock = eLock;
+  pFile->lockMask = eLock;
   if( bcvfsFileType(pFile)==BCVFS_NO_FILE ){
     return SQLITE_OK;
   }
@@ -1941,7 +1940,7 @@ static int bcvfsLock(sqlite3_file *pFd, int eLock){
 }
 static int bcvfsUnlock(sqlite3_file *pFd, int eLock){
   BcvfsFile *pFile = (BcvfsFile*)pFd;
-  pFile->eLock = eLock;
+  pFile->lockMask = eLock;
   bcvfsFileCacheFreeIf(pFile);
   if( bcvfsFileType(pFile)==BCVFS_NO_FILE ){
     return SQLITE_OK;
@@ -2335,128 +2334,16 @@ static void bcvBufferAppendEscaped(int *pRc, BcvBuffer *pBuf, const char *zStr){
 ** pPath. The caller is responsible for ensuring that the returned buffer
 ** is eventually freed using sqlite3_free().
 */
-static char *bcvfsLocalPath(
-  int *pRc, 
-  sqlite3_bcvfs *pFs, 
-  BcvDbPath *pPath,
-  int bReadonlyShm
-){
+static char *bcvfsLocalPath(int *pRc, sqlite3_bcvfs *pFs, BcvDbPath *pPath){
   BcvBuffer b = {0,0,0};
   bcvBufferAppendString(pRc, &b, pFs->c.zDir);
   bcvBufferAppendString(pRc, &b, BCV_PATH_SEPARATOR);
   bcvBufferAppendEscaped(pRc, &b, pPath->zContainer);
   bcvBufferAppendString(pRc, &b, BCV_PATH_SEPARATOR);
   bcvBufferAppendEscaped(pRc, &b, pPath->zDatabase);
-  if( bReadonlyShm ){
-    bcvBufferAppendRc(pRc, &b, "\0", 1);
-    bcvBufferAppendString(pRc, &b, "readonly_shm");
-    bcvBufferAppendRc(pRc, &b, "\0", 1);
-    bcvBufferAppendString(pRc, &b, "1");
-  }
   bcvBufferAppendRc(pRc, &b, "\0\0", 2);
   assert( *pRc==SQLITE_OK || b.aData==0 );
   return (char*)b.aData;
-}
-
-/*
-** This structure exactly matches the definition of WalIndexHdr in
-** SQLite core file wal.c. It is used by bcvfsEmptyWalIndexHdr() to
-** generate valid wal-index headers that correspond to empty wal files.
-*/
-typedef struct BcvfsWalIndexHdr BcvfsWalIndexHdr;
-struct BcvfsWalIndexHdr {
-  u32 iVersion;                   /* Wal-index version */
-  u32 unused;                     /* Unused (padding) field */
-  u32 iChange;                    /* Counter incremented each transaction */
-  u8 isInit;                      /* 1 when initialized */
-  u8 bigEndCksum;                 /* True if checksums in WAL are big-endian */
-  u16 szPage;                     /* Database page size in bytes. 1==64K */
-  u32 mxFrame;                    /* Index of last valid frame in the WAL */
-  u32 nPage;                      /* Size of database in pages */
-  u32 aFrameCksum[2];             /* Checksum of last frame in log */
-  u32 aSalt[2];                   /* Two salt values copied from WAL header */
-  u32 aCksum[2];                  /* Checksum over all prior fields */
-};
-
-/*
-** Write a valid wal-index header into the buffer passed as the only
-** argument. The header:
-**
-**   *  corresponds to an empty wal file - one with zero frames, and
-**
-**   *  sets the change-counter to a random value to ensure any 
-**      existing users purge their page caches when they read the new
-**      header.
-*/
-static void bcvfsEmptyWalIndexHdr(volatile void *aMap){
-  BcvfsWalIndexHdr hdr;
-  u32 s1 = 0;
-  u32 s2 = 0;
-
-  u32 *aData = (u32*)&hdr;
-  u32 *aEnd = (u32*)&hdr.aCksum[0];
-
-  memset(&hdr, 0, sizeof(hdr));
-  hdr.iVersion = 3007000;
-  hdr.isInit = 1;
-  sqlite3_randomness(sizeof(u32)*2, (void*)&hdr.unused);
-  do {
-    s1 += *aData++ + s2;
-    s2 += *aData++ + s1;
-  }while( aData<aEnd );
-  hdr.aCksum[0] = s1;
-  hdr.aCksum[1] = s2;
-
-  memcpy(&((u8*)aMap)[0 * sizeof(hdr)], &hdr, sizeof(hdr));
-  memcpy(&((u8*)aMap)[1 * sizeof(hdr)], &hdr, sizeof(hdr));
-  memset(&((u8*)aMap)[2 * sizeof(hdr)], 0, 512);
-}
-
-/*
-** Create database and shm files for database zCont/zDb. If successful,
-** open a file-descriptor on the database and hold the DMS lock on the shm
-** file. Return the file-descriptor to the caller via *ppFd.
-**
-** Otherwise, if an error occurs, return an SQLite error code and set *ppFd
-** to NULL.
-*/
-int bcvfsCreateLocalDb(
-  BcvCommon *p,
-  const char *zCont,
-  const char *zDb,
-  sqlite3_file **ppFd
-){
-  sqlite3_file *pFd = 0;
-  int rc = SQLITE_OK;
-  volatile void *aMap = 0;
-
-  BcvBuffer b = {0,0,0};
-  bcvBufferAppendString(&rc, &b, p->zDir);
-  bcvBufferAppendString(&rc, &b, BCV_PATH_SEPARATOR);
-  bcvBufferAppendEscaped(&rc, &b, zCont);
-  bcvBufferAppendString(&rc, &b, BCV_PATH_SEPARATOR);
-  bcvBufferAppendEscaped(&rc, &b, zDb);
-
-  if( rc==SQLITE_OK ){
-    rc = bcvOpenLocal((const char*)b.aData, 0, 0, &pFd);
-  }
-  if( rc==SQLITE_OK ){
-    rc = pFd->pMethods->xWrite(pFd, (void*)"daemon", 5, 0);
-  }
-  if( rc==SQLITE_OK ){
-    rc = pFd->pMethods->xShmMap(pFd, 0, 32*1024, 1, (volatile void**)&aMap); 
-    if( rc==SQLITE_OK ){
-      bcvfsEmptyWalIndexHdr(aMap);
-    }
-  }
-
-  if( rc==SQLITE_OK ){
-    *ppFd = pFd;
-  }else{
-    bcvCloseLocal(pFd);
-  }
-  bcvBufferZero(&b);
-  return rc;
 }
 
 /*
@@ -2651,12 +2538,8 @@ int bcvManifestUpdate(
               bFail = 1;
             }else{
               pWrapper->bUnlock = 1;
-              if( pCommon->bDaemon ){
-                bcvfsEmptyWalIndexHdr(aMap);
-              }else{
-                memset(aMap, 0, 24);
-                rc = bcvfsWalNonEmpty(pCommon, zWal, &bFail);
-              }
+              memset(aMap, 0, 24);
+              rc = bcvfsWalNonEmpty(pCommon, zWal, &bFail);
             }
           }
         }
@@ -2937,11 +2820,7 @@ static int bcvfsShmMap(
   void volatile **pp
 ){
   BcvfsFile *pFile = (BcvfsFile*)pFd;
-  int rc = pFile->pFile->pMethods->xShmMap(pFile->pFile, iPg, pgsz, eMode, pp);
-  if( pFile->pFs->zPortnumber && rc==SQLITE_READONLY_CANTINIT ){
-    rc = SQLITE_READONLY;
-  }
-  return rc;
+  return pFile->pFile->pMethods->xShmMap(pFile->pFile, iPg, pgsz, eMode, pp);
 }
 
 static int bcvfsShmLock(sqlite3_file *pFd, int offset, int n, int flags){
@@ -3307,31 +3186,24 @@ static int bcvfsOpen(
     }
 
     if( rc==SQLITE_OK ){
-      int bDaemon = pFs->zPortnumber!=0;
       sqlite3_vfs *pVfs = pFs->c.pVfs;
       if( pPath->zDatabase ){
-        char *zLocal = bcvfsLocalPath(&rc, pFs, pPath, bDaemon);
+        char *zLocal = bcvfsLocalPath(&rc, pFs, pPath);
         if( rc==SQLITE_OK ){
-          sqlite3_file *pFile = pRet->pFile;
           int fout = 0;
-          int f = flags | SQLITE_OPEN_URI;
-          if( pFs->zPortnumber==0 ){
-            f |= SQLITE_OPEN_READWRITE|SQLITE_OPEN_CREATE;
-            f &= ~SQLITE_OPEN_READONLY;
+          int f = (flags & ~SQLITE_OPEN_READONLY);
+          f |= SQLITE_OPEN_READWRITE|SQLITE_OPEN_CREATE;
+          rc = pVfs->xOpen(pVfs, zLocal, pRet->pFile, f, &fout);
+          if( rc==SQLITE_OK && bIsMain ){
+            rc = pRet->pFile->pMethods->xWrite(pRet->pFile,(void*)"bcvfs",5,0);
           }
-          rc = pVfs->xOpen(pVfs, zLocal, pFile, f, &fout);
-          if( rc==SQLITE_OK && pFs->zPortnumber==0 ){
-            if( bIsMain ){
-              rc = pFile->pMethods->xWrite(pFile, (void*)"bcvfs", 5, 0);
-            }
-            if( flags & SQLITE_OPEN_READONLY ){
-              fout &= ~(SQLITE_OPEN_READWRITE|SQLITE_OPEN_CREATE);
-              fout |= SQLITE_OPEN_READONLY;
-            }
+          if( flags & SQLITE_OPEN_READONLY ){
+            fout &= ~(SQLITE_OPEN_READWRITE|SQLITE_OPEN_CREATE);
+            fout |= SQLITE_OPEN_READONLY;
           }
           *pOutFlags = fout;
           if( rc==SQLITE_OK && bIsMain ){
-            rc = bcvOpenLocal(pFs->zCacheFile, 0, bDaemon, &pRet->pCacheFile);
+            rc = bcvOpenLocal(pFs->zCacheFile, 0, 0, &pRet->pCacheFile);
           }
           pRet->pPath = pPath;
           pRet->zLocalPath = zLocal;
@@ -3363,7 +3235,7 @@ static int bcvfsDelete(sqlite3_vfs *pVfs, const char *zPath, int dirSync){
 
   rc = bcvfsDecodeName(pFs, zPath, &pPath);
   if( rc==SQLITE_OK && pPath->zDatabase ){
-    char *zLocal = bcvfsLocalPath(&rc, pFs, pPath, 0);
+    char *zLocal = bcvfsLocalPath(&rc, pFs, pPath);
     if( rc==SQLITE_OK ){
       rc = pFs->c.pVfs->xDelete(pFs->c.pVfs, zLocal, dirSync);
       sqlite3_free(zLocal);
@@ -7073,6 +6945,7 @@ static int bcvKVStoreLoad(bcv_kv_vtab *pTab){
   BcvfsFile *pFile = pTab->pFile;
   int rc = SQLITE_OK;
 
+  assert( pFile->lockMask!=0 );
   if( pFile->kv.db==0 ){
     sqlite3_bcvfs *pFs = pFile->pFs;
     BcvContainer *pBcv = 0;
@@ -7132,6 +7005,7 @@ static int bcvKVStorePush(bcv_kv_vtab *pTab){
   BcvfsFile *pFile = pTab->pFile;
   int rc = SQLITE_OK;
 
+  assert( pFile->lockMask!=0 );
   if( pFile->kv.db ){
     BcvKVStore *pKv = &pFile->kv;
     sqlite3_bcvfs *pFs = pFile->pFs;
@@ -7201,6 +7075,7 @@ static int bcvFileVtabFilter(
   sqlite3_finalize(pCur->pSelect);
   pCur->pSelect = 0;
 
+  assert( pTab->pFile->lockMask!=0 );
   rc = bcvKVStoreLoad(pTab);
   if( rc==SQLITE_OK ){
     BcvKVStore *pKv = &pTab->pFile->kv;


### PR DESCRIPTION
…che. (#211)"

This reverts commit 422d88f3144c2d64f4364238b60a530a262465d4.

After one of our deployed backends was experiencing a performance degradation when using the daemon and it disappearing in daemonless mode, I am suspicious of this change that lets clients of the daemon work with readonly permissions to the cloudcache. Part of the reason that I am suspicious is that there is a flood of daemon logs which have the following pattern:
12->D: READ(0, []) 
D->12: READ_REPLY(0, "", [array of blocks in the cachefile])
12->D: END([])
The above pattern repeats itself often.

The performance degradation is seen when typing into the search bar on the model tree. Even though the hierarchy cache appears to be built up, the second search attempt is almost as slow as the first as if the cache is not being used. Without daemon mode on, the second search attempt is extremely fast. I don't quite understand how these two things would affect eachother but the presence of the above pattern in daemon logs when sending more requests is what makes me suspicious.

