### PR TITLE
Fix CA loading when schema context has multiple versions of same schema

### DIFF
--- a/iModelCore/ecobjects/PublicApi/ECObjects/ECContext.h
+++ b/iModelCore/ecobjects/PublicApi/ECObjects/ECContext.h
@@ -223,14 +223,15 @@ struct ECInstanceReadContext : RefCountedBase
 private:
     IStandaloneEnablerLocaterP      m_standaloneEnablerLocater;
     ECSchemaCR                      m_fallBackSchema;
+    ECSchemaCP                      m_containerSchema;
     IPrimitiveTypeResolver const*   m_typeResolver;
     IUnitResolver const*            m_unitResolver;
     IECSchemaRemapperCP             m_schemaRemapper;
     IssueReporter                   m_issueReporter;
 
 protected:
-    ECInstanceReadContext(IStandaloneEnablerLocaterP standaloneEnablerLocater, ECSchemaCR fallBackSchema, IPrimitiveTypeResolver const* typeResolver) 
-        : m_standaloneEnablerLocater (standaloneEnablerLocater), m_fallBackSchema (fallBackSchema), m_typeResolver (typeResolver), m_schemaRemapper (nullptr), m_unitResolver(nullptr)
+    ECInstanceReadContext(IStandaloneEnablerLocaterP standaloneEnablerLocater, ECSchemaCR fallBackSchema, IPrimitiveTypeResolver const* typeResolver, ECSchemaCP containerSchema = nullptr) 
+        : m_standaloneEnablerLocater (standaloneEnablerLocater), m_fallBackSchema (fallBackSchema), m_typeResolver (typeResolver), m_schemaRemapper (nullptr), m_unitResolver(nullptr), m_containerSchema(containerSchema)
         {
         }
 
@@ -258,13 +259,15 @@ public:
 
     ECSchemaCR GetFallBackSchema() {return m_fallBackSchema;}
 
+    ECSchemaCP GetContainerSchema() const {return m_containerSchema;}
+
     IssueReporter& Issues() { return m_issueReporter; }
 public:
     //! - For use when the caller knows the schema of the instance he is deserializing.
     ECOBJECTS_EXPORT static ECInstanceReadContextPtr CreateContext(ECSchemaCR, IStandaloneEnablerLocaterP = nullptr, IPrimitiveTypeResolver const* typeResolver = nullptr);
 
     //! - For use when the caller does not know the schema of the instance he is deserializing.
-    ECOBJECTS_EXPORT static ECInstanceReadContextPtr CreateContext(ECSchemaReadContextR, ECSchemaCR fallBackSchema, ECSchemaPtr* foundSchema);
+    ECOBJECTS_EXPORT static ECInstanceReadContextPtr CreateContext(ECSchemaReadContextR, ECSchemaCR fallBackSchema, ECSchemaPtr* foundSchema, ECSchemaCP containerSchema = nullptr);
 };
 /** @endGroup */
 END_BENTLEY_ECOBJECT_NAMESPACE

--- a/iModelCore/ecobjects/PublicApi/ECObjects/ECContext.h
+++ b/iModelCore/ecobjects/PublicApi/ECObjects/ECContext.h
@@ -223,15 +223,14 @@ struct ECInstanceReadContext : RefCountedBase
 private:
     IStandaloneEnablerLocaterP      m_standaloneEnablerLocater;
     ECSchemaCR                      m_fallBackSchema;
-    ECSchemaCP                      m_containerSchema;
     IPrimitiveTypeResolver const*   m_typeResolver;
     IUnitResolver const*            m_unitResolver;
     IECSchemaRemapperCP             m_schemaRemapper;
     IssueReporter                   m_issueReporter;
 
 protected:
-    ECInstanceReadContext(IStandaloneEnablerLocaterP standaloneEnablerLocater, ECSchemaCR fallBackSchema, IPrimitiveTypeResolver const* typeResolver, ECSchemaCP containerSchema = nullptr) 
-        : m_standaloneEnablerLocater (standaloneEnablerLocater), m_fallBackSchema (fallBackSchema), m_typeResolver (typeResolver), m_schemaRemapper (nullptr), m_unitResolver(nullptr), m_containerSchema(containerSchema)
+    ECInstanceReadContext(IStandaloneEnablerLocaterP standaloneEnablerLocater, ECSchemaCR fallBackSchema, IPrimitiveTypeResolver const* typeResolver) 
+        : m_standaloneEnablerLocater (standaloneEnablerLocater), m_fallBackSchema (fallBackSchema), m_typeResolver (typeResolver), m_schemaRemapper (nullptr), m_unitResolver(nullptr)
         {
         }
 
