### PR TITLE
Presentation: Use request-level read transactions

### DIFF
--- a/iModelCore/ECPresentation/Source/ECPresentationManager.cpp
+++ b/iModelCore/ECPresentation/Source/ECPresentationManager.cpp
@@ -52,6 +52,10 @@ protected:
             {
             IConnectionPtr taskConnection = connections.GetConnection(connectionId.c_str());
             task.SetTaskConnection(*taskConnection);
+
+            Savepoint txn(taskConnection->GetDb(), "_OnECInstancesChanged");
+            DIAGNOSTICS_ASSERT_SOFT(DiagnosticsCategory::Connections, txn.IsActive(), "Failed to start a transaction");
+
             NotifyECInstancesChanged(taskConnection->GetECDb(), changes);
             }, taskParams);
         }
@@ -487,6 +491,9 @@ folly::Future<NodesResponse> ECPresentationManager::GetNodes(WithPageOptions<Asy
         IConnectionCR taskConnection = GetConnection(connectionId.c_str());
         task.SetTaskConnection(taskConnection);
 
+        Savepoint txn(taskConnection.GetDb(), "GetNodes");
+        DIAGNOSTICS_ASSERT_SOFT(DiagnosticsCategory::Connections, txn.IsActive(), "Failed to start a transaction");
+
         auto source = m_impl->GetNodes(CreateImplRequestParams(params, taskConnection, *task.GetCancelationToken()));
         if (!source.IsValid())
             return NavNodesContainer();
@@ -514,6 +521,9 @@ folly::Future<NodesCountResponse> ECPresentationManager::GetNodesCount(AsyncHier
         IConnectionCR taskConnection = GetConnection(connectionId.c_str());
         task.SetTaskConnection(taskConnection);
 
+        Savepoint txn(taskConnection.GetDb(), "GetNodesCount");
+        DIAGNOSTICS_ASSERT_SOFT(DiagnosticsCategory::Connections, txn.IsActive(), "Failed to start a transaction");
+
         return m_impl->GetNodesCount(CreateImplRequestParams(params, taskConnection, *task.GetCancelationToken()));
         }, CreateNodesTaskParams(*m_impl, connection, params));
     }
@@ -536,6 +546,9 @@ folly::Future<NodesDescriptorResponse> ECPresentationManager::GetNodesDescriptor
 
         IConnectionCR taskConnection = GetConnection(connectionId.c_str());
         task.SetTaskConnection(taskConnection);
+
+        Savepoint txn(taskConnection.GetDb(), "GetNodesDescriptor");
+        DIAGNOSTICS_ASSERT_SOFT(DiagnosticsCategory::Connections, txn.IsActive(), "Failed to start a transaction");
 
         return m_impl->GetNodesDescriptor(CreateImplRequestParams(params, taskConnection, *task.GetCancelationToken()));
         }, taskParams);
