### PR TITLE
Handle nested content similar to how we handle direct content

### DIFF
--- a/iModelCore/ECPresentation/Source/Content/ContentProviders.cpp
+++ b/iModelCore/ECPresentation/Source/Content/ContentProviders.cpp
@@ -98,7 +98,6 @@ SpecificationContentProvider::SpecificationContentProvider(ContentProviderContex
 SpecificationContentProvider::SpecificationContentProvider(SpecificationContentProviderCR other)
     : ContentProvider(other), m_rules(other.m_rules)
     {
-    m_descriptor = other.m_descriptor;
     if (other.m_queries)
         m_queries = std::make_unique<QuerySet>(*other.m_queries);
     }
@@ -604,6 +603,20 @@ void ContentProvider::LoadNestedContent(ContentSetItemR item) const
     LoadNestedContent(item, descriptor->GetAllFields());
     }
 
+/*---------------------------------------------------------------------------------**//**
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+ContentDescriptorCP ContentProvider::GetContentDescriptor() const
+    {
+    BeMutexHolder lock(GetMutex());
+    if (m_descriptor.IsNull())
+        {
+        auto scope = Diagnostics::Scope::Create("Create content descriptor");
+        m_descriptor = _CreateContentDescriptor();
+        }
+    return m_descriptor.get();
+    }
+
 /*=================================================================================**//**
 * @bsiclass
 +===============+===============+===============+===============+===============+======*/
@@ -693,6 +706,16 @@ public:
     /*-----------------------------------------------------------------------------**//**
     * @bsimethod
     +---------------+---------------+---------------+---------------+---------------+--*/
+    void Visit(ContentDescriptor::NestedContentField const& field)
+        {
+        ContentDescriptorPtr fieldDescriptor = m_descriptorBuilder->CreateDescriptor(field);
+        if (fieldDescriptor.IsValid())
+            QueryBuilderHelpers::Aggregate(m_descriptor, *fieldDescriptor);
+        }
+
+    /*-----------------------------------------------------------------------------**//**
+    * @bsimethod
+    +---------------+---------------+---------------+---------------+---------------+--*/
     ContentDescriptorCPtr GetDescriptor() {return m_descriptor;}
 };
 
@@ -705,21 +728,27 @@ private:
     std::unique_ptr<MultiContentQueryBuilder> m_queryBuilder;
 
 private:
-    static void CollectMatchingNavigationPropertyClassAliases(bset<Utf8String>& aliases, bvector<RelatedClass> const& allClasses, bvector<ContentDescriptor::Property> const& properties)
+    static void CollectNavigationPropertyClassAliases(bset<Utf8String>& aliases, bvector<ContentDescriptor::Property> const& properties)
         {
-        for (RelatedClassCR rc : allClasses)
+        for (auto const& prop : properties)
             {
-            if (ContainerHelpers::Contains(properties, [&rc](auto const& prop){return prop.GetProperty().GetIsNavigation() && prop.GetPropertyClass().Is(&rc.GetTargetClass().GetClass());}))
-                aliases.insert(rc.GetTargetClass().GetAlias());
+            if (prop.GetProperty().GetIsNavigation())
+                aliases.insert(prop.GetPrefix());
             }
         }
     static void CollectRelatedContentFieldClassAliases(bset<Utf8String>& aliases, ContentDescriptor::RelatedContentField const& field)
         {
         QueryBuilderHelpers::CollectRelatedClassPathAliases(aliases, field.GetPathFromSelectToContentClass());
-        for (auto const& nestedField : field.GetFields())
+        CollectFieldAliases(aliases, field.GetFields());
+        }
+    static void CollectFieldAliases(bset<Utf8String>& aliases, bvector<ContentDescriptor::Field*> const& fields)
+        {
+        for (auto const& field : fields)
             {
-            if (nestedField->IsNestedContentField() && nestedField->AsNestedContentField()->AsRelatedContentField())
-                CollectRelatedContentFieldClassAliases(aliases, *nestedField->AsNestedContentField()->AsRelatedContentField());
+            if (field->IsPropertiesField())
+                CollectNavigationPropertyClassAliases(aliases, field->AsPropertiesField()->GetProperties());
+            else if (field->IsNestedContentField() && field->AsNestedContentField()->AsRelatedContentField())
+                CollectRelatedContentFieldClassAliases(aliases, *field->AsNestedContentField()->AsRelatedContentField());
             }
         }
     static bool AnySelectClassExceedsRelatedClassesThreshold(bvector<SelectClassInfo> const& selectClasses, bvector<ContentDescriptor::Field*> const& fields)