@@ -259,15 +258,16 @@ public:
 
     ECSchemaCR GetFallBackSchema() {return m_fallBackSchema;}
 
-    ECSchemaCP GetContainerSchema() const {return m_containerSchema;}
-
     IssueReporter& Issues() { return m_issueReporter; }
 public:
     //! - For use when the caller knows the schema of the instance he is deserializing.
     ECOBJECTS_EXPORT static ECInstanceReadContextPtr CreateContext(ECSchemaCR, IStandaloneEnablerLocaterP = nullptr, IPrimitiveTypeResolver const* typeResolver = nullptr);
 
     //! - For use when the caller does not know the schema of the instance he is deserializing.
-    ECOBJECTS_EXPORT static ECInstanceReadContextPtr CreateContext(ECSchemaReadContextR, ECSchemaCR fallBackSchema, ECSchemaPtr* foundSchema, ECSchemaCP containerSchema = nullptr);
+    ECOBJECTS_EXPORT static ECInstanceReadContextPtr CreateContext(ECSchemaReadContextR, ECSchemaCR fallBackSchema, ECSchemaPtr* foundSchema);
+
+    //! - For use when the caller is deserializing custom attributes and has the container schema for the current instance
+    ECOBJECTS_EXPORT static ECInstanceReadContextPtr CreateContextForCA(ECSchemaCR containerSchema, ECSchemaReadContextR schemaContext);
 };
 /** @endGroup */
 END_BENTLEY_ECOBJECT_NAMESPACE

--- a/iModelCore/ecobjects/PublicApi/ECObjects/ECSchema.h
+++ b/iModelCore/ecobjects/PublicApi/ECObjects/ECSchema.h
@@ -96,7 +96,7 @@ protected:
     //! Does not check if the container's ECSchema references the requisite ECSchema(s). @see SupplementedSchemaBuilder::SetMergedCustomAttribute
     ECObjectsStatus SetSupplementedCustomAttribute(IECInstanceR customAttributeInstance);
 
-    CustomAttributeReadStatus ReadCustomAttributes(pugi::xml_node containerNode, ECSchemaReadContextR context, ECSchemaCR fallBackSchema);
+    CustomAttributeReadStatus ReadCustomAttributes(pugi::xml_node containerNode, ECSchemaReadContextR context);
     SchemaWriteStatus WriteCustomAttributes(BeXmlWriterR xmlWriter, ECVersion ecXmlVersion = ECVersion::Latest) const;
     void WriteFilteredCustomAttributes(BeJsValue& parentNode, bool(*skipClassPredicate)(Utf8CP)) const;
     void WriteCustomAttributes(BeJsValue& parentNode) const;

