### PR TITLE
Fix to line style max offset calculation to properly account for modifiers.

### DIFF
--- a/iModelCore/iModelPlatform/DgnCore/linestyle/DgnLineStyles.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/linestyle/DgnLineStyles.cpp
@@ -35,9 +35,7 @@ BentleyStatus DgnLineStyles::Insert(DgnStyleId& newStyleId, DgnModelId modelId, 
     
     newStyleId = DgnStyleId(constLs->GetElementId().GetValue());
 
-    LsDefinition* lsDef = new LsDefinition(name, m_dgndb, jsonObj, newStyleId);
-    GetCache().AddIdEntry(lsDef);
-
+    // NOTE: New cache entry added in LineStyleElement::_OnInsert...
     return SUCCESS;
     }
 

--- a/iModelCore/iModelPlatform/DgnCore/linestyle/LsDb.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/linestyle/LsDb.cpp
@@ -523,6 +523,26 @@ DgnDbStatus LineStyleElement::_OnDelete() const
     return GetDgnDb().IsPurgeOperationActive() ? T_Super::_OnDelete() : DgnDbStatus::DeletionProhibited;
     }
 
+//---------------------------------------------------------------------------------------
+// @bsimethod
+//---------------------------------------------------------------------------------------
+DgnDbStatus LineStyleElement::_OnInsert()
+    {
+    auto status = T_Super::_OnInsert();
+    if (DgnDbStatus::Success != status)
+        return status;
+
+    Json::Value dataObj(Json::objectValue);
+    if (!Json::Reader::Parse(GetData(), dataObj))
+        return DgnDbStatus::Success;
+
+    DgnDbR db = GetDgnDb();
+    LsDefinition* lsDef = new LsDefinition(GetName().c_str(), db, dataObj, DgnStyleId(GetElementId().GetValue()));
+    db.LineStyles().GetCache().AddIdEntry(lsDef);
+
+    return DgnDbStatus::Success;
+    }
+
 BEGIN_BENTLEY_DGNPLATFORM_NAMESPACE
 namespace dgn_ElementHandler
 {

--- a/iModelCore/iModelPlatform/DgnCore/linestyle/LsSymbology.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/linestyle/LsSymbology.cpp
@@ -7,6 +7,62 @@
 /*---------------------------------------------------------------------------------**//**
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/
+static double getMaxStyleOffset(LineStyleSymbCR symb, LsComponentCR topComponent)
+    {
+    // NOTE: Because "maxWidth" is twice the maximum offset it gets divided by two.
+    double styleWidth = 0.0;
+
+    switch (topComponent.GetComponentType())
+        {
+        case LsComponentType::LinePoint:
+            {
+            LsPointComponentCR pointComponent = (LsPointComponentCR)topComponent;
+
+            // Only symbols affect width, stroke component is strictly for positioning symbols...
+            for (size_t iSymb = 0; iSymb < pointComponent.GetNumberSymbols(); iSymb++)
+                {
+                LsSymbolReferenceCP symbolRef = pointComponent.GetSymbolCP(iSymb);
+                if (nullptr == symbolRef)
+                    continue;
+
+                // Never affected by width, sometimes not affected by scale...
+                double scale = (symbolRef->GetSymbolComponentCP()->IsNoScale() ? 1.0 : symb.GetScale());
+                styleWidth = DoubleOps::Max(styleWidth, (symbolRef->_GetMaxWidth() * scale) / 2.0);
+                }
+            break;
+            }
+
+        case LsComponentType::Compound:
+            {
+            LsCompoundComponentCR compoundComponent = (LsCompoundComponentCR)topComponent;
+
+            for (size_t iComp = 0; iComp < compoundComponent.GetNumComponents(); iComp++)
+                {
+                LsComponentCP component = compoundComponent.GetComponentCP(iComp);
+
+                if (nullptr != component)
+                    styleWidth = DoubleOps::Max(styleWidth, getMaxStyleOffset(symb, *component));
+                }
+            break;
+            }
+
+        default:
+            {
+            // A width modifier overrides the definition even if it's 0.0...
+            if (topComponent._IsAffectedByWidth(false) && symb.HasTrueWidth())
+                styleWidth = symb.GetMaxWidth() / 2.0;
+            else
+                styleWidth = ((topComponent._GetMaxWidth() * symb.GetScale()) / 2.0);
+            break;
+            }
+        }
+
+    return styleWidth;
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
 double LsPointComponent::_GetLength () const
     {
     return NULL == GetStrokeComponentCP() ? 0 : GetStrokeComponentCP()->_GetLength();
@@ -546,14 +602,8 @@ void LineStyleSymb::Init(DgnStyleId styleId, LineStyleParamsCR styleParams, DgnD
     if (!topComponent->_HasRasterImageComponent())
         SetUseStroker(true);
 
-    double maxWidth = nameRec->_GetMaxWidth() * unitDef; // Unit scale not accounted for in component width...
-    
-    // Get the width of this linestyle for "discernable" checks and to pad range..."maxWidth" is actually twice the maximum offset, so divide it by two.
-    m_styleWidth = ((maxWidth * GetScale()) / 2.0);
-
-    // Account for start/end width modifiers if they would affect the linestyle...
-    if (topComponent->_IsAffectedByWidth(false))
-        m_styleWidth = DoubleOps::Max(m_styleWidth, GetMaxWidth() / 2.0);
+    // Set the maximum offset for "discernable" checks and to pad element ranges as the poorly named m_styleWidth.
+    m_styleWidth = getMaxStyleOffset(*this, *topComponent);
     }
 
 /*---------------------------------------------------------------------------------**//**

--- a/iModelCore/iModelPlatform/DgnCore/linestyle/LsSymbology.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/linestyle/LsSymbology.cpp
@@ -9,7 +9,7 @@
 +---------------+---------------+---------------+---------------+---------------+------*/
 static double getMaxStyleOffset(LineStyleSymbCR symb, LsComponentCR topComponent)
     {
-    // NOTE: Because "maxWidth" is twice the maximum offset it gets divided by two.
+    // NOTE: Because "maxWidth" is twice the maximum offset, it gets divided by two.
     double styleWidth = 0.0;
 
     switch (topComponent.GetComponentType())

--- a/iModelCore/iModelPlatform/DgnCore/linestyle/StrokeSymbol.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/linestyle/StrokeSymbol.cpp
@@ -26,17 +26,16 @@ LsSymbolReference::RotationMode LsSymbolReference::GetRotationMode () const
 //---------------------------------------------------------------------------------------
 static double getGeometryPartMaxOffset (LsSymbolComponentCR symbol, double angle)
     {
-    //  NEEDSWORK_LINESTYLES  It would be better to draw this with the transform instead of transforming the range
+    DRange3d range;
+    symbol.GetRange(range);
+
     Transform transform;
     transform.InitFromPrincipleAxisRotations(Transform::FromIdentity(), 0.0, 0.0, angle);
-    DRange3d        range;
-
-    symbol.GetRange(range);
     transform.Multiply(range.low);
     transform.Multiply(range.high);
 
-    double      maxWidth = fabs (range.low.y);
-    double      test;
+    double maxWidth = fabs (range.low.y);
+    double test;
 
     if ((test = fabs (range.high.y)) > maxWidth)
         maxWidth = test;
@@ -50,7 +49,6 @@ static double getGeometryPartMaxOffset (LsSymbolComponentCR symbol, double angle
     return maxWidth;
     }
 
-
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //---------------------------------------------------------------------------------------
@@ -60,7 +58,7 @@ double LsSymbolReference::_GetMaxWidth () const
         return 0.0;
 
     double offset   = m_offset.Magnitude ();
-    double maxWidth = getGeometryPartMaxOffset(*m_symbol, m_angle)/m_symbol->GetMuDef();
+    double maxWidth = getGeometryPartMaxOffset(*m_symbol, m_angle) / (m_symbol->IsNotScaled() ? 1.0 : m_symbol->GetMuDef());
 
     return  (offset + maxWidth) * 2.0;
     }

--- a/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/LineStyle.h
+++ b/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/LineStyle.h
@@ -1232,9 +1232,10 @@ private:
     int GetUnits() const {return m_attributes & LSATTR_UNITMASK;}
     StatusInt GetGeometryTexture(TextureDescr& textureDescr, ViewContextR viewContext, Render::LineStyleSymbR lineStyleSymb, Render::GeometryParamsCR params);
     StatusInt GenerateTexture(TextureDescr& textureDescr, ViewContextR viewContext, Render::LineStyleSymbR lineStyleSymb, Render::GeometryParamsCR params);
-    LsDefinition (Utf8CP name, DgnDbR project, Json::Value& lsDefinition, DgnStyleId styleId);
 
 public:
+    LsDefinition(Utf8CP name, DgnDbR project, Json::Value& lsDefinition, DgnStyleId styleId);
+
     DGNPLATFORM_EXPORT static double GetUnitDef (Json::Value& lsDefinition);
     DGNPLATFORM_EXPORT static uint32_t GetAttributes (Json::Value& lsDefinition);
     DGNPLATFORM_EXPORT static LsComponentId GetComponentId (Json::Value& lsDefinition);
@@ -1541,6 +1542,7 @@ private:
 
 protected:
     DGNPLATFORM_EXPORT DgnDbStatus _OnDelete() const override;
+    DGNPLATFORM_EXPORT DgnDbStatus _OnInsert() override;
     DgnCode _GenerateDefaultCode() const override { return DgnCode(); }
     bool _SupportsCodeSpec(CodeSpecCR codeSpec) const override { return !codeSpec.IsNullCodeSpec(); }
 


### PR DESCRIPTION
Partial fix for [issue](https://github.com/iTwin/itwinjs-core/issues/6010#event-10498971483l) also need change to batch connector.

itwinjs-core: https://github.com/iTwin/itwinjs-core/pull/6039

Previously padding only considered width of line style definition without considering modifiers which can both increase or decrease the overall width. There was a special case for continuous with width, but this did not account for point symbol or stroke pattern width.

This also fixes keeping the line style name map up to date when new styles are inserted. This previously was done in the C++ method and has now been move to the _OnInsert method of the line style definition element.