### PR TITLE
Update SQLite to v3.43.1

### DIFF
--- a/iModelCore/BeSQLite/SQLite/UpdateSqlite.bat
+++ b/iModelCore/BeSQLite/SQLite/UpdateSqlite.bat
@@ -8,7 +8,7 @@ rem +---------------------------------------------------------------------------
 rem This script will update the SQLite source from a fossil branch, and then create the amalgamation `sqlite.c` source file.
 rem @note that it requires cygwin be installed
 
-set sqlite_tag=itwin-sqlite-v3.42.0-r0
+set sqlite_tag=itwin-sqlite-v3.43.1-r0
 set imodel_native_sqlite=%SrcRoot%imodel-native\iModelCore\BeSQLite\SQLite\
 set sqlite_root=%appdata%\itwin-sqlite
 set build_dir=outdir


### PR DESCRIPTION
Updated from [itwin-sqlite-v3.43.1-r0](https://github.com/iTwin/sqlite/releases/tag/itwin-sqlite-v3.43.1-r0)

### 2023-09-11 (3.43.1)

1.  Fix a regression in the way that the [sum()](https://www.sqlite.org/lang_aggfunc.html#sumunc), [avg()](https://www.sqlite.org/lang_aggfunc.html#avg), and [total()](https://www.sqlite.org/lang_aggfunc.html#sumunc) aggregate functions handle infinities.
2.  Fix a bug in the [json\_array\_length()](https://www.sqlite.org/json1.html#jarraylen) function that occurs when the argument comes directly from [json\_remove()](https://www.sqlite.org/json1.html#jrm).
3.  Fix the omit-unused-subquery-columns optimization (introduced in in version 3.42.0) so that it works correctly if the subquery is a compound where one arm is DISTINCT and the other is not.
4.  Other minor fixes.

### 2023-08-24 (3.43.0)

1.  Add support for [Contentless-Delete FTS5 Indexes](https://www.sqlite.org/fts5.html#clssdeltab). This is a variety of [FTS5](https://www.sqlite.org/fts5.html) full-text search index that omits storing the content that is being indexed while also allowing records to be deleted.
2.  Enhancements to the [date and time functions](https://www.sqlite.org/lang_datefunc.html):
    1.  Added new [time shift modifiers](https://www.sqlite.org/lang_datefunc.html#tmshf) of the form ±YYYY-MM-DD HH:MM:SS.SSS.
    2.  Added the [timediff() SQL function](https://www.sqlite.org/lang_datefunc.html#tmdif).
3.  Added the [octet\_length(X)](https://www.sqlite.org/lang_corefunc.html#octet_length) SQL function.
4.  Added the [sqlite3\_stmt\_explain()](https://www.sqlite.org/c3ref/stmt_explain.html) API.
5.  Query planner enhancements:
    1.  Generalize the LEFT JOIN strength reduction optimization so that it works for RIGHT and FULL JOINs as well. Rename it to [OUTER JOIN strength reduction](https://www.sqlite.org/optoverview.html#leftjoinreduction).
    2.  Enhance the theorem prover in the [OUTER JOIN strength reduction](https://www.sqlite.org/optoverview.html#leftjoinreduction) optimization so that it returns fewer false-negatives.
6.  Enhancements to the [decimal extension](https://www.sqlite.org/floatingpoint.html#decext):
    1.  New function decimal\_pow2(N) returns the N-th power of 2 for integer N between -20000 and +20000.
    2.  New function decimal\_exp(X) works like decimal(X) except that it returns the result in exponential notation - with a "e+NN" at the end.
    3.  If X is a floating-point value, then the decimal(X) function now does a full expansion of that value into its exact decimal equivalent.
7.  Performance enhancements to [JSON processing](json1.html) results in a 2x performance improvement for some kinds of processing on large JSON strings.
8.  New makefile target "verify-source" checks to ensure that there are no unintentional changes in the source tree. (Works for [canonical source code](https://www.sqlite.org/getthecode.html) only - not for [precompiled amalgamation tarballs](amalgamation.html#amalgtarball).)
9.  Added the [SQLITE\_USE\_SEH](https://www.sqlite.org/compile.html#use_seh) compile-time option that enables Structured Exception Handling on Windows while working with the memory-mapped [shm file](https://www.sqlite.org/walformat.html#shm) that is part of [WAL mode](https://www.sqlite.org/wal.html) processing. This option is enabled by default when building on Windows using Makefile.msc.
10.  The [VFS](https://www.sqlite.org/vfs.html) for unix now assumes that the nanosleep() system call is available unless compiled with -DHAVE\_NANOSLEEP=0.
    