--- a/iModelCore/ecobjects/src/ECCustomAttribute.cpp
+++ b/iModelCore/ecobjects/src/ECCustomAttribute.cpp
@@ -419,9 +419,18 @@ ECClassCR classDefinition
 /*---------------------------------------------------------------------------------**//**
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/
-CustomAttributeReadStatus IECCustomAttributeContainer::ReadCustomAttributes (pugi::xml_node containerNode, ECSchemaReadContextR schemaContext, ECSchemaCR fallBackSchema)
+CustomAttributeReadStatus IECCustomAttributeContainer::ReadCustomAttributes (pugi::xml_node containerNode, ECSchemaReadContextR schemaContext)
     {
     CustomAttributeReadStatus status = CustomAttributeReadStatus::Success;
+    ECSchemaP containerSchemaP = GetContainerSchema();
+    if (containerSchemaP == nullptr)
+        {
+        BeAssert (false);
+        LOG.error("Container schema for custom attribute is null.");
+        return CustomAttributeReadStatus::SkippedCustomAttributes;
+        }
+
+    ECSchemaR containerSchema = *containerSchemaP;
 
     // allow for multiple <ECCustomAttributes> nodes, even though we only ever write one.
     for (pugi::xml_node customAttributeNode : containerNode.children(ECXML_CUSTOM_ATTRIBUTES_ELEMENT))
@@ -430,7 +439,7 @@ CustomAttributeReadStatus IECCustomAttributeContainer::ReadCustomAttributes (pug
             {
             if(customAttributeClassNode.type() != pugi::xml_node_type::node_element)
                 continue;
-            ECInstanceReadContextPtr context = ECInstanceReadContext::CreateContext (schemaContext, fallBackSchema, NULL, &fallBackSchema);
+            ECInstanceReadContextPtr context = ECInstanceReadContext::CreateContextForCA (containerSchema, schemaContext);
 
             IECInstancePtr  customAttributeInstance;
             InstanceReadStatus thisStatus = InstanceReadStatus::Success;
@@ -448,22 +457,25 @@ CustomAttributeReadStatus IECCustomAttributeContainer::ReadCustomAttributes (pug
             if (InstanceReadStatus::Success != thisStatus && InstanceReadStatus::CommentOnly != thisStatus)
                 {
                 // In EC3 we will fail to load the schema if any invalid custom attributes are found, for EC2 schemas we will skip the invalid attributes and continue to load the schema
-                if (fallBackSchema.OriginalECXmlVersionAtLeast(ECVersion::V3_0))
+                if (containerSchema.OriginalECXmlVersionAtLeast(ECVersion::V3_0))
                     status = CustomAttributeReadStatus::InvalidCustomAttributes;
                 else if (CustomAttributeReadStatus::Success == status)
                     status = CustomAttributeReadStatus::SkippedCustomAttributes;
                 }
             if (customAttributeInstance.IsValid())
                 {
-                ECSchemaP containerSchema = const_cast<ECSchemaP>(_GetContainerSchema());
                 ECClassP customAttribClass = const_cast<ECClassP>(&customAttributeInstance->GetClass());
-                if ((_GetContainerSchema() != &(customAttributeInstance->GetClass().GetSchema()) && !ECSchema::IsSchemaReferenced(*containerSchema, customAttribClass->GetSchemaR())))
-                    containerSchema->AddReferencedSchema(customAttribClass->GetSchemaR());
+                if ((containerSchemaP != &(customAttributeInstance->GetClass().GetSchema()) && !ECSchema::IsSchemaReferenced(containerSchema, customAttribClass->GetSchemaR())))
+                    {
+                    LOG.warningv("Custom attribute '%s' on schema '%s' requires reference to '%s' which is not on the schema. Adding reference during deserialization...",
+                        customAttributeClassNode.name(), ns.c_str(), containerSchema.GetFullSchemaName().c_str());
+                    containerSchema.AddReferencedSchema(customAttribClass->GetSchemaR());
+                    }
                 ECObjectsStatus caSetStatus = SetCustomAttribute(*customAttributeInstance);
                 if (ECObjectsStatus::Success != caSetStatus)
                     {
                     // In EC3 we will fail to load the schema if any invalid custom attributes are found, for EC2 schemas we will skip the invalid attributes and continue to load the schema
-                    if (fallBackSchema.OriginalECXmlVersionAtLeast(ECVersion::V3_0))
+                    if (containerSchema.OriginalECXmlVersionAtLeast(ECVersion::V3_0))
                         status = CustomAttributeReadStatus::InvalidCustomAttributes;
                     else if (CustomAttributeReadStatus::Success == status)
                         status = CustomAttributeReadStatus::SkippedCustomAttributes;

--- a/iModelCore/ecobjects/src/ECCustomAttribute.cpp
+++ b/iModelCore/ecobjects/src/ECCustomAttribute.cpp
@@ -430,7 +430,7 @@ CustomAttributeReadStatus IECCustomAttributeContainer::ReadCustomAttributes (pug
             {
             if(customAttributeClassNode.type() != pugi::xml_node_type::node_element)
                 continue;
-            ECInstanceReadContextPtr context = ECInstanceReadContext::CreateContext (schemaContext, fallBackSchema, NULL);
+            ECInstanceReadContextPtr context = ECInstanceReadContext::CreateContext (schemaContext, fallBackSchema, NULL, &fallBackSchema);
 
             IECInstancePtr  customAttributeInstance;
             InstanceReadStatus thisStatus = InstanceReadStatus::Success;

--- a/iModelCore/ecobjects/src/ECSchema.cpp
+++ b/iModelCore/ecobjects/src/ECSchema.cpp
@@ -2422,8 +2422,11 @@ ECObjectsStatus ECSchema::AddReferencedSchema(ECSchemaR refSchema, Utf8StringCR 
 
     SchemaKeyCR refSchemaKey = refSchema.GetSchemaKey();
 
-    if (GetSchemaKey() == refSchemaKey)
+    if (GetSchemaKey().GetName().EqualsI(refSchemaKey.GetName())) //Make sure we are not referencing ourselves, in any version
+        {
+        LOG.warningv("%s is trying to add itself (%s) as a referenced schema.", this->GetFullSchemaName().c_str(), refSchema.GetFullSchemaName().c_str());
         return ECObjectsStatus::SchemaHasReferenceCycle;
+        }
 
     if (m_refSchemaList.end () != m_refSchemaList.find (refSchemaKey))
         return ECObjectsStatus::NamedItemAlreadyExists;

--- a/iModelCore/ecobjects/src/SchemaXml.cpp
+++ b/iModelCore/ecobjects/src/SchemaXml.cpp
@@ -427,7 +427,7 @@ CustomAttributeReadStatus SchemaXmlReaderImpl::ReadChildrenCustomAttributes(ECSc
 template<typename T>
 CustomAttributeReadStatus SchemaXmlReaderImpl::ReadContainerCustomAttributes(ECSchemaR parentSchema, pugi::xml_node xmlNode, T& container)
     {
-    return container.ReadCustomAttributes(xmlNode, m_schemaContext, parentSchema);
+    return container.ReadCustomAttributes(xmlNode, m_schemaContext);
     }
 
 //---------------------------------------------------------------------------------------
@@ -436,7 +436,7 @@ CustomAttributeReadStatus SchemaXmlReaderImpl::ReadContainerCustomAttributes(ECS
 template<>
 CustomAttributeReadStatus SchemaXmlReaderImpl::ReadContainerCustomAttributes(ECSchemaR parentSchema, pugi::xml_node xmlNode, ECClassR container)
     {
-    if (CustomAttributeReadStatus::InvalidCustomAttributes == container.ReadCustomAttributes(xmlNode, m_schemaContext, parentSchema))
+    if (CustomAttributeReadStatus::InvalidCustomAttributes == container.ReadCustomAttributes(xmlNode, m_schemaContext))
         return CustomAttributeReadStatus::InvalidCustomAttributes;
 
     if (container.IsRelationshipClass())
@@ -1031,7 +1031,7 @@ SchemaReadStatus SchemaXmlReader::ReadSchemaContents(SchemaXmlReaderImpl* reader
         }
 
     // Schema-level Custom Attributes
-    if (CustomAttributeReadStatus::InvalidCustomAttributes == schemaOut->ReadCustomAttributes(schemaNode, m_schemaContext, *schemaOut))
+    if (CustomAttributeReadStatus::InvalidCustomAttributes == schemaOut->ReadCustomAttributes(schemaNode, m_schemaContext))
         {
         LOG.errorv("Failed to read schema '%s' because one or more invalid custom attributes were applied to it.", schemaOut->GetName().c_str());
         return SchemaReadStatus::InvalidECSchemaXml;

--- a/iModelCore/ecobjects/test/NonPublished/AdhocPropertyTests.cpp
+++ b/iModelCore/ecobjects/test/NonPublished/AdhocPropertyTests.cpp
@@ -25,6 +25,7 @@ struct AdHocPropertyTest : ECTestFixture
         Utf8CP const s_schemaXml =
             "<?xml version='1.0' encoding='utf-8'?>"
             "<ECSchema schemaName='TestSchema' nameSpacePrefix='ts' version='1.0.0' xmlns='http://www.bentley.com/schemas/Bentley.ECXML.3.0'>"
+            "   <ECSchemaReference name='Bentley_Standard_CustomAttributes' version='01.10' prefix='bsca' />"
             "   <ECStructClass typeName = 'AdHocHolder'>"
             "       <ECCustomAttributes>"
             "           <AdhocPropertyContainerDefinition xmlns='Bentley_Standard_CustomAttributes.01.10'>"

--- a/iModelCore/ecobjects/test/NonPublished/CopyTests/ClassCopyTests.cpp
+++ b/iModelCore/ecobjects/test/NonPublished/CopyTests/ClassCopyTests.cpp
@@ -590,6 +590,53 @@ TEST_F(ClassCopyTest, CopyCustomAttributesWithReferencedSourceSchema)
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //---------------------------------------------------------------------------------------
+TEST_F(ClassCopyTest, CopyCustomAttributesWithReferencedSourceSchemaSameSchemaName)
+    {
+    //Alternate version of the previous test, but the new schema has the same name as the original
+    //which is illegal, so the copy process will fail.
+    Utf8CP schemaString = R"(
+        <ECSchema schemaName="testSchema" alias="ts" version="01.00.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+            <ECCustomAttributeClass typeName="CustomClass" appliesTo="Any"/>
+            <ECEntityClass typeName="EntityClass">
+                <ECCustomAttributes>
+                    <CustomClass xmlns="testSchema.01.00.00"/>
+                </ECCustomAttributes>
+            </ECEntityClass>
+        </ECSchema>
+        )";
+
+    ECSchemaPtr schemaCopyFrom;
+    auto const schemaContext = ECSchemaReadContext::CreateContext();
+    ASSERT_EQ(SchemaReadStatus::Success, ECSchema::ReadFromXmlString(schemaCopyFrom, schemaString, *schemaContext));
+
+    ASSERT_NE(nullptr, schemaCopyFrom->GetClassCP("EntityClass"));
+    ASSERT_NE(nullptr, schemaCopyFrom->GetClassCP("CustomClass"));
+    ASSERT_TRUE(schemaCopyFrom->GetClassCP("EntityClass")->GetCustomAttribute("testSchema", "CustomClass").IsValid());
+    ASSERT_EQ(schemaCopyFrom->GetClassCP("CustomClass"), &schemaCopyFrom->GetClassCP("EntityClass")->GetCustomAttribute("testSchema", "CustomClass")->GetClass());
+
+    {
+    ECSchemaPtr schemaCopyTo;
+    ECSchema::CreateSchema(schemaCopyTo, "testSchema", "ts", 2, 0, 0);
+    ECClassP ecClass;
+    EXPECT_EQ(ECObjectsStatus::SchemaHasReferenceCycle, schemaCopyTo->CopyClass(ecClass, *schemaCopyFrom->GetClassCP("EntityClass"), false));
+    EXPECT_NE(nullptr, schemaCopyTo->GetClassCP("EntityClass")); //EntityClass may have been removed after failure, but we do not remove it if the error is just in custom attributes
+    }
+
+    { //Same call but with copyReferences=true
+    ECSchemaPtr schemaCopyTo;
+    ECSchema::CreateSchema(schemaCopyTo, "testSchema", "ts", 2, 0, 0);
+    ECClassP ecClass;
+    EC_EXPECT_SUCCESS(schemaCopyTo->CopyClass(ecClass, *schemaCopyFrom->GetClassCP("EntityClass"), true));
+    EXPECT_NE(nullptr, schemaCopyTo->GetClassCP("EntityClass"));
+    EXPECT_NE(schemaCopyFrom->GetClassCP("EntityClass"), schemaCopyTo->GetClassCP("EntityClass"));
+    EXPECT_TRUE(schemaCopyTo->GetClassCP("EntityClass")->GetCustomAttribute("testSchema", "CustomClass").IsValid());
+    EXPECT_FALSE(ECSchema::IsSchemaReferenced(*schemaCopyTo, *schemaCopyFrom));
+    }
+    }
+
+//---------------------------------------------------------------------------------------
+// @bsimethod
+//---------------------------------------------------------------------------------------
 TEST_F(ClassCopyTest, CopyNavigationPropertyIncludingReferences)
     {
     Utf8CP schemaString = R"**(

--- a/iModelCore/ecobjects/test/NonPublished/CopyTests/ClassCopyTests.cpp
+++ b/iModelCore/ecobjects/test/NonPublished/CopyTests/ClassCopyTests.cpp
@@ -569,7 +569,7 @@ TEST_F(ClassCopyTest, CopyCustomAttributesWithReferencedSourceSchema)
     ASSERT_EQ(schemaCopyFrom->GetClassCP("CustomClass"), &schemaCopyFrom->GetClassCP("EntityClass")->GetCustomAttribute("testSchema", "CustomClass")->GetClass());
 
     ECSchemaPtr schemaCopyTo;
-    ECSchema::CreateSchema(schemaCopyTo, "testSchema", "ts", 2, 0, 0);
+    ECSchema::CreateSchema(schemaCopyTo, "testSchema2", "ts2", 2, 0, 0);
 
     ASSERT_EQ(nullptr, schemaCopyTo->GetClassCP("EntityClass"));
     ASSERT_EQ(nullptr, schemaCopyTo->GetClassCP("CustomClass"));

--- a/iModelCore/ecobjects/test/NonPublished/ECSchemaValidatorTests.cpp
+++ b/iModelCore/ecobjects/test/NonPublished/ECSchemaValidatorTests.cpp
@@ -290,6 +290,7 @@ TEST_F(SchemaValidatorTests, TestSchemaStandardReferences)
         "<ECSchema schemaName='TestSchema' alias='ts' version='1.0.0' xmlns='http://www.bentley.com/schemas/Bentley.ECXML." + ECSchema::GetECVersionString(ECVersion::Latest) + "'>"
         "    <ECSchemaReference name='BisCore' version='01.00.00' alias='bis'/>"
         "    <ECSchemaReference name='ECv3ConversionAttributes' version='01.00.00' alias='ts'/>"
+        "    <ECSchemaReference name='CoreCustomAttributes' version='01.00.00' alias='CoreCA'/>"
         "    <ECCustomAttributes>"
         "        <DynamicSchema xmlns='CoreCustomAttributes.01.00.00'/>"
         "    </ECCustomAttributes>"
@@ -324,6 +325,7 @@ TEST_F(SchemaValidatorTests, TestSchemasWithNameContainingDynamicApplyDynamicSch
     {
     Utf8String goodSchemaXml = Utf8String("<?xml version='1.0' encoding='UTF-8'?>") +
         "<ECSchema schemaName='DynamicFunkMachine' alias='fnk' version='1.0.0' xmlns='http://www.bentley.com/schemas/Bentley.ECXML." + ECSchema::GetECVersionString(ECVersion::Latest) + "'>"
+        "    <ECSchemaReference name='CoreCustomAttributes' version='01.00.00' alias='CoreCA'/>"
         "    <ECCustomAttributes>"
         "        <DynamicSchema xmlns='CoreCustomAttributes.01.00.00'/>"
         "    </ECCustomAttributes>"
@@ -3222,6 +3224,7 @@ TEST_F(SchemaValidatorTests, SchemaUseDeprecatedSchema)
     schemaXml = R"xml(
         <ECSchema schemaName="testSchema2" alias="deprecatedTs" version="01.00.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
             <ECSchemaReference name="deprecatedSchema" version="01.00.00" alias="deprecated"/>
+            <ECSchemaReference name='CoreCustomAttributes' version='01.00.02' alias='CoreCA'/>
             <ECCustomAttributes>
                 <Deprecated xmlns="CoreCustomAttributes.01.00.02"/>
             </ECCustomAttributes>
@@ -3241,6 +3244,7 @@ TEST_F(SchemaValidatorTests, SchemaClassDerivedFromDeprecatedClass)
     Utf8CP schemaXml = R"xml(
         <ECSchema schemaName="testSchema1" alias="ts" version="01.00.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
             <ECSchemaReference name="BisCore" version="01.00.00" alias="bis"/>
+            <ECSchemaReference name='CoreCustomAttributes' version='01.00.02' alias='CoreCA'/>
             <ECEntityClass typeName="DeprecatedEntityClass" description="description here for silencing validator warning">
                 <ECCustomAttributes>
                     <Deprecated xmlns="CoreCustomAttributes.01.00.02"/>

--- a/iModelCore/ecobjects/test/NonPublished/SchemaDeserializationTests.cpp
+++ b/iModelCore/ecobjects/test/NonPublished/SchemaDeserializationTests.cpp
@@ -2561,4 +2561,42 @@ TEST_F(SchemaDeserializationTest, MultipleVersionsOfSchemaInSameContext)
     }
     }
 
+//---------------------------------------------------------------------------------------
+// @bsimethod
+//---------------+---------------+---------------+---------------+---------------+-------
+TEST_F(SchemaDeserializationTest, MissingBSCAReference)
+    {
+    // For standard schemas, our custom attribute deserializer automatically adds missing references. It writes a warning to the logs but schema is expected
+    // to load successfully
+    ECSchemaPtr schema;
+    ECSchemaReadContextPtr context = ECSchemaReadContext::CreateContext();
+
+    Utf8CP const schemaXml =
+        "<?xml version='1.0' encoding='utf-8'?>"
+        "<ECSchema schemaName='TestSchema' nameSpacePrefix='ts' version='1.0.0' xmlns='http://www.bentley.com/schemas/Bentley.ECXML.3.0'>"
+        "   <ECStructClass typeName = 'AdHocHolder'>"
+        "       <ECCustomAttributes>"
+        "           <AdhocPropertyContainerDefinition xmlns='Bentley_Standard_CustomAttributes.01.10'>"
+        "               <NameProperty>Name</NameProperty>"
+        "               <DisplayLabelProperty>Label</DisplayLabelProperty>"
+        "               <ValueProperty>Value</ValueProperty>"
+        "               <TypeProperty>Type</TypeProperty>"
+        "               <UnitProperty>Unit</UnitProperty>"
+        "               <ExtendTypeProperty>ExtendType</ExtendTypeProperty>"
+        "               <IsReadOnlyProperty>IsReadOnly</IsReadOnlyProperty>"
+        "           </AdhocPropertyContainerDefinition>"
+        "       </ECCustomAttributes>"
+        "       <ECProperty propertyName='Name' typeName='string' />"
+        "       <ECProperty propertyName='Label' typeName='string' />"
+        "       <ECProperty propertyName='Value' typeName='string' />"
+        "       <ECProperty propertyName='Type' typeName='int' />"
+        "       <ECProperty propertyName='Unit' typeName='string' />"
+        "       <ECProperty propertyName='ExtendType' typeName='string' />"
+        "       <ECProperty propertyName='IsReadOnly' typeName='boolean' />"
+        "   </ECStructClass>"
+        "</ECSchema>";
+            
+    EXPECT_EQ(SchemaReadStatus::Success, ECSchema::ReadFromXmlString(schema, schemaXml, *context));
+    }
+
 END_BENTLEY_ECN_TEST_NAMESPACE

--- a/iModelCore/ecobjects/test/NonPublished/SchemaDeserializationTests.cpp
+++ b/iModelCore/ecobjects/test/NonPublished/SchemaDeserializationTests.cpp
@@ -2465,4 +2465,100 @@ TEST_F(SchemaDeserializationTest, RoundtripSchemaWithEmptyElements)
     ASSERT_FALSE(diff.Changes().IsChanged());
     }
 
+//---------------------------------------------------------------------------------------
+// @bsimethod
+//---------------+---------------+---------------+---------------+---------------+-------
+TEST_F(SchemaDeserializationTest, MultipleVersionsOfSchemaInSameContext)
+    {
+    //There was a bug in CA deserialization so the CA would use a wrong version
+    //of the schema if multiple versions were in a context.
+    //Since SchemaMatchType::LatestReadCompatible and ECSchemaCache behave unpredictable (the cache uses a bmap and returns the first valid item),
+    //we are adding more than two versions of the schema to increase the likelyhood of the cache hitting the wrong instance
+    ECSchemaReadContextPtr context = ECSchemaReadContext::CreateContext();
+
+    Utf8CP schemaXml = R"xml(<ECSchema schemaName="TestSchema" alias="ts" version="01.00.02" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+          <ECCustomAttributeClass typeName="MyCustomAttribute" appliesTo="AnyClass" modifier="Sealed">
+            <ECProperty propertyName="Foo" typeName="string" />
+          </ECCustomAttributeClass>
+          <ECEntityClass typeName="MyClass">
+            <ECCustomAttributes>
+              <MyCustomAttribute xmlns="TestSchema.01.00.01">
+                <Foo>Something</Foo>
+              </MyCustomAttribute>
+            </ECCustomAttributes>
+          </ECEntityClass>
+        </ECSchema>)xml";
+
+    Utf8CP schemaXmlAlt = R"xml(<ECSchema schemaName="TestSchema" alias="ts" version="01.00.03" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+          <ECCustomAttributeClass typeName="MyCustomAttribute" appliesTo="AnyClass" modifier="Sealed">
+            <ECProperty propertyName="Foo" typeName="string" />
+          </ECCustomAttributeClass>
+          <ECEntityClass typeName="MyClass">
+            <ECCustomAttributes>
+              <MyCustomAttribute xmlns="TestSchema.01.00.03">
+                <Foo>Something</Foo>
+              </MyCustomAttribute>
+            </ECCustomAttributes>
+          </ECEntityClass>
+        </ECSchema>)xml";
+
+    Utf8CP schemaXmlAlt2 = R"xml(<ECSchema schemaName="TestSchema" alias="ts" version="01.00.01" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+          <ECCustomAttributeClass typeName="MyCustomAttribute" appliesTo="AnyClass" modifier="Sealed">
+            <ECProperty propertyName="Foo" typeName="string" />
+          </ECCustomAttributeClass>
+          <ECEntityClass typeName="MyClass">
+            <ECCustomAttributes>
+              <MyCustomAttribute xmlns="TestSchema.01.00.01">
+                <Foo>Something</Foo>
+              </MyCustomAttribute>
+            </ECCustomAttributes>
+          </ECEntityClass>
+        </ECSchema>)xml";
+
+    StringSchemaLocater locater;
+    SchemaKey key ("TestSchema", 1, 0, 2);
+    SchemaKey keyAlt ("TestSchema", 1, 0, 3);
+    SchemaKey keyAlt2 ("TestSchema", 1, 0, 1);
+    locater.AddSchemaString(keyAlt, schemaXmlAlt);
+    locater.AddSchemaString(keyAlt2, schemaXmlAlt2);
+    locater.AddSchemaString(key, schemaXml);
+    context->AddSchemaLocater(locater);
+
+    {
+    ECSchemaPtr schema = context->LocateSchema(keyAlt, SchemaMatchType::Exact);
+    ASSERT_TRUE(schema.IsValid());
+    ASSERT_EQ(3, schema->GetVersionMinor());
+    ASSERT_EQ(0, schema->GetReferencedSchemas().size());
+    auto c = schema->GetClassCP("MyClass");
+    ASSERT_TRUE(c != nullptr);
+    auto ca = c->GetCustomAttribute("MyCustomAttribute");
+    ASSERT_TRUE(ca.IsValid());
+    ASSERT_EQ(3, ca->GetClass().GetSchema().GetVersionMinor());
+    }
+
+    {
+    ECSchemaPtr schema = context->LocateSchema(keyAlt2, SchemaMatchType::Exact);
+    ASSERT_TRUE(schema.IsValid());
+    ASSERT_EQ(1, schema->GetVersionMinor());
+    ASSERT_EQ(0, schema->GetReferencedSchemas().size());
+    auto c = schema->GetClassCP("MyClass");
+    ASSERT_TRUE(c != nullptr);
+    auto ca = c->GetCustomAttribute("MyCustomAttribute");
+    ASSERT_TRUE(ca.IsValid());
+    ASSERT_EQ(1, ca->GetClass().GetSchema().GetVersionMinor());
+    }
+
+    {
+    ECSchemaPtr schema = context->LocateSchema(key, SchemaMatchType::Exact);
+    ASSERT_TRUE(schema.IsValid());
+    ASSERT_EQ(2, schema->GetVersionMinor());
+    ASSERT_EQ(0, schema->GetReferencedSchemas().size());
+    auto c = schema->GetClassCP("MyClass");
+    ASSERT_TRUE(c != nullptr);
+    auto ca = c->GetCustomAttribute("MyCustomAttribute");
+    ASSERT_TRUE(ca.IsValid());
+    ASSERT_EQ(2, ca->GetClass().GetSchema().GetVersionMinor());
+    }
+    }
+
 END_BENTLEY_ECN_TEST_NAMESPACE


### PR DESCRIPTION
Previously, the CA deserialization would go through the schema read context and may occasionally obtain a wrong (compatible) schema version which would then be used to load the CA and be added as a reference to the schema in which the CA is in.

The deserializer now prioritizes the container schema and its references when locating schemas used for custom attributes. Also added a defensive check to make sure schemas never reference another schema of the same name.