@@ -568,6 +581,9 @@ folly::Future<NodePathsResponse> ECPresentationManager::GetNodePaths(AsyncNodePa
 
         IConnectionCR taskConnection = GetConnection(connectionId.c_str());
         task.SetTaskConnection(taskConnection);
+
+        Savepoint txn(taskConnection.GetDb(), "GetNodePaths");
+        DIAGNOSTICS_ASSERT_SOFT(DiagnosticsCategory::Connections, txn.IsActive(), "Failed to start a transaction");
 
         Utf8String lowerCaseFilter(params.GetFilterText());
         lowerCaseFilter.ToLower();
@@ -611,6 +627,9 @@ folly::Future<NodePathsResponse> ECPresentationManager::GetNodePaths(AsyncNodePa
         IConnectionCR taskConnection = GetConnection(connectionId.c_str());
         task.SetTaskConnection(taskConnection);
 
+        Savepoint txn(taskConnection.GetDb(), "GetNodePaths");
+        DIAGNOSTICS_ASSERT_SOFT(DiagnosticsCategory::Connections, txn.IsActive(), "Failed to start a transaction");
+
         auto pathParamsBase = NodePathFromInstanceKeyPathRequestImplParams::Create(taskConnection, task.GetCancelationToken(), HierarchyRequestParams(params), bvector<ECInstanceKey>());
         auto paths = ContainerHelpers::TransformContainer<bvector<NodesPathElement>>(params.GetInstanceKeyPaths(), [&](auto const& keyPath)
             {
@@ -644,6 +663,9 @@ folly::Future<ContentClassesResponse> ECPresentationManager::GetContentClasses(A
 
         IConnectionCR taskConnection = GetConnection(connectionId.c_str());
         task.SetTaskConnection(taskConnection);
+
+        Savepoint txn(taskConnection.GetDb(), "GetContentClasses");
+        DIAGNOSTICS_ASSERT_SOFT(DiagnosticsCategory::Connections, txn.IsActive(), "Failed to start a transaction");
 
         return m_impl->GetContentClasses(CreateImplRequestParams(params, taskConnection, *task.GetCancelationToken()));
         }, taskParams);
@@ -700,6 +722,9 @@ folly::Future<ContentDescriptorResponse> ECPresentationManager::GetContentDescri
         IConnectionCR taskConnection = GetConnection(connectionId.c_str());
         task.SetTaskConnection(taskConnection);
 
+        Savepoint txn(taskConnection.GetDb(), "GetContentDescriptor");
+        DIAGNOSTICS_ASSERT_SOFT(DiagnosticsCategory::Connections, txn.IsActive(), "Failed to start a transaction");
+
         return m_impl->GetContentDescriptor(CreateImplRequestParams(params, taskConnection, *task.GetCancelationToken()));
         }, taskParams);
     }
@@ -737,6 +762,9 @@ folly::Future<ContentResponse> ECPresentationManager::GetContent(WithPageOptions
 
         IConnectionCR taskConnection = GetConnection(params.GetContentDescriptor().GetConnectionId().c_str());
         task.SetTaskConnection(taskConnection);
+
+        Savepoint txn(taskConnection.GetDb(), "GetContent");
+        DIAGNOSTICS_ASSERT_SOFT(DiagnosticsCategory::Connections, txn.IsActive(), "Failed to start a transaction");
 
         ContentCPtr content = m_impl->GetContent(CreateImplRequestParams(params, taskConnection, *task.GetCancelationToken()));
         if (content.IsValid())
@@ -778,6 +806,9 @@ folly::Future<ContentSetSizeResponse> ECPresentationManager::GetContentSetSize(A
 
         IConnectionCR taskConnection = GetConnection(params.GetContentDescriptor().GetConnectionId().c_str());
         task.SetTaskConnection(taskConnection);
+
+        Savepoint txn(taskConnection.GetDb(), "GetContentSetSize");
+        DIAGNOSTICS_ASSERT_SOFT(DiagnosticsCategory::Connections, txn.IsActive(), "Failed to start a transaction");
 
         return m_impl->GetContentSetSize(CreateImplRequestParams(params, taskConnection, *task.GetCancelationToken()));
         }, taskParams);
@@ -821,6 +852,9 @@ folly::Future<DisplayLabelResponse> ECPresentationManager::GetDisplayLabel(Async
         IConnectionCR taskConnection = GetConnection(connectionId.c_str());
         task.SetTaskConnection(taskConnection);
 
+        Savepoint txn(taskConnection.GetDb(), "GetDisplayLabel");
+        DIAGNOSTICS_ASSERT_SOFT(DiagnosticsCategory::Connections, txn.IsActive(), "Failed to start a transaction");
+
         return m_impl->GetDisplayLabel(CreateImplRequestParams(params, taskConnection, *task.GetCancelationToken()));
         }, taskParams);
     }