@@ -729,15 +758,7 @@ private:
             bset<Utf8String> uniqueAliases;
             QueryBuilderHelpers::CollectRelatedClassPathAliases(uniqueAliases, selectClass.GetPathFromInputToSelectClass());
             QueryBuilderHelpers::CollectRelatedClassPathAliases(uniqueAliases, selectClass.GetRelatedInstancePaths());
-
-            for (auto const& field : fields)
-                {
-                if (field->IsPropertiesField())
-                    CollectMatchingNavigationPropertyClassAliases(uniqueAliases, selectClass.GetNavigationPropertyClasses(), field->AsPropertiesField()->GetProperties());
-                else if (field->IsNestedContentField() && field->AsNestedContentField()->AsRelatedContentField())
-                    CollectRelatedContentFieldClassAliases(uniqueAliases, *field->AsNestedContentField()->AsRelatedContentField());
-                }
-
+            CollectFieldAliases(uniqueAliases, fields);
             if (uniqueAliases.size() > RELATED_CLASS_PATH_ALIASES_THRESHOLD)
                 return true;
             }
@@ -779,16 +800,29 @@ public:
     /*-----------------------------------------------------------------------------**//**
     * @bsimethod
     +---------------+---------------+---------------+---------------+---------------+--*/
-    QueryBuilder(ContentProviderContextCR context, ContentDescriptorCR descriptor, bool forceDirectReadOfAllProperties = false, bool isCountQuery = false)
-        : ContentSpecificationsVisitor()
+    QueryBuilder(
+        ContentProviderContextCR context,
+        ContentDescriptorCR descriptor,
+        bool forceDirectReadOfAllProperties = false,
+        bool isCountQuery = false,
+        bool isCompositePropertyValueQuery = false
+    ) : ContentSpecificationsVisitor()
         {
         IECPropertyFormatter const* formatter = context.IsPropertyFormattingContext() ? &context.GetECPropertyFormatter() : nullptr;
         bool exceedsFieldsOrRelatedClassesLimit = descriptor.GetTotalFieldsCount() > 1000 || AnySelectClassExceedsRelatedClassesThreshold(descriptor.GetSelectClasses(), descriptor.GetAllFields());
         bool canDirectlyReadXToManyRelatedContent = (forceDirectReadOfAllProperties || !exceedsFieldsOrRelatedClassesLimit) && !isCountQuery;
         ContentQueryBuilderParameters params(context.GetSchemaHelper(), context.GetConnections(), context.GetNodesLocater(), context.GetConnection(), &context.GetCancelationToken(),
             context.GetRulesPreprocessor(), context.GetRuleset(), context.GetRulesetVariables(), context.GetECExpressionsCache(), &context.GetUsedVariablesListener(),
-            context.GetCategorySupplier(), true, !canDirectlyReadXToManyRelatedContent, formatter, context.GetLocalState());
+            context.GetCategorySupplier(), !isCompositePropertyValueQuery, !canDirectlyReadXToManyRelatedContent, formatter, context.GetLocalState());
         m_queryBuilder = std::make_unique<MultiContentQueryBuilder>(params, descriptor);
