### PR TITLE
Update SQLite to 3.43.2 + cherry-picked changeset grouping enhancement

### DIFF
--- a/iModelCore/BeSQLite/PublicAPI/BeSQLite/ChangeSet.h
+++ b/iModelCore/BeSQLite/PublicAPI/BeSQLite/ChangeSet.h
@@ -154,7 +154,9 @@ public:
     bool ContainsEcSchemaChanges() const { return m_containsEcSchemaChanges; }
     void SetContainsEcSchemaChanges() { m_containsEcSchemaChanges = true; }
     BE_SQLITE_EXPORT ChangeGroup();
-    BE_SQLITE_EXPORT ~ChangeGroup();
+    BE_SQLITE_EXPORT ChangeGroup(DbCR, Utf8CP zDb = "main");
+    BE_SQLITE_EXPORT void Finalize();
+    ~ChangeGroup() { Finalize(); }
 };
 
 //=======================================================================================

--- a/iModelCore/BeSQLite/SQLite/UpdateSqlite.bat
+++ b/iModelCore/BeSQLite/SQLite/UpdateSqlite.bat
@@ -8,7 +8,7 @@ rem +---------------------------------------------------------------------------
 rem This script will update the SQLite source from a fossil branch, and then create the amalgamation `sqlite.c` source file.
 rem @note that it requires cygwin be installed
 
-set sqlite_tag=itwin-sqlite-v3.43.1-r0
+set sqlite_tag=itwin-sqlite-v3.43.2-r0
 set imodel_native_sqlite=%SrcRoot%imodel-native\iModelCore\BeSQLite\SQLite\
 set sqlite_root=%appdata%\itwin-sqlite
 set build_dir=outdir

--- a/iModelCore/BeSQLite/SQLite/shell.c
+++ b/iModelCore/BeSQLite/SQLite/shell.c
@@ -1260,7 +1260,7 @@ static void shellDtostr(
   char z[400];
   if( n<1 ) n = 1;
   if( n>350 ) n = 350;
-  sprintf(z, "%#+.*e", n, r);
+  snprintf(z, sizeof(z)-1, "%#+.*e", n, r);
   sqlite3_result_text(pCtx, z, -1, SQLITE_TRANSIENT);
 }
 

