### PR TITLE
Disable broken unused functionality in folly

### DIFF
--- a/iModelCore/libsrc/facebook/VendorApi/folly/Range.h
+++ b/iModelCore/libsrc/facebook/VendorApi/folly/Range.h
@@ -188,8 +188,10 @@ public:
     Range<const value_type*>,
     Range<Iter>>::type const_range_type;
 
+#if defined (BENTLEY_CHANGE)
   typedef std::char_traits<typename std::remove_const<value_type>::type>
     traits_type;
+#endif
 
   static const size_type npos;
 
@@ -420,6 +422,7 @@ public:
     return const_range_type(*this);
   }
 
+#if defined (BENTLEY_CHANGE)
   // Works only for Range<const char*> and Range<char*>
   int compare(const const_range_type& o) const {
     const size_type tsize = this->size();
@@ -435,6 +438,7 @@ public:
     }
     return r;
   }
+#endif
 
   value_type& operator[](size_t i) {
     DCHECK_GT(size(), i);


### PR DESCRIPTION
It contains code that uses `unsigned char` in a `char_traits`, which produces a compile error in Xcode 15 due to the behavior being undefined. Since the functionality isn't used, wrap it in an ifdef to disable it entirely.