+        }
+
+    /*-----------------------------------------------------------------------------**//**
+    * @bsimethod
+    +---------------+---------------+---------------+---------------+---------------+--*/
+    void Visit(ContentDescriptor::NestedContentField const& field)
+        {
+        m_queryBuilder->Accept(field);
         }
 
     /*-----------------------------------------------------------------------------**//**
@@ -811,6 +845,7 @@ ContentProvider::ContentProvider(ContentProviderCR other)
     : m_pageOptions(other.m_pageOptions)
     {
     m_context = ContentProviderContext::Create(*other.m_context);
+    m_descriptor = other.m_descriptor;
     if (other.m_fullContentSetSize)
         m_fullContentSetSize = std::make_unique<size_t>(*other.m_fullContentSetSize);
     }
@@ -894,17 +929,11 @@ static void VisitRuleSpecifications(ContentSpecificationsVisitor& visitor, bmap<
 /*---------------------------------------------------------------------------------**//**
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/
-ContentDescriptorCP SpecificationContentProvider::_GetContentDescriptor() const
+ContentDescriptorCPtr SpecificationContentProvider::_CreateContentDescriptor() const
     {
-    BeMutexHolder lock(GetMutex());
-    if (m_descriptor.IsNull())
-        {
-        auto scope = Diagnostics::Scope::Create("Create content descriptor");
-        DescriptorBuilder builder(GetContext());
-        VisitRuleSpecifications(builder, m_inputCache, GetContext(), m_rules);
-        m_descriptor = builder.GetDescriptor();
-        }
-    return m_descriptor.get();
+    DescriptorBuilder builder(GetContext());
+    VisitRuleSpecifications(builder, m_inputCache, GetContext(), m_rules);
+    return builder.GetDescriptor();
     }
 
 /*---------------------------------------------------------------------------------**//**
@@ -972,7 +1001,7 @@ QuerySet SpecificationContentProvider::_GetCountQuerySet() const
 /*---------------------------------------------------------------------------------**//**
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/
-void SpecificationContentProvider::SetContentDescriptor(ContentDescriptorCR descriptor)
+void ContentProvider::SetContentDescriptor(ContentDescriptorCR descriptor)
     {
     BeMutexHolder lock(GetMutex());
     auto scope = Diagnostics::Scope::Create("Set content descriptor");
@@ -1323,11 +1352,11 @@ void NestedContentProvider::_OnDescriptorChanged()
 /*---------------------------------------------------------------------------------**//**
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/
-ContentDescriptorCP NestedContentProvider::_GetContentDescriptor() const
+ContentDescriptorCPtr NestedContentProvider::_CreateContentDescriptor() const
     {
-    auto const& querySet = _GetContentQuerySet();
-    auto const& contract = ContentQueryContractsFilter(querySet).GetContract();
-    return contract ? &contract->GetDescriptor() : nullptr;
+    DescriptorBuilder builder(GetContext());
+    builder.Visit(m_field);
+    return builder.GetDescriptor();
     }
 
 /*---------------------------------------------------------------------------------**//**
@@ -1339,12 +1368,9 @@ QuerySet const& NestedContentProvider::_GetContentQuerySet() const
     auto scope = Diagnostics::Scope::Create("Create content queries");
     if (m_unfilteredQueries == nullptr)
         {
-        IECPropertyFormatter const* formatter = GetContext().IsPropertyFormattingContext() ? &GetContext().GetECPropertyFormatter() : nullptr;
-        ContentQueryBuilderParameters params(GetContext().GetSchemaHelper(), GetContext().GetConnections(), GetContext().GetNodesLocater(), GetContext().GetConnection(), &GetContext().GetCancelationToken(),
-            GetContext().GetRulesPreprocessor(), GetContext().GetRuleset(), GetContext().GetRulesetVariables(), GetContext().GetECExpressionsCache(), &GetContext().GetUsedVariablesListener(),
-            GetContext().GetCategorySupplier(), false, false, formatter, GetContext().GetLocalState());
-        ContentQueryBuilder queryBuilder(params);
-        m_unfilteredQueries = std::make_unique<QuerySet>(queryBuilder.CreateQuerySet(m_field));
+        QueryBuilder queryBuilder(GetContext(), *GetContentDescriptor(), false, false, m_field.AsCompositeContentField());
+        queryBuilder.Visit(m_field);
+        m_unfilteredQueries = std::make_unique<QuerySet>(queryBuilder.GetQuerySet());
         DIAGNOSTICS_DEV_LOG(DiagnosticsCategory::Content, LOG_TRACE, Utf8PrintfString("Created %" PRIu64 " unfiltered queries", (uint64_t)m_unfilteredQueries->GetQueries().size()));
         }
     if (m_queries == nullptr)

--- a/iModelCore/ECPresentation/Source/Content/ContentQueryBuilder.cpp
+++ b/iModelCore/ECPresentation/Source/Content/ContentQueryBuilder.cpp
@@ -648,6 +648,23 @@ bool MultiContentQueryBuilder::Accept(ContentInstancesOfSpecificClassesSpecifica
 /*---------------------------------------------------------------------------------**//**
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/
+bool MultiContentQueryBuilder::Accept(ContentDescriptor::NestedContentField const& field)
+    {
+    auto scope = Diagnostics::Scope::Create(Utf8PrintfString("Create queries for field %s", field.GetUniqueName().c_str()));
+
+    QuerySet querySet = m_builder->CreateQuerySet(field);
+    DIAGNOSTICS_DEV_LOG(DiagnosticsCategory::Content, LOG_TRACE, Utf8PrintfString("Created %" PRIu64 " queries.", (uint64_t)querySet.GetQueries().size()));
+
+    if (querySet.GetQueries().empty())
+        return false;
+
+    for (auto const& query : querySet.GetQueries())
+        QueryBuilderHelpers::AddToUnionSet(m_unions, *query);
+    return true;
+    }
+/*---------------------------------------------------------------------------------**//**
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
 QuerySet const& MultiContentQueryBuilder::GetQuerySet()
     {
     if (!m_adjustmentsApplied)

--- a/iModelCore/ECPresentation/Source/Content/ContentQueryBuilder.h
+++ b/iModelCore/ECPresentation/Source/Content/ContentQueryBuilder.h
@@ -155,6 +155,7 @@ public:
     ECPRESENTATION_EXPORT bool Accept(SelectedNodeInstancesSpecificationCR, IParsedInput const&);
     ECPRESENTATION_EXPORT bool Accept(ContentRelatedInstancesSpecificationCR, IParsedInput const&);
     ECPRESENTATION_EXPORT bool Accept(ContentInstancesOfSpecificClassesSpecificationCR);
+    ECPRESENTATION_EXPORT bool Accept(ContentDescriptor::NestedContentField const&);
     ECPRESENTATION_EXPORT QuerySet const& GetQuerySet();
 };
 

--- a/iModelCore/ECPresentation/Tests/NonPublished/Integration/Content/Content_RelatedPropertiesTests.cpp
+++ b/iModelCore/ECPresentation/Tests/NonPublished/Integration/Content/Content_RelatedPropertiesTests.cpp
@@ -7259,7 +7259,7 @@ TEST_F(RulesDrivenECPresentationManagerContentTests, LoadsRelatedPropertiesCorre
 /*---------------------------------------------------------------------------------**//**
 * @bsitest
 +---------------+---------------+---------------+---------------+---------------+------*/
