### PR TITLE
fix text offset for SimplifyGraphic::ProcessText

### DIFF
--- a/iModelCore/iModelPlatform/DgnCore/SimplifyGraphic.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/SimplifyGraphic.cpp
@@ -559,7 +559,8 @@ void SimplifyGraphic::ProcessText(TextStringCR text)
                 CurveVectorPtr  curves = glyphs[iGlyph]->GetCurveVector ();
                 if (curves.IsNull())
                     continue;
-                curves->TransformInPlace (Transform::FromProduct (Transform::From(glyphOrigins[iGlyph]), rotationTransform));
+                auto origin = DPoint3d::FromSumOf(text.GetOrigin(), glyphOrigins[iGlyph]);
+                curves->TransformInPlace (Transform::FromProduct (Transform::From(origin), rotationTransform));
                 ProcessCurveVector(*curves, curves->IsAnyRegionType ());
                 }
             }
@@ -860,6 +861,7 @@ void SimplifyGraphic::_AddBody(IBRepEntityCR geom)
 +---------------+---------------+---------------+---------------+---------------+------*/
 void SimplifyGraphic::_AddTextString(TextStringCR text)
     {
+//*q*/printf("SimplifyGraphic::_AddTextString\n");
     m_processor._OnNewGeometry();
 
     ProcessText(text);

--- a/iModelCore/iModelPlatform/DgnCore/SimplifyGraphic.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/SimplifyGraphic.cpp
@@ -861,7 +861,6 @@ void SimplifyGraphic::_AddBody(IBRepEntityCR geom)
 +---------------+---------------+---------------+---------------+---------------+------*/
 void SimplifyGraphic::_AddTextString(TextStringCR text)
     {
-//*q*/printf("SimplifyGraphic::_AddTextString\n");
     m_processor._OnNewGeometry();
 
     ProcessText(text);


### PR DESCRIPTION
The offset from the text itself is now taken into account along with the glyph offset.