### PR TITLE
Fix typo in SolveBezierCubic declaration

### DIFF
--- a/iModelCore/GeomLibs/PublicAPI/Geom/AnalyticRoots.h
+++ b/iModelCore/GeomLibs/PublicAPI/Geom/AnalyticRoots.h
@@ -52,7 +52,7 @@ static int SolveBezierCubic
         double y2,
         double y3,
         double e,
-        double uvals[2],
+        double uvals[3],
         bool bRestrictSolutionsTo01
         );
 


### PR DESCRIPTION
It lists the `uvals` array as being of size 2 when the C++ file lists (and requires) 3. The incorrect code causes a compile error in Xcode 15.