-TEST_F(RulesDrivenECPresentationManagerContentTests, CreatesContentForSelectedInstanceNode_WithManyRelatedInstances)
+TEST_F(RulesDrivenECPresentationManagerContentTests, CreatesContentForSelectedInstanceNode_WithManyDirectlyRelatedInstances)
     {
     // set up the schema
     RulesEngineTestHelpers::ImportSchema(s_project->GetECDb(), [&](ECSchemaR schema)
@@ -7320,6 +7320,92 @@ TEST_F(RulesDrivenECPresentationManagerContentTests, CreatesContentForSelectedIn
 
     // request content
     ContentDescriptorCPtr descriptor = GetValidatedResponse(m_manager->GetContentDescriptor(AsyncContentDescriptorRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables(), ContentDisplayType::PropertyPane, 0, *KeySet::Create(*elementInstance))));
+
+    ContentCPtr content = GetVerifiedContent(*descriptor);
+    ASSERT_TRUE(content.IsValid());
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* @bsitest
++---------------+---------------+---------------+---------------+---------------+------*/
+TEST_F(RulesDrivenECPresentationManagerContentTests, CreatesContentForSelectedInstanceNode_WithManyIndirectlyRelatedInstances)
+    {
+    // set up the schema
+    RulesEngineTestHelpers::ImportSchema(s_project->GetECDb(), [&](ECSchemaR schema)
+        {
+        ECEntityClassP classA = nullptr;
+        ASSERT_EQ(ECObjectsStatus::Success, schema.CreateEntityClass(classA, "A"));
+        ASSERT_TRUE(nullptr != classA);
+
+        ECEntityClassP classB = nullptr;
+        ASSERT_EQ(ECObjectsStatus::Success, schema.CreateEntityClass(classB, "B"));
+        ASSERT_TRUE(nullptr != classB);
+
+        ECEntityClassP classC = nullptr;
+        ASSERT_EQ(ECObjectsStatus::Success, schema.CreateEntityClass(classC, "C"));
+        ASSERT_TRUE(nullptr != classC);
+
+        IECInstancePtr classMapCustomAttribute = GetClass("ECDbMap", "ClassMap")->GetDefaultStandaloneEnabler()->CreateInstance();
+        classMapCustomAttribute->SetValue("MapStrategy", ECValue("TablePerHierarchy"));
+        ASSERT_EQ(ECObjectsStatus::Success, classC->SetCustomAttribute(*classMapCustomAttribute));
+
+        ECRelationshipClassP relAB = nullptr;
+        ASSERT_EQ(ECObjectsStatus::Success, schema.CreateRelationshipClass(relAB, "AB", *classA, "Source", *classB, "Target"));
+        ASSERT_EQ(ECObjectsStatus::Success, relAB->GetTarget().SetMultiplicity("(0..*)"));
+
+        ECRelationshipClassP relBC = nullptr;
+        ASSERT_EQ(ECObjectsStatus::Success, schema.CreateRelationshipClass(relBC, "BC", *classB, "Source", *classC, "Target"));
+        ASSERT_EQ(ECObjectsStatus::Success, relBC->GetTarget().SetMultiplicity("(0..*)"));
+
+        auto derivedClasses = RulesEngineTestHelpers::CreateNDerivedClasses(schema, *classC, 100);
+        for (auto derivedClass : derivedClasses)
+            {
+            PrimitiveECPropertyP prop = nullptr;
+            ASSERT_EQ(ECObjectsStatus::Success, derivedClass->CreatePrimitiveProperty(prop, "StringProp", PRIMITIVETYPE_String));
+            }
+        });
+
+    // set up the data
+    auto classA = GetClass("A")->GetEntityClassCP();
+    auto classB = GetClass("B")->GetEntityClassCP();
+    auto classC = GetClass("C")->GetEntityClassCP();
+    auto relAB = GetClass("AB")->GetRelationshipClassCP();
+    auto relBC = GetClass("BC")->GetRelationshipClassCP();
+    bvector<ECEntityClassCP> derivedClasses;
+    for (int i = 0; i < 100; ++i)
+        derivedClasses.push_back(GetClass(Utf8PrintfString("Class%d", i + 1).c_str())->GetEntityClassCP());
+
+    auto instanceA = RulesEngineTestHelpers::InsertInstance(s_project->GetECDb(), *classA);
+    auto instanceB = RulesEngineTestHelpers::InsertInstance(s_project->GetECDb(), *classB);
+    RulesEngineTestHelpers::InsertRelationship(s_project->GetECDb(), *relAB, *instanceA, *instanceB);
+
+    bvector<IECInstancePtr> derivedInstances;
+    for (auto derivedClass : derivedClasses)
+        {
+        derivedInstances.push_back(RulesEngineTestHelpers::InsertInstance(s_project->GetECDb(), *derivedClass));
+        RulesEngineTestHelpers::InsertRelationship(s_project->GetECDb(), *relBC, *instanceB, *derivedInstances.back());
+        }
+
+    // set up ruleset
+    PresentationRuleSetPtr rules = PresentationRuleSet::CreateInstance(BeTest::GetNameOfCurrentTest());
+    m_locater->AddRuleSet(*rules);
+
+    ContentRule* rule = new ContentRule();
+    rule->AddSpecification(*new SelectedNodeInstancesSpecification());
+    rules->AddPresentationRule(*rule);
+
+    ContentModifier* modifier = new ContentModifier(GetSchema()->GetName(), classA->GetName());
+    modifier->AddRelatedProperty(*new RelatedPropertiesSpecification(
+        *new RelationshipPathSpecification({ new RelationshipStepSpecification(relAB->GetFullName(), RequiredRelationDirection_Forward) }),
+        { new PropertySpecification("*") }, RelationshipMeaning::SameInstance, true));
+    modifier->GetRelatedProperties().back()->AddNestedRelatedProperty(*new RelatedPropertiesSpecification(
+        *new RelationshipPathSpecification({ new RelationshipStepSpecification(relBC->GetFullName(), RequiredRelationDirection_Forward), }),
+        { new PropertySpecification("*") }, RelationshipMeaning::SameInstance, true));
+    rules->AddPresentationRule(*modifier);
+
+    // request content
+    ContentDescriptorCPtr descriptor = GetValidatedResponse(m_manager->GetContentDescriptor(AsyncContentDescriptorRequestParams::Create(
+        s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables(), ContentDisplayType::PropertyPane, 0, *KeySet::Create(*instanceA))));
 
     ContentCPtr content = GetVerifiedContent(*descriptor);
     ASSERT_TRUE(content.IsValid());

--- a/iModelCore/ECPresentation/Tests/NonPublished/Integration/Content/Content_RelatedPropertiesTests.cpp
+++ b/iModelCore/ECPresentation/Tests/NonPublished/Integration/Content/Content_RelatedPropertiesTests.cpp
@@ -7368,7 +7368,6 @@ TEST_F(RulesDrivenECPresentationManagerContentTests, CreatesContentForSelectedIn
     // set up the data
     auto classA = GetClass("A")->GetEntityClassCP();
     auto classB = GetClass("B")->GetEntityClassCP();
-    auto classC = GetClass("C")->GetEntityClassCP();
     auto relAB = GetClass("AB")->GetRelationshipClassCP();
     auto relBC = GetClass("BC")->GetRelationshipClassCP();
     bvector<ECEntityClassCP> derivedClasses;


### PR DESCRIPTION
Fixes https://github.com/iTwin/itwinjs-backlog/issues/846.

1. Related content may have a large number of nested related content fields, causing us to exceed max joins limit. So we have to handle related content similar to how we handle direct content - count related classes and query related content separately if the number of related classes is too large.

2. When counting related classes, we have to add one for every navigation property as they require joining the target class.