### PR TITLE
Patch FontDb::Load to correctly load fonts with many faces

### DIFF
--- a/iModelCore/iModelPlatform/DgnCore/FontManager.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/FontManager.cpp
@@ -316,7 +316,7 @@ void FontDb::Load() const {
             FontFace face(row);
             if (!face.m_familyName.empty())
                 reader->m_faces.emplace_back(face);
-            return true; // keep going
+            return false; // keep going
         });
         AddDbReader(reader);
     }


### PR DESCRIPTION
TTC data is embedded as a single row in be_Prop, and its metadata describes all the faces in the collection. The intent and comment of FontDb::Load was correct, but you should return false in ForEachArrayMember's callback to continue iterating.