### PR TITLE
make writeLockExpires a getter

### DIFF
--- a/iModelJsNodeAddon/JsCloudSqlite.cpp
+++ b/iModelJsNodeAddon/JsCloudSqlite.cpp
@@ -438,7 +438,8 @@ struct JsCloudContainer : CloudContainer, Napi::ObjectWrap<JsCloudContainer> {
     Napi::Value GetWriteLockExpiryTime(NapiInfoCR) {
         RequireConnected();
         BeJsDocument lockedBy;
-        ReadWriteLock(lockedBy); // What if write lock is empty? 
+        ReadWriteLock(lockedBy); 
+        // Returns empty string if writeLock is empty.
         return Napi::String::New(Env(), lockedBy[JSON_NAME(expires)].asString());
     }
 

--- a/iModelJsNodeAddon/JsCloudSqlite.cpp
+++ b/iModelJsNodeAddon/JsCloudSqlite.cpp
@@ -435,6 +435,13 @@ struct JsCloudContainer : CloudContainer, Napi::ObjectWrap<JsCloudContainer> {
         });
     }
 
+    Napi::Value GetWriteLockExpiryTime(NapiInfoCR) {
+        RequireConnected();
+        BeJsDocument lockedBy;
+        ReadWriteLock(lockedBy); // What if write lock is empty? 
+        return Napi::String::New(Env(), lockedBy[JSON_NAME(expires)].asString());
+    }
+
     void ReadWriteLock(BeJsDocument& out) {
         Statement stmt;
         auto rc = stmt.Prepare(m_containerDb, "SELECT value FROM bcv_kv WHERE name=?");
@@ -654,6 +661,7 @@ struct JsCloudContainer : CloudContainer, Napi::ObjectWrap<JsCloudContainer> {
             InstanceAccessor<&JsCloudContainer::IsWriteable>("isWriteable"),
             InstanceAccessor<&JsCloudContainer::IsPublic>("isPublic"),
             InstanceAccessor<&JsCloudContainer::GetBlockSize>("blockSize"),
+            InstanceAccessor<&JsCloudContainer::GetWriteLockExpiryTime>("writeLockExpires"),
             InstanceMethod<&JsCloudContainer::AbandonChanges>("abandonChanges"),
             InstanceMethod<&JsCloudContainer::AcquireWriteLockJs>("acquireWriteLock"),
             InstanceMethod<&JsCloudContainer::CleanDeletedBlocks>("cleanDeletedBlocks"),

--- a/iModelJsNodeAddon/api_package/ts/src/NativeLibrary.ts
+++ b/iModelJsNodeAddon/api_package/ts/src/NativeLibrary.ts
@@ -1006,7 +1006,6 @@ export declare namespace IModelJsNative {
     public get logId(): string;
     /** The time that the write lock expires. Of the form 'YYYY-MM-DDTHH:MM:SS.000Z' in UTC.
      *  Returns empty string if write lock is not held.
-
      */
     public get writeLockExpires(): string;
     /** true if this CloudContainer is currently connected to a CloudCache via the `connect` method. */

--- a/iModelJsNodeAddon/api_package/ts/src/NativeLibrary.ts
+++ b/iModelJsNodeAddon/api_package/ts/src/NativeLibrary.ts
@@ -1004,6 +1004,10 @@ export declare namespace IModelJsNative {
     public get alias(): string;
     /** The logId. */
     public get logId(): string;
+    /** The time that the write lock expires. Of the form 'YYYY-MM-DDTHH:MM:SS.000Z' in UTC.
+     *  Returns empty string if no write lock expiry time.
+     */
+    public get writeLockExpires(): string;
     /** true if this CloudContainer is currently connected to a CloudCache via the `connect` method. */
     public get isConnected(): boolean;
     /** true if this CloudContainer was created with the `writeable` flag (and its `accessToken` supplies write access). */

--- a/iModelJsNodeAddon/api_package/ts/src/NativeLibrary.ts
+++ b/iModelJsNodeAddon/api_package/ts/src/NativeLibrary.ts
@@ -1005,7 +1005,8 @@ export declare namespace IModelJsNative {
     /** The logId. */
     public get logId(): string;
     /** The time that the write lock expires. Of the form 'YYYY-MM-DDTHH:MM:SS.000Z' in UTC.
-     *  Returns empty string if no write lock expiry time.
+     *  Returns empty string if write lock is not held.
+
      */
     public get writeLockExpires(): string;
     /** true if this CloudContainer is currently connected to a CloudCache via the `connect` method. */


### PR DESCRIPTION
itwinjs-core: https://github.com/iTwin/itwinjs-core/tree/nick/exposebcvkvtime

I noticed that write lock expiry time no longer gets updated when you call acquireWriteLock in TS with the same user. I didn't want to test against the containerInternal object and preferred to have validation from the getter that I'm adding in which reads the actual bcv_kv table. 