### PR TITLE
Silence spurious assertion

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -222,6 +222,27 @@
             ]
         },
         {
+            "name": "LNX TilesetPublisher",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${env:OutRoot}LinuxX64/Product/TilesetPublisher/TilesetPublisher",
+            "cwd": "${workspaceFolder}",
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                }
+            ],
+            "args": [
+                "-i /media/paul/External 2TB SDD1/bim/NormalMaps/Cubes32PBR_A.bim",
+                "-o /home/paul/imdl"
+            ]
+        },
+
+        {
           "name": "MacOS Native Single iModelPlatformTest",
           "type": "cppdbg",
           "request": "launch",

--- a/iModelCore/iModelPlatform/DgnCore/RenderMaterial.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/RenderMaterial.cpp
@@ -28,14 +28,14 @@ RgbFactor RenderingAsset::GetColor(Utf8CP name) const
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //---------------------------------------------------------------------------------------
-static DPoint2d getDPoint2dValue(BeJsConst rootValue, Utf8CP key)
+static DPoint2d getDPoint2dValue(BeJsConst rootValue, Utf8CP key, bool required = true)
     {
     auto value = rootValue[key];
     DPoint2d point = { 0.0, 0.0 };
 
     if (value.size() < 2)
         {
-        BeAssert(false);
+        BeAssert(!required && "Expected material JSON to contain a 2d point");
         return point;
         }
 
@@ -128,7 +128,7 @@ Render::TextureMapping::ConstantLodParams RenderingAsset::TextureMap::GetConstan
     {
     return Render::TextureMapping::ConstantLodParams(
         m_value[RENDER_MATERIAL_PatternConstantLodRepetitions].asDouble(1.0),
-        getDPoint2dValue(m_value, RENDER_MATERIAL_PatternConstantLodOffset),
+        getDPoint2dValue(m_value, RENDER_MATERIAL_PatternConstantLodOffset, false),
         m_value[RENDER_MATERIAL_PatternConstantLodMinDistanceClamp].asDouble(1.0),
         m_value[RENDER_MATERIAL_PatternConstantLodMaxDistanceClamp].asDouble(4096.0 * 1024.0 * 1024.0) );
     }


### PR DESCRIPTION
`getDPoint2d` asserts the requested property must exist, but constant LOD params offset is optional.
imodel-native-internal: https://github.com/iTwin/imodel-native-internal/pull/175