--- a/iModelCore/BeSQLite/SQLite/sqlite3.h
+++ b/iModelCore/BeSQLite/SQLite/sqlite3.h
@@ -146,9 +146,9 @@ extern "C" {
 ** [sqlite3_libversion_number()], [sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.43.1"
-#define SQLITE_VERSION_NUMBER 3043001
-#define SQLITE_SOURCE_ID      "2023-09-11 12:01:27 2d3a40c05c49e1a49264912b1a05bc2143ac0e7c3df588276ce80a4cbc9bd1b0"
+#define SQLITE_VERSION        "3.43.2"
+#define SQLITE_VERSION_NUMBER 3043002
+#define SQLITE_SOURCE_ID      "2023-10-07 17:29:10 801623a6c9020b7872133b10d555c2cff29d723963486d8204052f9719345c7a"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers
@@ -11678,6 +11678,18 @@ SQLITE_API int sqlite3changeset_concat(
 
 
 /*
+** CAPI3REF: Upgrade the Schema of a Changeset/Patchset
+*/
+SQLITE_API int sqlite3changeset_upgrade(
+  sqlite3 *db,
+  const char *zDb,
+  int nIn, const void *pIn,       /* Input changeset */
+  int *pnOut, void **ppOut        /* OUT: Inverse of input */
+);
+
+
+
+/*
 ** CAPI3REF: Changegroup Handle
 **
 ** A changegroup is an object used to combine two or more
@@ -11722,6 +11734,38 @@ typedef struct sqlite3_changegroup sqlite3_changegroup;
 ** versions sqlite3changegroup_add_strm() and sqlite3changegroup_output_strm().
 */
 SQLITE_API int sqlite3changegroup_new(sqlite3_changegroup **pp);
+
+/*
+** CAPI3REF: Add a Schema to a Changegroup
+** METHOD: sqlite3_changegroup_schema
+**
+** This method may be used to optionally enforce the rule that the changesets
+** added to the changegroup handle must match the schema of database zDb
+** ("main", "temp", or the name of an attached database). If
+** sqlite3changegroup_add() is called to add a changeset that is not compatible
+** with the configured schema, SQLITE_SCHEMA is returned and the changegroup
+** object is left in an undefined state.
+**
+** A changeset schema is considered compatible with the database schema in
+** the same way as for sqlite3changeset_apply(). Specifically, for each
+** table in the changeset, there exists a database table with:
+**
+** <ul>
+**   <li> The name identified by the changeset, and
+**   <li> at least as many columns as recorded in the changeset, and
+**   <li> the primary key columns in the same position as recorded in
+**        the changeset.
+** </ul>
+**
+** The output of the changegroup object always has the same schema as the
+** database nominated using this function. In cases where changesets passed
+** to sqlite3changegroup_add() have fewer columns than the corresponding table
+** in the database schema, these are filled in using the default column
+** values from the database schema. This makes it possible to combined
+** changesets that have different numbers of columns for a single table
+** within a changegroup, provided that they are otherwise compatible.
+*/
+SQLITE_API int sqlite3changegroup_schema(sqlite3_changegroup*, sqlite3*, const char *zDb);
 
 /*
 ** CAPI3REF: Add A Changeset To A Changegroup
@@ -11791,13 +11835,18 @@ SQLITE_API int sqlite3changegroup_new(sqlite3_changegroup **pp);
 ** If the new changeset contains changes to a table that is already present
 ** in the changegroup, then the number of columns and the position of the
 ** primary key columns for the table must be consistent. If this is not the
-** case, this function fails with SQLITE_SCHEMA. If the input changeset
-** appears to be corrupt and the corruption is detected, SQLITE_CORRUPT is
-** returned. Or, if an out-of-memory condition occurs during processing, this
-** function returns SQLITE_NOMEM. In all cases, if an error occurs the state
-** of the final contents of the changegroup is undefined.
+** case, this function fails with SQLITE_SCHEMA. Except, if the changegroup
+** object has been configured with a database schema using the
+** sqlite3changegroup_schema() API, then it is possible to combine changesets
+** with different numbers of columns for a single table, provided that
+** they are otherwise compatible.
 **
-** If no error occurs, SQLITE_OK is returned.
+** If the input changeset appears to be corrupt and the corruption is
+** detected, SQLITE_CORRUPT is returned. Or, if an out-of-memory condition
+** occurs during processing, this function returns SQLITE_NOMEM.
+**
+** In all cases, if an error occurs the state of the final contents of the
+** changegroup is undefined. If no error occurs, SQLITE_OK is returned.
 */
 SQLITE_API int sqlite3changegroup_add(sqlite3_changegroup*, int nData, void *pData);
 

--- a/iModelCore/iModelPlatform/DgnCore/ChangesetTxns.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/ChangesetTxns.cpp
@@ -695,7 +695,7 @@ ChangesetPropsPtr TxnManager::StartCreateChangeset(Utf8CP extension) {
     int64_t lastRebaseId = QueryLastRebaseId();
 
     DdlChanges ddlChanges;
-    ChangeGroup dataChangeGroup;
+    ChangeGroup dataChangeGroup(m_dgndb);
     for (TxnId currTxnId = startTxnId; currTxnId < endTxnId; currTxnId = QueryNextTxnId(currTxnId)) {
         auto txnType = GetTxnType(currTxnId);
         if (txnType == TxnType::EcSchema) // if we have EcSchema changes, set the flag on the change group

--- a/iModelCore/iModelPlatform/Tests/DgnProject/NonPublished/RevisionMem_Test.cpp
+++ b/iModelCore/iModelPlatform/Tests/DgnProject/NonPublished/RevisionMem_Test.cpp
@@ -351,9 +351,9 @@ TEST_F(RevisionMemTestFixture, changeset_size_api) {
 
     ASSERT_EQ(m_db->Txns().GetChangesetSize(), 249572);
     #ifdef BENTLEYCONFIG_OS_APPLE_MACOS
-        ASSERT_EQ(m_db->Txns().GetMemoryUsed(), 10496);
+        ASSERT_EQ(m_db->Txns().GetMemoryUsed(), 11664);
     #else
-        ASSERT_EQ(m_db->Txns().GetMemoryUsed(), 10392);
+        ASSERT_EQ(m_db->Txns().GetMemoryUsed(), 11344);
     #endif
 
     m_db->SaveChanges();


### PR DESCRIPTION
## Update to [Version 3.43.2](https://github.com/iTwin/sqlite/releases/tag/version-3.43.2)

## Addition changeset cherry-picked from master

* [Fix a problem with sqlite3changegroup_schema() and patchsets.](https://github.com/iTwin/sqlite/commit/3b381b4afccd90e1c2cdd5cd5ea3ba9f15ba358b) 
* [Add the sqlite3changegroup_schema() API. To allow changegroup objects…](https://github.com/iTwin/sqlite/commit/4bdcfc6666a99a9710cb94541afadf49e84bf2bc)
* [Fix a problem with the changes on this branch and tables that use an …](https://github.com/iTwin/sqlite/commit/18efe17553c8c777452607d6605cf77a00142418)
* [Add missing source code comments and fix other issues with the new co…](https://github.com/iTwin/sqlite/commit/83e43dc757d0572dc468129f08f6a1e54d917f43)
* [Add tests for the sqlite3changegroup_schema() API.](https://github.com/iTwin/sqlite/commit/53e91a5e22172d57edc095dd89c85524860815f5)
* [Add the sqlite3changegroup_schema() API. To allow changegroups to han…](https://github.com/iTwin/sqlite/commit/16381d062aa6b769a68359b1eec20ba881c40888)
* [Allow a session object to generate a changeset, even if columns were …](https://github.com/iTwin/sqlite/commit/6d8e91be9d76f499f0bbcc73192a23c3787f9ba7)

## Change group can group data changeset across schema changes

This is an issue encountered by Local Sync 

1. Some data was added to a table and txn was saved.
2. Schema change causes new columns to be added to the table with data in the previous txn.
3. Some more data is added with additional columns and txn is saved.
4. create changeset failed when trying to group changesets with different numbers of columns but the same table.
