### PR TITLE
Allow customize instance json using OPTIONS flag

### DIFF
--- a/iModelCore/ECDb/CHANGES.md
+++ b/iModelCore/ECDb/CHANGES.md
@@ -5,7 +5,27 @@ This document including important changes to syntax or file format.
 | Module  | Version   |
 | ------- | --------- |
 | Profile | `4.0.0.3` |
-| ECSQL   | `1.2.6.0` |
+| ECSQL   | `1.2.7.0` |
+
+## `9/7/2023`: Add option to customize ECSQL Instance
+
+1. ECSql version updated to `1.2.6.0` -> `1.2.7.0`.
+2. Added following `ECSQLOPTIONS` or `OPTIONS`
+   * `USE_JS_PROP_NAMES` returns json compilable with iTwin.js typescript.
+   * `DO_NOT_TRUNCATE_BLOB` return full blob instead of truncating it.
+3. Instance access now add `json()` around `extract_inst()` function.
+
+Following return iTwin.js compilable json
+
+```sql
+  SELECT $ FROM Bis.Element OPTIONS USE_JS_PROP_NAMES
+```
+
+Following return complete blob as base64
+
+```sql
+  SELECT $ FROM  Bis.GeometricElement3d OPTIONS DO_NOT_TRUNCATE_BLOB
+```
 
 ## `9/6/2023`: Changes to ECSQLOPTIONS
 

--- a/iModelCore/ECDb/ECDb/BuiltInFuncs.h
+++ b/iModelCore/ECDb/ECDb/BuiltInFuncs.h
@@ -188,7 +188,7 @@ struct ExtractInstFunc final : ScalarFunction {
         void _ComputeScalar(Context& ctx, int nArgs, DbValue* args) override;
 
     public:
-        explicit ExtractInstFunc(ECDbCR ecdb) : ScalarFunction(SQLFUNC_ExtractInst, 2, DbValueType::TextVal), m_ecdb(ecdb) {}
+        explicit ExtractInstFunc(ECDbCR ecdb) : ScalarFunction(SQLFUNC_ExtractInst, 3, DbValueType::TextVal), m_ecdb(ecdb) {}
         ~ExtractInstFunc() {}
         static std::unique_ptr<ExtractInstFunc> Create(ECDbCR);
 };

--- a/iModelCore/ECDb/ECDb/ECSql/ECSqlPreparer.h
+++ b/iModelCore/ECDb/ECDb/ECSql/ECSqlPreparer.h
@@ -39,6 +39,7 @@ struct ECSqlExpPreparer final
         static void RemovePropertyRefs(ECSqlPrepareContext&, ClassRefExp const&, ClassMap const&);
         // query options
         static bool QueryOptionExperimentalFeaturesEnabled(ECDbCR db, ExpCR exp);
+        static unsigned int QueryOptionsInstanceFlags(ExpCR exp);
 
     public:
         static ECSqlStatus PrepareAllOrAnyExp(ECSqlPrepareContext&, AllOrAnyExp const&);