@@ -851,6 +885,9 @@ folly::Future<DistinctValuesResponse> ECPresentationManager::GetDistinctValues(W
 
         IConnectionCR taskConnection = GetConnection(params.GetContentDescriptor().GetConnectionId().c_str());
         task.SetTaskConnection(taskConnection);
+
+        Savepoint txn(taskConnection.GetDb(), "GetDistinctValues");
+        DIAGNOSTICS_ASSERT_SOFT(DiagnosticsCategory::Connections, txn.IsActive(), "Failed to start a transaction");
 
         PagingDataSourceCPtr<DisplayValueGroupCPtr> source = m_impl->GetDistinctValues(CreateImplRequestParams(params, taskConnection, *task.GetCancelationToken()));
         if (source.IsValid())
@@ -892,6 +929,9 @@ folly::Future<HierarchiesCompareResponse> ECPresentationManager::CompareHierarch
 
         IConnectionCR taskConnection = GetConnection(connectionId.c_str());
         task.SetTaskConnection(taskConnection);
+
+        Savepoint txn(taskConnection.GetDb(), "CompareHierarchies");
+        DIAGNOSTICS_ASSERT_SOFT(DiagnosticsCategory::Connections, txn.IsActive(), "Failed to start a transaction");
 
         return m_impl->CompareHierarchies(CreateImplRequestParams(params, taskConnection, *task.GetCancelationToken()));
         }, taskParams);

