### PR TITLE
Always use std:: prefix when calling move

### DIFF
--- a/iModelCore/ECDb/ECDb/ECSql/ECSqlFieldFactory.cpp
+++ b/iModelCore/ECDb/ECDb/ECSql/ECSqlFieldFactory.cpp
@@ -79,7 +79,7 @@ ECSqlStatus ECSqlFieldFactory::CreateField(ECSqlPrepareContext& ctx, DerivedProp
         }
 
     if (stat.IsSuccess())
-        selectPreparedStatement.AddField(move(field));
+        selectPreparedStatement.AddField(std::move(field));
 
     return stat;
     }

--- a/iModelCore/ECDb/ECDb/ECSql/ECSqlInsertPreparer.cpp
+++ b/iModelCore/ECDb/ECDb/ECSql/ECSqlInsertPreparer.cpp
@@ -66,7 +66,7 @@ ECSqlStatus ECSqlInsertPreparer::GenerateNativeSqlSnippets(NativeSqlSnippets& in
         if (!stat.IsSuccess())
             return stat;
 
-        insertSqlSnippets.m_propertyNamesNativeSqlSnippets.push_back(move(nativeSqlSnippets));
+        insertSqlSnippets.m_propertyNamesNativeSqlSnippets.push_back(std::move(nativeSqlSnippets));
         }
 
     status = ECSqlExpPreparer::PrepareValueExpListExp(insertSqlSnippets.m_valuesNativeSqlSnippets, ctx, *exp.GetValuesExp(), insertSqlSnippets.m_propertyNamesNativeSqlSnippets);

--- a/iModelCore/ECDb/ECDb/ECSql/ECSqlParser.cpp
+++ b/iModelCore/ECDb/ECDb/ECSql/ECSqlParser.cpp
@@ -289,7 +289,7 @@ BentleyStatus ECSqlParser::ParseSelection(std::unique_ptr<SelectClauseExp>& exp,
             selectClauseExp->AddProperty(std::move(derivedPropExp));
         }
 
-    exp = move(selectClauseExp);
+    exp = std::move(selectClauseExp);
     return SUCCESS;
     }
 
@@ -1380,7 +1380,7 @@ BentleyStatus ECSqlParser::ParseFromClause(std::unique_ptr<FromExp>& exp, OSQLPa
         if (stat != SUCCESS)
             return stat;
 
-        stat = from_clause->TryAddClassRef(*m_context, move(classRefExp));
+        stat = from_clause->TryAddClassRef(*m_context, std::move(classRefExp));
         if (stat != SUCCESS)
             return stat;
         }

--- a/iModelCore/ECDb/ECDb/ECSql/ECSqlPreparer.cpp
+++ b/iModelCore/ECDb/ECDb/ECSql/ECSqlPreparer.cpp
@@ -2033,7 +2033,7 @@ ECSqlStatus ECSqlExpPreparer::PrepareValueExpListExp(NativeSqlBuilder::ListOfLis
         if (!stat.IsSuccess())
             return stat;
 
-        nativeSqlSnippetLists.push_back(move(nativeSqlSnippets));
+        nativeSqlSnippetLists.push_back(std::move(nativeSqlSnippets));
         index++;
         }
 

--- a/iModelCore/ECDb/ECDb/ECSql/JoinExp.cpp
+++ b/iModelCore/ECDb/ECDb/ECSql/JoinExp.cpp
@@ -33,7 +33,7 @@ FromExp const* JoinExp::FindFromExpression() const
 //+---------------+---------------+---------------+---------------+---------------+------
 JoinConditionExp::JoinConditionExp(std::unique_ptr<BooleanExp> searchCondition) : JoinSpecExp(Type::JoinCondition)
     {
-    AddChild(move(searchCondition));
+    AddChild(std::move(searchCondition));
     }
 
 //-----------------------------------------------------------------------------------------
@@ -73,7 +73,7 @@ Utf8String NaturalJoinExp::_ToString() const
 // @bsimethod
 //+---------------+---------------+---------------+---------------+---------------+--------
 QualifiedJoinExp::QualifiedJoinExp(std::unique_ptr<ClassRefExp> from, std::unique_ptr<ClassRefExp> to, ECSqlJoinType joinType, std::unique_ptr<JoinSpecExp> joinSpecExp)
-    : JoinExp(Type::QualifiedJoin, joinType, move(from), move(to))
+    : JoinExp(Type::QualifiedJoin, joinType, std::move(from), std::move(to))
     {
     m_nJoinSpecIndex = AddChild(std::move(joinSpecExp));
     }

--- a/iModelCore/ECDb/ECDb/ECSql/JoinExp.h
+++ b/iModelCore/ECDb/ECDb/ECSql/JoinExp.h
@@ -60,8 +60,8 @@ struct JoinExp : ClassRefExp
         JoinExp(Type type, ECSqlJoinType joinType, std::unique_ptr<ClassRefExp> from, std::unique_ptr<ClassRefExp> to)
             : ClassRefExp(type), m_joinType(joinType)
             {
-            m_nFromClassRefIndex = AddChild(move(from));
-            m_nToClassRefIndex = AddChild(move(to));
+            m_nFromClassRefIndex = AddChild(std::move(from));
+            m_nToClassRefIndex = AddChild(std::move(to));
             }
 
     public:
@@ -188,7 +188,7 @@ struct ECRelationshipJoinExp final : JoinExp
         ECRelationshipJoinExp(std::unique_ptr<ClassRefExp> from, std::unique_ptr<ClassRefExp> to, std::unique_ptr<ClassRefExp> relationship, JoinDirection direction)
             : JoinExp(Type::ECRelationshipJoin, ECSqlJoinType::JoinUsingRelationship, std::move(from), std::move(to)), m_direction(direction)
             {
-            m_relationshipClassNameExpIndex = AddChild(move(relationship));
+            m_relationshipClassNameExpIndex = AddChild(std::move(relationship));
             }
 
         ClassNameExp const& GetRelationshipClassNameExp() const { return *GetChild<ClassNameExp>(m_relationshipClassNameExpIndex); }

--- a/iModelCore/ECDb/ECDb/ECSql/SelectStatementExp.cpp
+++ b/iModelCore/ECDb/ECDb/ECSql/SelectStatementExp.cpp
@@ -269,7 +269,7 @@ BentleyStatus FromExp::TryAddClassRef(ECSqlParseContext& ctx, std::unique_ptr<Cl
             }
         }
 
-    AddChild(move(classRefExp));
+    AddChild(std::move(classRefExp));
     return SUCCESS;
     }
 
@@ -1021,7 +1021,7 @@ Utf8String SubqueryRefExp::_ToString() const
 SubqueryTestExp::SubqueryTestExp(SubqueryTestOperator op, std::unique_ptr<SubqueryExp> subquery)
     : BooleanExp(Type::SubqueryTest), m_op(op)
     {
-    AddChild(move(subquery));
+    AddChild(std::move(subquery));
     }
 
 //-----------------------------------------------------------------------------------------
@@ -1058,7 +1058,7 @@ SubqueryValueExp::SubqueryValueExp(std::unique_ptr<SubqueryExp> subquery)
     : ValueExp(Type::SubqueryValue)
     {
     SetHasParentheses(); //subquery value exp always wrapped in parentheses
-    AddChild(move(subquery));
+    AddChild(std::move(subquery));
     }
 
 //-----------------------------------------------------------------------------------------

--- a/iModelCore/ECDb/ECDb/ECSql/SelectStatementExp.h
+++ b/iModelCore/ECDb/ECDb/ECSql/SelectStatementExp.h
@@ -215,7 +215,7 @@ struct OrderByExp final : Exp
         explicit OrderByExp(std::vector<std::unique_ptr<OrderBySpecExp>>& specs) : Exp(Type::OrderBy)
             {
             for (auto& spec : specs)
-                AddChild(move(spec));
+                AddChild(std::move(spec));
             }
     };
 

--- a/iModelCore/ECDb/ECDb/ECSql/UpdateStatementExp.cpp
+++ b/iModelCore/ECDb/ECDb/ECSql/UpdateStatementExp.cpp
@@ -106,8 +106,8 @@ void UpdateStatementExp::_ToECSql(ECSqlRenderContext& ctx) const
 AssignmentExp::AssignmentExp(std::unique_ptr<PropertyNameExp> propNameExp, std::unique_ptr<ValueExp> valueExp)
     : Exp(Type::Assignment)
     {
-    m_propNameExpIndex = AddChild(move(propNameExp));
-    m_valueExpIndex = AddChild(move(valueExp));
+    m_propNameExpIndex = AddChild(std::move(propNameExp));
+    m_valueExpIndex = AddChild(std::move(valueExp));
     }
 
 

--- a/iModelCore/ECDb/ECDb/ECSql/ValueExp.cpp
+++ b/iModelCore/ECDb/ECDb/ECSql/ValueExp.cpp
@@ -749,7 +749,7 @@ BentleyStatus MemberFunctionCallExp::AddArgument(std::unique_ptr<ValueExp> argum
     if (ValidateArgument(*argument, error) != SUCCESS)
         return ERROR;
 
-    AddChild(move(argument));
+    AddChild(std::move(argument));
     return SUCCESS;
     }
 
@@ -861,7 +861,7 @@ BentleyStatus FunctionCallExp::AddArgument(std::unique_ptr<ValueExp> argument)
         return ERROR;
         }
 
-    AddChild(move(argument));
+    AddChild(std::move(argument));
     return SUCCESS;
     }
 


### PR DESCRIPTION
The clang from the current Xcode generates a warning when std:: prefix is missing from move calls, and warnings are treated as errors. Many (most?) existing calls to move already have the std:: prefix, despite `using namespace std` being present in one of the top-level EC header files.

For reference, the error comes from `-Wunqualified-std-call`. I assume that the bb settings either specify -Wmost and this is in the list for that, or that they specify -Wall. This specific warning could be disabled in bsicommon, but I feel that adding the std:: prefix is better since it is in use in so many other std::move calls. If others disagree, this PR can be closed and bsicommon can be updated to exclude that warning.