--- a/iModelCore/ECDb/ECDb/ECSql/OptionsExp.cpp
+++ b/iModelCore/ECDb/ECDb/ECSql/OptionsExp.cpp
@@ -10,19 +10,6 @@ BEGIN_BENTLEY_SQLITE_EC_NAMESPACE
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //+---------------+---------------+---------------+---------------+---------------+------
-//static
-Utf8CP const OptionsExp::NOECCLASSIDFILTER_OPTION = "NoECClassIdFilter";
-
-//---------------------------------------------------------------------------------------
-// @bsimethod
-//+---------------+---------------+---------------+---------------+---------------+------
-//static
-Utf8CP const OptionsExp::READONLYPROPERTIESAREUPDATABLE_OPTION = "ReadonlyPropertiesAreUpdatable";
-Utf8CP const OptionsExp::ENABLE_EXPERIMENTAL_FEATURES = "ENABLE_EXPERIMENTAL_FEATURES";
-
-//---------------------------------------------------------------------------------------
-// @bsimethod
-//+---------------+---------------+---------------+---------------+---------------+------
 BentleyStatus OptionsExp::AddOptionExp(std::unique_ptr<OptionExp> optionExp, IssueDataSource const& issues)
     {
     Utf8CP name = optionExp->GetName();

--- a/iModelCore/ECDb/ECDb/ECSql/OptionsExp.h
+++ b/iModelCore/ECDb/ECDb/ECSql/OptionsExp.h
@@ -41,9 +41,11 @@ struct OptionsExp final : Exp
     using OptionMap = bmap<Utf8CP, size_t, CompareIUtf8Ascii>;
 
 public:
-    static Utf8CP const NOECCLASSIDFILTER_OPTION;
-    static Utf8CP const READONLYPROPERTIESAREUPDATABLE_OPTION;
-    static Utf8CP const ENABLE_EXPERIMENTAL_FEATURES;
+    static Utf8CP constexpr NOECCLASSIDFILTER_OPTION="NoECClassIdFilter";
+    static Utf8CP constexpr READONLYPROPERTIESAREUPDATABLE_OPTION="ReadonlyPropertiesAreUpdatable";
+    static Utf8CP constexpr ENABLE_EXPERIMENTAL_FEATURES = "ENABLE_EXPERIMENTAL_FEATURES";
+    static Utf8CP constexpr USE_JS_PROP_NAMES = "USE_JS_PROP_NAMES";
+    static Utf8CP constexpr DO_NOT_TRUNCATE_BLOB = "DO_NOT_TRUNCATE_BLOB";
 
 private:
     OptionMap m_optionsByName;

--- a/iModelCore/ECDb/ECDb/QueryJsonAdaptor.cpp
+++ b/iModelCore/ECDb/ECDb/QueryJsonAdaptor.cpp
@@ -39,10 +39,30 @@ BentleyStatus QueryJsonAdaptor::RenderRow(BeJsValue rowJson, IECSqlRow const& st
                 continue;
             }
 
-            auto memberProp = ecsqlValue.GetColumnInfo().GetProperty();
+            const auto memberProp = ecsqlValue.GetColumnInfo().GetProperty();
             if (m_useJsName) {
+                const auto prim = memberProp->GetAsPrimitiveProperty();
                 Utf8String memberName = memberProp->GetName();
-                ECN::ECJsonUtilities::LowerFirstChar(memberName);
+                if (prim && !prim->GetExtendedTypeName().empty()) {
+                    const auto extendTypeId = ExtendedTypeHelper::GetExtendedType(prim->GetExtendedTypeName());
+                    if (extendTypeId == ExtendedTypeHelper::ExtendedType::Id)
+                        memberName = ECN::ECJsonSystemNames::Id();
+                    else if(extendTypeId == ExtendedTypeHelper::ExtendedType::ClassId)
+                        memberName = ECN::ECJsonSystemNames::ClassName();
+                    else if(extendTypeId == ExtendedTypeHelper::ExtendedType::SourceId)
+                        memberName = ECN::ECJsonSystemNames::SourceId();
+                    else if(extendTypeId == ExtendedTypeHelper::ExtendedType::SourceClassId)
+                        memberName = ECN::ECJsonSystemNames::SourceClassName();
+                    else if(extendTypeId == ExtendedTypeHelper::ExtendedType::TargetId)
+                        memberName = ECN::ECJsonSystemNames::TargetId();
+                    else if(extendTypeId == ExtendedTypeHelper::ExtendedType::TargetClassId)
+                        memberName = ECN::ECJsonSystemNames::TargetClassName();
+                    else
+                        ECN::ECJsonUtilities::LowerFirstChar(memberName);
+                } else {
+                    ECN::ECJsonUtilities::LowerFirstChar(memberName);
+                }
+
                 if (SUCCESS != RenderRootProperty(rowJson[memberName], ecsqlValue))
                     return ERROR;
             } else {
@@ -348,13 +368,13 @@ void QueryJsonAdaptor::GetMetaData(QueryProperty::List& list, ECSqlStatement con
         std::string className = col.IsGeneratedProperty() || isSystem ? "" : prop->GetClass().GetFullName();
         std::string typeName = col.GetDataType().IsNavigation() ? "navigation" : prop->GetTypeFullName();
         std::string name = col.IsGeneratedProperty() ? prop->GetDisplayLabel() : prop->GetName();
-        
+
         // Blobs are abbreviated as a Json string with info about the blob. See RenderBinaryProperty().
         if (m_abbreviateBlobs && typeName == "binary") {
             typeName = "string";
             extendType = "Json";
         }
-        
+
         if (col.IsGeneratedProperty()) {
             jsName.assign(prop->GetDisplayLabel());
             if (jsName.empty()) {

--- a/iModelCore/ECDb/PublicAPI/ECDb/ECDb.h
+++ b/iModelCore/ECDb/PublicAPI/ECDb/ECDb.h
@@ -303,7 +303,7 @@ public:
     //         e.g. Remove a sql function or change required argument or format of its return value.
     //  Sub1:  Backward compatible change to 'Syntax'. For example adding new syntax/functions but not breaking any existing.
     //  Sub2:  Backward compatible change to 'Runtime'. For example adding a new sql function.
-    static BeVersion GetECSqlVersion() { return BeVersion(1, 2, 6, 0); }
+    static BeVersion GetECSqlVersion() { return BeVersion(1, 2, 7, 0); }
 
     //! Gets the current version of the ECDb profile
     static ProfileVersion CurrentECDbProfileVersion() { return ProfileVersion(4, 0, 0, 3); }

--- a/iModelCore/ECDb/PublicAPI/ECDb/InstanceReader.h
+++ b/iModelCore/ECDb/PublicAPI/ECDb/InstanceReader.h
@@ -17,6 +17,10 @@ BEGIN_BENTLEY_SQLITE_EC_NAMESPACE
 //! @internal Allow fast reading of full instance by its classid and instanceId
 //=======================================================================================
 struct InstanceReader final {
+    public:
+    constexpr static unsigned FLAGS_UseJsPropertyNames = 0x1u;
+    constexpr static unsigned FLAGS_DoNotTruncateBlobs = 0x2u;
+
     struct JsonParams {
         private:
             bool m_abbreviateBlobs:1;
@@ -59,12 +63,12 @@ struct InstanceReader final {
             Position(ECInstanceId instanceId,  ECN::ECClassId classId, Utf8CP accessString = nullptr):
                 m_instanceId(instanceId), m_classId(classId), m_accessString(accessString),m_classFullName(nullptr){}
             Position(ECInstanceId instanceId, Utf8CP classFullName, Utf8CP accessString = nullptr):
-                m_instanceId(instanceId), m_classFullName(classFullName), m_accessString(accessString){} 
+                m_instanceId(instanceId), m_classFullName(classFullName), m_accessString(accessString){}
             ECN::ECClassId GetClassId() const { return m_classId; }
             ECInstanceId GetInstanceId() const { return m_instanceId; }
             Utf8CP GetAccessString() const { return m_accessString; }
             Utf8CP GetClassFullName() const { return m_classFullName; }
-            Position Resolve(ECN::ECClassId classId) const { 
+            Position Resolve(ECN::ECClassId classId) const {
                 return Position(m_instanceId, classId, m_accessString) ;
             }
     };

--- a/iModelCore/ECDb/Tests/NonPublished/ECDbTests.cpp
+++ b/iModelCore/ECDb/Tests/NonPublished/ECDbTests.cpp
@@ -538,7 +538,7 @@ TEST_F(ECDbTestFixture, GetAndChangeGUIDForDb)
 //+---------------+---------------+---------------+---------------+---------------+------
 TEST_F(ECDbTestFixture, CurrentECSqlVersion)
     {
-    BeVersion expectedVersion (1, 2, 6, 0);
+    BeVersion expectedVersion (1, 2, 7, 0);
     ASSERT_EQ(ECDb::GetECSqlVersion(), expectedVersion);
     }
 

--- a/iModelCore/ECDb/Tests/NonPublished/InstanceReaderTest.cpp
+++ b/iModelCore/ECDb/Tests/NonPublished/InstanceReaderTest.cpp
@@ -663,7 +663,7 @@ TEST_F(InstanceReaderFixture, check_option_DO_NOT_TRUNCATE_BLOB) {
     if ("do not truncate geometryStream/BLOB") {
         ECSqlStatement stmt;
         ASSERT_EQ(ECSqlStatus::Success, stmt.Prepare(m_ecdb, "SELECT $ FROM Bis.GeometricElement3d OPTIONS USE_JS_PROP_NAMES DO_NOT_TRUNCATE_BLOB"));
-        ASSERT_STREQ(stmt.GetNativeSql(), "SELECT json(extract_inst([GeometricElement3d].[ECClassId],[GeometricElement3d].[ECInstanceId], 0x5)) FROM (SELECT [bis_GeometricElement3d].[ElementId] ECInstanceId,[bis_GeometricElement3d].[ECClassId] FROM [main].[bis_GeometricElement3d]) [GeometricElement3d]");
+        ASSERT_STREQ(stmt.GetNativeSql(), "SELECT json(extract_inst([GeometricElement3d].[ECClassId],[GeometricElement3d].[ECInstanceId], 0x3)) FROM (SELECT [bis_GeometricElement3d].[ElementId] ECInstanceId,[bis_GeometricElement3d].[ECClassId] FROM [main].[bis_GeometricElement3d]) [GeometricElement3d]");
         BeJsDocument expectedDoc;
         expectedDoc.Parse(R"x({
             "id": "0x38",
@@ -754,7 +754,7 @@ TEST_F(InstanceReaderFixture, optional_and_non_optional_properties) {
 
         Utf8String nativeSql = stmt.GetNativeSql();
         ASSERT_TRUE(nativeSql.Contains(R"x(INNER JOIN class_props('["Url"]'))x"));
-        ASSERT_TRUE(nativeSql.Contains(R"x(WHERE extract_prop([Element].[ECClassId],[Element].[ECInstanceId],'Url')='file:///d|/dgn/rf2.dgn')x"));
+        ASSERT_TRUE(nativeSql.Contains(R"x(WHERE extract_prop([Element].[ECClassId],[Element].[ECInstanceId],'Url',0x0)='file:///d|/dgn/rf2.dgn')x"));
     }
 
     if ("optional property must not be part of class_props filter") {
@@ -766,7 +766,7 @@ TEST_F(InstanceReaderFixture, optional_and_non_optional_properties) {
 
         Utf8String nativeSql = stmt.GetNativeSql();
         ASSERT_FALSE(nativeSql.Contains(R"x(INNER JOIN class_props('["Url"]'))x"));
-        ASSERT_TRUE(nativeSql.Contains(R"x(WHERE extract_prop([Element].[ECClassId],[Element].[ECInstanceId],'Url')='file:///d|/dgn/rf2.dgn')x"));
+        ASSERT_TRUE(nativeSql.Contains(R"x(WHERE extract_prop([Element].[ECClassId],[Element].[ECInstanceId],'Url',0x0)='file:///d|/dgn/rf2.dgn')x"));
     }
 
     if ("multiple required properties") {
@@ -782,8 +782,8 @@ TEST_F(InstanceReaderFixture, optional_and_non_optional_properties) {
 
         Utf8String nativeSql = stmt.GetNativeSql();
         ASSERT_TRUE(nativeSql.Contains(R"x(INNER JOIN class_props('["Roll","Yaw"]'))x"));
-        ASSERT_TRUE(nativeSql.Contains(R"x(FLOOR(extract_prop([Element].[ECClassId],[Element].[ECInstanceId],'Yaw'))=65)x"));
-        ASSERT_TRUE(nativeSql.Contains(R"x(FLOOR(extract_prop([Element].[ECClassId],[Element].[ECInstanceId],'Roll'))=63)x"));
+        ASSERT_TRUE(nativeSql.Contains(R"x(FLOOR(extract_prop([Element].[ECClassId],[Element].[ECInstanceId],'Yaw',0x0))=65)x"));
+        ASSERT_TRUE(nativeSql.Contains(R"x(FLOOR(extract_prop([Element].[ECClassId],[Element].[ECInstanceId],'Roll',0x0))=63)x"));
     }
 
     if ("one required and one optional properties") {
@@ -799,8 +799,8 @@ TEST_F(InstanceReaderFixture, optional_and_non_optional_properties) {
 
         Utf8String nativeSql = stmt.GetNativeSql();
         ASSERT_TRUE(nativeSql.Contains(R"x(INNER JOIN class_props('["Yaw"]'))x"));
-        ASSERT_TRUE(nativeSql.Contains(R"x(FLOOR(extract_prop([Element].[ECClassId],[Element].[ECInstanceId],'Yaw'))=65)x"));
-        ASSERT_TRUE(nativeSql.Contains(R"x(FLOOR(extract_prop([Element].[ECClassId],[Element].[ECInstanceId],'Roll'))=63)x"));
+        ASSERT_TRUE(nativeSql.Contains(R"x(FLOOR(extract_prop([Element].[ECClassId],[Element].[ECInstanceId],'Yaw',0x0))=65)x"));
+        ASSERT_TRUE(nativeSql.Contains(R"x(FLOOR(extract_prop([Element].[ECClassId],[Element].[ECInstanceId],'Roll',0x0))=63)x"));
     }
 
     if ("non existing non optional property ORed") {
@@ -810,9 +810,9 @@ TEST_F(InstanceReaderFixture, optional_and_non_optional_properties) {
 
         Utf8String nativeSql = stmt.GetNativeSql();
         ASSERT_TRUE(nativeSql.Contains(R"x(INNER JOIN class_props('["NonExistingRequiredProp"]'))x"));
-        ASSERT_TRUE(nativeSql.Contains(R"x(FLOOR(extract_prop([Element].[ECClassId],[Element].[ECInstanceId],'Yaw'))=65)x"));
-        ASSERT_TRUE(nativeSql.Contains(R"x(FLOOR(extract_prop([Element].[ECClassId],[Element].[ECInstanceId],'Roll'))=63)x"));
-        ASSERT_TRUE(nativeSql.Contains(R"x(extract_prop([Element].[ECClassId],[Element].[ECInstanceId],'NonExistingRequiredProp')=65)x"));
+        ASSERT_TRUE(nativeSql.Contains(R"x(FLOOR(extract_prop([Element].[ECClassId],[Element].[ECInstanceId],'Yaw',0x0))=65)x"));
+        ASSERT_TRUE(nativeSql.Contains(R"x(FLOOR(extract_prop([Element].[ECClassId],[Element].[ECInstanceId],'Roll',0x0))=63)x"));
+        ASSERT_TRUE(nativeSql.Contains(R"x(extract_prop([Element].[ECClassId],[Element].[ECInstanceId],'NonExistingRequiredProp',0x0)=65)x"));
     }
 
     if ("non existing non optional property ANDed") {
@@ -822,9 +822,9 @@ TEST_F(InstanceReaderFixture, optional_and_non_optional_properties) {
 
         Utf8String nativeSql = stmt.GetNativeSql();
         ASSERT_TRUE(nativeSql.Contains(R"x(INNER JOIN class_props('["NonExistingRequiredProp"]'))x"));
-        ASSERT_TRUE(nativeSql.Contains(R"x(FLOOR(extract_prop([Element].[ECClassId],[Element].[ECInstanceId],'Yaw'))=65)x"));
-        ASSERT_TRUE(nativeSql.Contains(R"x(FLOOR(extract_prop([Element].[ECClassId],[Element].[ECInstanceId],'Roll'))=63)x"));
-        ASSERT_TRUE(nativeSql.Contains(R"x(extract_prop([Element].[ECClassId],[Element].[ECInstanceId],'NonExistingRequiredProp')=65)x"));
+        ASSERT_TRUE(nativeSql.Contains(R"x(FLOOR(extract_prop([Element].[ECClassId],[Element].[ECInstanceId],'Yaw',0x0))=65)x"));
+        ASSERT_TRUE(nativeSql.Contains(R"x(FLOOR(extract_prop([Element].[ECClassId],[Element].[ECInstanceId],'Roll',0x0))=63)x"));
+        ASSERT_TRUE(nativeSql.Contains(R"x(extract_prop([Element].[ECClassId],[Element].[ECInstanceId],'NonExistingRequiredProp',0x0)=65)x"));
     }
 
     if ("non existing optional property ANDed") {
@@ -834,9 +834,9 @@ TEST_F(InstanceReaderFixture, optional_and_non_optional_properties) {
 
         Utf8String nativeSql = stmt.GetNativeSql();
         ASSERT_FALSE(nativeSql.Contains(R"x(INNER JOIN class_props)x"));
-        ASSERT_TRUE(nativeSql.Contains(R"x(FLOOR(extract_prop([Element].[ECClassId],[Element].[ECInstanceId],'Yaw'))=65)x"));
-        ASSERT_TRUE(nativeSql.Contains(R"x(FLOOR(extract_prop([Element].[ECClassId],[Element].[ECInstanceId],'Roll'))=63)x"));
-        ASSERT_TRUE(nativeSql.Contains(R"x(extract_prop([Element].[ECClassId],[Element].[ECInstanceId],'NonExistingRequiredProp')=65)x"));
+        ASSERT_TRUE(nativeSql.Contains(R"x(FLOOR(extract_prop([Element].[ECClassId],[Element].[ECInstanceId],'Yaw',0x0))=65)x"));
+        ASSERT_TRUE(nativeSql.Contains(R"x(FLOOR(extract_prop([Element].[ECClassId],[Element].[ECInstanceId],'Roll',0x0))=63)x"));
+        ASSERT_TRUE(nativeSql.Contains(R"x(extract_prop([Element].[ECClassId],[Element].[ECInstanceId],'NonExistingRequiredProp',0x0)=65)x"));
     }
 
     if ("non existing optional property ORed") {
@@ -852,9 +852,9 @@ TEST_F(InstanceReaderFixture, optional_and_non_optional_properties) {
 
         Utf8String nativeSql = stmt.GetNativeSql();
         ASSERT_FALSE(nativeSql.Contains(R"x(INNER JOIN class_props)x"));
-        ASSERT_TRUE(nativeSql.Contains(R"x(FLOOR(extract_prop([Element].[ECClassId],[Element].[ECInstanceId],'Yaw'))=65)x"));
-        ASSERT_TRUE(nativeSql.Contains(R"x(FLOOR(extract_prop([Element].[ECClassId],[Element].[ECInstanceId],'Roll'))=63)x"));
-        ASSERT_TRUE(nativeSql.Contains(R"x(extract_prop([Element].[ECClassId],[Element].[ECInstanceId],'NonExistingOptionalProp')=65)x"));
+        ASSERT_TRUE(nativeSql.Contains(R"x(FLOOR(extract_prop([Element].[ECClassId],[Element].[ECInstanceId],'Yaw',0x0))=65)x"));
+        ASSERT_TRUE(nativeSql.Contains(R"x(FLOOR(extract_prop([Element].[ECClassId],[Element].[ECInstanceId],'Roll',0x0))=63)x"));
+        ASSERT_TRUE(nativeSql.Contains(R"x(extract_prop([Element].[ECClassId],[Element].[ECInstanceId],'NonExistingOptionalProp',0x0)=65)x"));
     }
 }
 
@@ -1072,7 +1072,7 @@ TEST_F(InstanceReaderFixture, ecsql_read_instance) {
 
     ASSERT_EQ(BE_SQLITE_ROW, stmt.Step());
 
-    ASSERT_STREQ(stmt.GetNativeSql(), "SELECT extract_inst([ECClassDef].[ECClassId],[ECClassDef].[ECInstanceId]) FROM (SELECT [Id] ECInstanceId,32 ECClassId,[Description] FROM [main].[ec_Class]) [ECClassDef] WHERE [ECClassDef].[Description]='Relates the property to its PropertyCategory.'");
+    ASSERT_STREQ(stmt.GetNativeSql(), "SELECT json(extract_inst([ECClassDef].[ECClassId],[ECClassDef].[ECInstanceId], 0x0)) FROM (SELECT [Id] ECInstanceId,32 ECClassId,[Description] FROM [main].[ec_Class]) [ECClassDef] WHERE [ECClassDef].[Description]='Relates the property to its PropertyCategory.'");
     ASSERT_STREQ(stmt.GetValueText(0), R"json({"ECInstanceId":"0x2e","ECClassId":"0x20","Schema":{"Id":"0x4","RelECClassId":"0x21"},"Name":"PropertyHasCategory","Description":"Relates the property to its PropertyCategory.","Type":1,"Modifier":2,"RelationshipStrength":0,"RelationshipStrengthDirection":1})json");
 }
 
@@ -1090,7 +1090,7 @@ TEST_F(InstanceReaderFixture, ecsql_read_property) {
     )sql"));
 
     ASSERT_EQ(BE_SQLITE_ROW, stmt.Step());
-    ASSERT_STREQ(stmt.GetNativeSql(), "SELECT extract_prop([ECClassDef].[ECClassId],[ECClassDef].[ECInstanceId],'name',:ecdb_this_ptr,0) FROM (SELECT [Id] ECInstanceId,32 ECClassId,[Description] FROM [main].[ec_Class]) [ECClassDef] WHERE [ECClassDef].[Description]='Relates the property to its PropertyCategory.'");
+    ASSERT_STREQ(stmt.GetNativeSql(), "SELECT extract_prop([ECClassDef].[ECClassId],[ECClassDef].[ECInstanceId],'name',0x0,:ecdb_this_ptr,0) FROM (SELECT [Id] ECInstanceId,32 ECClassId,[Description] FROM [main].[ec_Class]) [ECClassDef] WHERE [ECClassDef].[Description]='Relates the property to its PropertyCategory.'");
     ASSERT_STREQ(stmt.GetValueText(0), "PropertyHasCategory");
 }
 
@@ -1167,7 +1167,7 @@ TEST_F(InstanceReaderFixture, instance_reader) {
 
     ECSqlStatement stmt;
     ASSERT_EQ(ECSqlStatus::Success, stmt.Prepare(m_ecdb, R"sql(
-        SELECT ECClassId, ECInstanceId, EXTRACT_INST('meta.ecClassDef',ECInstanceId) FROM meta.ECClassDef WHERE Description='Relates the property to its PropertyCategory.'
+        SELECT ECClassId, ECInstanceId, EXTRACT_INST('meta.ecClassDef',ECInstanceId,0x0) FROM meta.ECClassDef WHERE Description='Relates the property to its PropertyCategory.'
     )sql"));
 
     BeJsDocument doc;
@@ -1196,7 +1196,7 @@ TEST_F(InstanceReaderFixture, instance_reader) {
     if ("use syntax to get full instance") {
         ECSqlStatement stmt;
         ASSERT_EQ(ECSqlStatus::Success, stmt.Prepare(m_ecdb, "SELECT ECClassId, ECInstanceId, $ FROM meta.ECClassDef WHERE Description='Relates the property to its PropertyCategory.'"));
-        const auto expectedSQL = "SELECT [ECClassDef].[ECClassId],[ECClassDef].[ECInstanceId],extract_inst([ECClassDef].[ECClassId],[ECClassDef].[ECInstanceId]) FROM (SELECT [Id] ECInstanceId,32 ECClassId,[Description] FROM [main].[ec_Class]) [ECClassDef] WHERE [ECClassDef].[Description]='Relates the property to its PropertyCategory.'";
+        const auto expectedSQL = "SELECT [ECClassDef].[ECClassId],[ECClassDef].[ECInstanceId],json(extract_inst([ECClassDef].[ECClassId],[ECClassDef].[ECInstanceId], 0x0)) FROM (SELECT [Id] ECInstanceId,32 ECClassId,[Description] FROM [main].[ec_Class]) [ECClassDef] WHERE [ECClassDef].[Description]='Relates the property to its PropertyCategory.'";
         EXPECT_STRCASEEQ(expectedSQL, stmt.GetNativeSql());
         if(stmt.Step() == BE_SQLITE_ROW) {
             BeJsDocument inst;
@@ -1208,7 +1208,7 @@ TEST_F(InstanceReaderFixture, instance_reader) {
     if ("use syntax to get full instance using alias") {
         ECSqlStatement stmt;
         ASSERT_EQ(ECSqlStatus::Success, stmt.Prepare(m_ecdb, "SELECT m.ECClassId, m.ECInstanceId, m.$ FROM meta.ECClassDef m WHERE m.Description='Relates the property to its PropertyCategory.'"));
-        const auto expectedSQL = "SELECT [m].[ECClassId],[m].[ECInstanceId],extract_inst([m].[ECClassId],[m].[ECInstanceId]) FROM (SELECT [Id] ECInstanceId,32 ECClassId,[Description] FROM [main].[ec_Class]) [m] WHERE [m].[Description]='Relates the property to its PropertyCategory.'";
+        const auto expectedSQL = "SELECT [m].[ECClassId],[m].[ECInstanceId],json(extract_inst([m].[ECClassId],[m].[ECInstanceId], 0x0)) FROM (SELECT [Id] ECInstanceId,32 ECClassId,[Description] FROM [main].[ec_Class]) [m] WHERE [m].[Description]='Relates the property to its PropertyCategory.'";
         EXPECT_STRCASEEQ(expectedSQL, stmt.GetNativeSql());
         if(stmt.Step() == BE_SQLITE_ROW) {
             BeJsDocument inst;
@@ -1632,16 +1632,16 @@ TEST_F(InstanceReaderFixture, extract_prop) {
 
     const auto sql =
         "SELECT                                        "
-        "   EXTRACT_INST(ecClassId, ecInstanceId),"
-        "   EXTRACT_PROP(ecClassId, ecInstanceId, 's'  ),"
-        "   EXTRACT_PROP(ecClassId, ecInstanceId, 'i'  ),"
-        "   EXTRACT_PROP(ecClassId, ecInstanceId, 'd'  ),"
-        "   EXTRACT_PROP(ecClassId, ecInstanceId, 'p2d'),"
-        "   EXTRACT_PROP(ecClassId, ecInstanceId, 'p3d'),"
-        "   EXTRACT_PROP(ecClassId, ecInstanceId, 'bi' ),"
-        "   EXTRACT_PROP(ecClassId, ecInstanceId, 'l'  ),"
-        "   EXTRACT_PROP(ecClassId, ecInstanceId, 'dt' ),"
-        "   EXTRACT_PROP(ecClassId, ecInstanceId, 'b'  ) "
+        "   EXTRACT_INST(ecClassId, ecInstanceId, 0),"
+        "   EXTRACT_PROP(ecClassId, ecInstanceId, 's'  , 0),"
+        "   EXTRACT_PROP(ecClassId, ecInstanceId, 'i'  , 0),"
+        "   EXTRACT_PROP(ecClassId, ecInstanceId, 'd'  , 0),"
+        "   EXTRACT_PROP(ecClassId, ecInstanceId, 'p2d', 0),"
+        "   EXTRACT_PROP(ecClassId, ecInstanceId, 'p3d', 0),"
+        "   EXTRACT_PROP(ecClassId, ecInstanceId, 'bi' , 0),"
+        "   EXTRACT_PROP(ecClassId, ecInstanceId, 'l'  , 0),"
+        "   EXTRACT_PROP(ecClassId, ecInstanceId, 'dt' , 0),"
+        "   EXTRACT_PROP(ecClassId, ecInstanceId, 'b'  , 0) "
         "FROM ts.P                                     ";
 
     ECSqlStatement stmt;
@@ -1662,7 +1662,7 @@ TEST_F(InstanceReaderFixture, extract_prop) {
     if ("use syntax to extract property") {
         ECSqlStatement stmt;
         ASSERT_EQ(ECSqlStatus::Success, stmt.Prepare(m_ecdb, "SELECT $->s, $->i, $->d, $->p2d, $->p3d, $->bi, $->l, $->dt, $->b FROM ts.P"));
-        const auto expectedSQL = "SELECT extract_prop([P].[ECClassId],[P].[ECInstanceId],'s',:ecdb_this_ptr,0),extract_prop([P].[ECClassId],[P].[ECInstanceId],'i',:ecdb_this_ptr,1),extract_prop([P].[ECClassId],[P].[ECInstanceId],'d',:ecdb_this_ptr,2),extract_prop([P].[ECClassId],[P].[ECInstanceId],'p2d',:ecdb_this_ptr,3),extract_prop([P].[ECClassId],[P].[ECInstanceId],'p3d',:ecdb_this_ptr,4),extract_prop([P].[ECClassId],[P].[ECInstanceId],'bi',:ecdb_this_ptr,5),extract_prop([P].[ECClassId],[P].[ECInstanceId],'l',:ecdb_this_ptr,6),extract_prop([P].[ECClassId],[P].[ECInstanceId],'dt',:ecdb_this_ptr,7),extract_prop([P].[ECClassId],[P].[ECInstanceId],'b',:ecdb_this_ptr,8) FROM (SELECT [Id] ECInstanceId,73 ECClassId FROM [main].[ts_P]) [P]";
+        const auto expectedSQL = "SELECT extract_prop([P].[ECClassId],[P].[ECInstanceId],'s',0x0,:ecdb_this_ptr,0),extract_prop([P].[ECClassId],[P].[ECInstanceId],'i',0x0,:ecdb_this_ptr,1),extract_prop([P].[ECClassId],[P].[ECInstanceId],'d',0x0,:ecdb_this_ptr,2),extract_prop([P].[ECClassId],[P].[ECInstanceId],'p2d',0x0,:ecdb_this_ptr,3),extract_prop([P].[ECClassId],[P].[ECInstanceId],'p3d',0x0,:ecdb_this_ptr,4),extract_prop([P].[ECClassId],[P].[ECInstanceId],'bi',0x0,:ecdb_this_ptr,5),extract_prop([P].[ECClassId],[P].[ECInstanceId],'l',0x0,:ecdb_this_ptr,6),extract_prop([P].[ECClassId],[P].[ECInstanceId],'dt',0x0,:ecdb_this_ptr,7),extract_prop([P].[ECClassId],[P].[ECInstanceId],'b',0x0,:ecdb_this_ptr,8) FROM (SELECT [Id] ECInstanceId,73 ECClassId FROM [main].[ts_P]) [P]";
         EXPECT_STRCASEEQ(expectedSQL, stmt.GetNativeSql());
         if(stmt.Step() == BE_SQLITE_ROW) {
             int i = 0;


### PR DESCRIPTION
1. ECSql version updated to `1.2.6.0` -> `1.2.7.0`.
2. Added following `ECSQLOPTIONS` or `OPTIONS`
   * `USE_JS_PROP_NAMES` returns json compilable with iTwin.js typescript.
   * `DO_NOT_TRUNCATE_BLOB` return full blob instead of truncating it.
3. Instance access now add `json()` around `extract_inst()` function.

Following return iTwin.js compilable json

```sql
  SELECT $ FROM Bis.Element OPTIONS USE_JS_PROP_NAMES
```

Following return complete blob as base64

```sql
  SELECT $ FROM  Bis.GeometricElement3d OPTIONS DO_NOT_TRUNCATE_BLOB
```

itwinjs-core: https://github.com/iTwin/itwinjs-core/tree/rohitptnkr/use-instance-queries-getAspects
