### PR TITLE
Fixed DLL issue for imodel02 stream

### DIFF
--- a/iModelCore/libsrc/openssl/BeOpenSSL.def
+++ b/iModelCore/libsrc/openssl/BeOpenSSL.def
@@ -2,7 +2,11 @@
 ; Exports for the BeOpenSSL library (Windows-only)
 ;
 
-LIBRARY iTwinOpenSSL
+%if defined(iTwinNativeThirdParty)
+  LIBRARY BeOpenSSL
+%else
+  LIBRARY iTwinOpenSSL
+%endif
 
 EXPORTS
   gcm_ghash_4bit


### PR DESCRIPTION
This conditional execution will fix the issue of "iTwinOpenSSL.dll was not found" in imodel02 steam while consuming the openssl component. 