### PR TITLE
restore existing API method

### DIFF
--- a/iModelCore/GeomLibs/PublicAPI/Mtg/MtgStructs.h
+++ b/iModelCore/GeomLibs/PublicAPI/Mtg/MtgStructs.h
@@ -461,8 +461,10 @@ GEOMDLLIMPEXP MTGNodeId FPred (MTGNodeId nodeId) const;
 /// Navigate to the edge mate of nodeId (at opposite end and opposite side of same edge.)
 GEOMDLLIMPEXP MTGNodeId EdgeMate (MTGNodeId nodeId) const;
 
+// Count the number of face loops whose nodes lack the given face mask
+GEOMDLLIMPEXP size_t CountFaceLoops(MTGMask ignoreMask);
 // Count the number of face loops
-GEOMDLLIMPEXP size_t CountFaceLoops (MTGMask ignoreMask = MTG_NULL_MASK);
+GEOMDLLIMPEXP size_t CountFaceLoops ();
 // Count the number of vertex loops.
 GEOMDLLIMPEXP size_t CountVertexLoops ();
 

--- a/iModelCore/GeomLibs/geom/src/mtg/MTGGraph.cpp
+++ b/iModelCore/GeomLibs/geom/src/mtg/MTGGraph.cpp
@@ -692,6 +692,11 @@ size_t MTGGraph::CountFaceLoops(MTGMask ignoreMask)
     return n;
     }
 
+size_t MTGGraph::CountFaceLoops ()
+    {
+    return CountFaceLoops(MTG_NULL_MASK); 
+    }
+
 size_t MTGGraph::CountVertexLoops ()
     {
     MTGMask visitMask = GrabMask ();


### PR DESCRIPTION
Amending #444

When an arg is added to an existing API method, this breaks C++ binary compatibility, even when a default value is supplied in the signature.

This PR adds an overload instead, and the original method now delegates to the overload.