--- a/iModelCore/ECPresentation/Source/PresentationManagerImpl.cpp
+++ b/iModelCore/ECPresentation/Source/PresentationManagerImpl.cpp
@@ -904,12 +904,18 @@ void RulesDrivenECPresentationManagerImpl::_OnConnectionEvent(ConnectionEvent co
 void RulesDrivenECPresentationManagerImpl::_OnECInstancesChanged(ECDbCR db, bvector<ECInstanceChangeEventSource::ChangedECInstance> changes)
     {
     auto scope = Diagnostics::Scope::Create(Utf8PrintfString("ECInstances changed with %" PRIu64 " changes", (uint64_t)changes.size()));
+
+    if (changes.empty())
+        return;
+
     IConnectionPtr connection = m_connections->GetConnection(db);
     if (connection.IsNull())
         DIAGNOSTICS_HANDLE_FAILURE(DiagnosticsCategory::Connections, "Failed to get a connection for current task");
 
-    if (!changes.empty())
-        m_updateHandler->NotifyECInstancesChanged(*connection, changes);
+    Savepoint txn(connection->GetDb(), "Impl::_OnECInstancesChanged");
+    DIAGNOSTICS_ASSERT_SOFT(DiagnosticsCategory::Connections, txn.IsActive(), "Failed to start a transaction");
+
+    m_updateHandler->NotifyECInstancesChanged(*connection, changes);
     }
 
 /*---------------------------------------------------------------------------------**//**
@@ -1116,6 +1122,10 @@ static void ReportNodesResponse(WithPageOptions<HierarchyRequestParams> const& p
 NavNodesDataSourcePtr RulesDrivenECPresentationManagerImpl::_GetNodes(WithPageOptions<HierarchyRequestImplParams> const& params)
     {
     auto scope = CreateScopeForHierarchyRequest(params, "nodes");
+
+    Savepoint txn(params.GetConnection().GetDb(), "Impl::_GetNodes");
+    DIAGNOSTICS_ASSERT_SOFT(DiagnosticsCategory::Connections, txn.IsActive(), "Failed to start a transaction");
+
     NavNodesDataSourcePtr source = GetCachedDataSource(params);
     ReportNodesResponse(params, source.get());
     return source;
@@ -1149,6 +1159,9 @@ size_t RulesDrivenECPresentationManagerImpl::_GetNodesCount(HierarchyRequestImpl
     {
     auto scope = CreateScopeForHierarchyRequest(params, "nodes count");
 
+    Savepoint txn(params.GetConnection().GetDb(), "Impl::_GetNodesCount");
+    DIAGNOSTICS_ASSERT_SOFT(DiagnosticsCategory::Connections, txn.IsActive(), "Failed to start a transaction");
+
     NavNodesDataSourcePtr source = GetCachedDataSource(params);
     size_t size = source.IsValid() ? source->GetSize() : 0;
     ReportNodesCountResponse(params, size);
@@ -1172,6 +1185,9 @@ static Diagnostics::Scope::Holder CreateScopeForHierarchyRequest(HierarchyLevelD
 ContentDescriptorCPtr RulesDrivenECPresentationManagerImpl::_GetNodesDescriptor(HierarchyLevelDescriptorRequestImplParams const& params)
     {
     auto scope = CreateScopeForHierarchyRequest(params, "nodes descriptor");
+
+    Savepoint txn(params.GetConnection().GetDb(), "Impl::_GetNodesDescriptor");
+    DIAGNOSTICS_ASSERT_SOFT(DiagnosticsCategory::Connections, txn.IsActive(), "Failed to start a transaction");
 
     auto context = CreateNodesProviderContext(HierarchyRequestImplParams::Create(HierarchyRequestParams(params, params.GetParentNodeKey()), params));
     auto ruleset = HierarchiesFilteringHelper::CreateHierarchyLevelDescriptorRuleset(
@@ -1226,6 +1242,10 @@ void RulesDrivenECPresentationManagerImpl::TraverseHierarchy(HierarchyRequestImp
 bvector<NavNodeCPtr> RulesDrivenECPresentationManagerImpl::_GetFilteredNodes(NodePathsFromFilterTextRequestImplParams const& params)
     {
     auto scope = Diagnostics::Scope::Create(Utf8PrintfString("Get filtered nodes: '%s'", params.GetFilterText().c_str()));
+
+    Savepoint txn(params.GetConnection().GetDb(), "Impl::_GetFilteredNodes");
+    DIAGNOSTICS_ASSERT_SOFT(DiagnosticsCategory::Connections, txn.IsActive(), "Failed to start a transaction");
+
     bvector<NavNodeCPtr> result;
 
     std::shared_ptr<NodesCache> nodesCache = m_nodesCachesManager->GetPersistentCache(params.GetConnection().GetId());
@@ -1302,6 +1322,9 @@ bvector<NavNodeCPtr> RulesDrivenECPresentationManagerImpl::_GetFilteredNodes(Nod
 bvector<NodesPathElement> RulesDrivenECPresentationManagerImpl::_CreateNodesHierarchy(CreateNodesHierarchyRequestImplParams const& params)
     {
     auto scope = Diagnostics::Scope::Create("Create nodes hierarchy");
+
+    Savepoint txn(params.GetConnection().GetDb(), "Impl::_CreateNodesHierarchy");
+    DIAGNOSTICS_ASSERT_SOFT(DiagnosticsCategory::Connections, txn.IsActive(), "Failed to start a transaction");
 
     std::shared_ptr<NodesCache> cache = m_nodesCachesManager->GetPersistentCache(params.GetConnection().GetId());
     VALID_HIERARCHY_CACHE_PRECONDITION(cache, nullptr);
@@ -1494,6 +1517,9 @@ bvector<SelectClassInfo> RulesDrivenECPresentationManagerImpl::_GetContentClasse
     {
     auto scope = Diagnostics::Scope::Create("Get content classes");
 
+    Savepoint txn(params.GetConnection().GetDb(), "Impl::_GetContentClasses");
+    DIAGNOSTICS_ASSERT_SOFT(DiagnosticsCategory::Connections, txn.IsActive(), "Failed to start a transaction");
+
     // get the ruleset
     PresentationRuleSetPtr ruleset = FindRuleset(GetLocaters(), params.GetConnection(), params.GetRulesetId().c_str());
     if (!ruleset.IsValid())
@@ -1537,6 +1563,9 @@ ContentDescriptorCPtr RulesDrivenECPresentationManagerImpl::_GetContentDescripto
     {
     auto scope = Diagnostics::Scope::Create("Get content descriptor");
 
+    Savepoint txn(params.GetConnection().GetDb(), "Impl::_GetContentDescriptor");
+    DIAGNOSTICS_ASSERT_SOFT(DiagnosticsCategory::Connections, txn.IsActive(), "Failed to start a transaction");
+
     Utf8CP preferredDisplayType = params.GetPreferredDisplayType().size() ? params.GetPreferredDisplayType().c_str() : ContentDisplayType::Undefined;
     INavNodeKeysContainerCPtr nodeKeys = params.GetInputKeys().GetAllNavNodeKeys();
     ContentProviderKey key(params.GetConnection().GetId(), params.GetRulesetId(), preferredDisplayType, params.GetContentFlags(), params.GetUnitSystem(), *nodeKeys, params.GetSelectionInfo());
@@ -1576,6 +1605,9 @@ ContentCPtr RulesDrivenECPresentationManagerImpl::_GetContent(WithPageOptions<Co
     {
     auto scope = Diagnostics::Scope::Create("Get content");
 
+    Savepoint txn(params.GetConnection().GetDb(), "Impl::_GetContent");
+    DIAGNOSTICS_ASSERT_SOFT(DiagnosticsCategory::Connections, txn.IsActive(), "Failed to start a transaction");
+
     SpecificationContentProviderPtr provider = GetContentProvider(params);
     if (provider.IsNull())
         {
@@ -1614,6 +1646,9 @@ size_t RulesDrivenECPresentationManagerImpl::_GetContentSetSize(ContentRequestIm
     {
     auto scope = Diagnostics::Scope::Create("Get content set size");
 
+    Savepoint txn(params.GetConnection().GetDb(), "Impl::_GetContentSetSize");
+    DIAGNOSTICS_ASSERT_SOFT(DiagnosticsCategory::Connections, txn.IsActive(), "Failed to start a transaction");
+
     SpecificationContentProviderPtr provider = GetContentProvider(params);
     if (provider.IsNull())
         {
@@ -1648,6 +1683,9 @@ size_t RulesDrivenECPresentationManagerImpl::_GetContentSetSize(ContentRequestIm
 LabelDefinitionCPtr RulesDrivenECPresentationManagerImpl::_GetDisplayLabel(KeySetDisplayLabelRequestImplParams const& params)
     {
     auto scope = Diagnostics::Scope::Create("Get display label");
+
+    Savepoint txn(params.GetConnection().GetDb(), "Impl::_GetDisplayLabel");
+    DIAGNOSTICS_ASSERT_SOFT(DiagnosticsCategory::Connections, txn.IsActive(), "Failed to start a transaction");
 
     Utf8String rulesetId(params.GetRulesetId());
     RulesetVariables rulesetVariables(params.GetRulesetVariables());
@@ -1689,6 +1727,9 @@ LabelDefinitionCPtr RulesDrivenECPresentationManagerImpl::_GetDisplayLabel(KeySe
 PagingDataSourcePtr<DisplayValueGroupCPtr> RulesDrivenECPresentationManagerImpl::_GetDistinctValues(WithPageOptions<DistinctValuesRequestImplParams> const& params)
     {
     auto scope = Diagnostics::Scope::Create("Get distinct values");
+
+    Savepoint txn(params.GetConnection().GetDb(), "Impl::_GetDistinctValues");
+    DIAGNOSTICS_ASSERT_SOFT(DiagnosticsCategory::Connections, txn.IsActive(), "Failed to start a transaction");
 
     ContentDescriptor::Field const* field = params.GetContentDescriptor().FindField(params.GetDistinctFieldMatcher());
     if (field == nullptr)
@@ -1776,6 +1817,9 @@ public:
 HierarchyComparePositionPtr RulesDrivenECPresentationManagerImpl::_CompareHierarchies(HierarchyCompareRequestImplParams const& params)
     {
     auto scope = Diagnostics::Scope::Create("Compare hierarchies");
+
+    Savepoint txn(params.GetConnection().GetDb(), "Impl::_CompareHierarchies");
+    DIAGNOSTICS_ASSERT_SOFT(DiagnosticsCategory::Connections, txn.IsActive(), "Failed to start a transaction");
 
     std::shared_ptr<INavNodesCache> nodesCache = m_nodesCachesManager->GetPersistentCache(params.GetConnection().GetId());
     if (nullptr == nodesCache)


### PR DESCRIPTION
I was pretty sure we have them, but turns out we don't...

Provides ~6-7% performance boost for requests that run large numbers of queries (Models tree initial load & filtering, consolidated content descriptor).