### PR TITLE
CloudSQLite: Fix daemon segfault when client disconnects during prefetch

### DIFF
--- a/iModelCore/BeSQLite/SQLite/blockcachevfsd.c
+++ b/iModelCore/BeSQLite/SQLite/blockcachevfsd.c
@@ -1500,6 +1500,7 @@ static void bdDisconnectClient(
 
   /* Close the socket connection */
   bcv_close_socket(pClient->fd);
+  pClient->fd = INVALID_SOCKET;
 
   if( pClient->apRef ){
     bdReleaseEntryRefs(pClient);
@@ -2443,8 +2444,6 @@ static void bdPrefetchCb(
   CacheEntry *pEntry = pDLCtx->pEntry;
   int rc = errCode;
 
-  pClient->prefetch.nOutstanding--;
-
   if( rc==SQLITE_OK ){
     i64 iOff = (pEntry->iPos * p->c.szBlk);
     rc = bdWriteFile(p->pCacheFile, pDLCtx->pKey, aData, nData, iOff);
@@ -2459,17 +2458,21 @@ static void bdPrefetchCb(
     bcvfsUnusedAdd(&p->c, pEntry);
   }
 
+  if( pClient ){
+    pClient->prefetch.nOutstanding--;
+
+    if( rc!=SQLITE_OK && pClient->prefetch.errCode==SQLITE_OK ){
+      pClient->prefetch.errCode = rc;
+      pClient->prefetch.zErrMsg = sqlite3_mprintf("%s", zETag);
+    }
+
+    if( pClient->prefetch.bReply ){
+      bdSendPrefetchReply(pClient);
+      pClient->prefetch.bReply = 0;
+    }
+  }
+
   bdBlockDownloadFree(pDLCtx);
-
-  if( rc!=SQLITE_OK && pClient->prefetch.errCode==SQLITE_OK ){
-    pClient->prefetch.errCode = rc;
-    pClient->prefetch.zErrMsg = sqlite3_mprintf("%s", zETag);
-  }
-
-  if( pClient && pClient->prefetch.bReply ){
-    bdSendPrefetchReply(pClient);
-    pClient->prefetch.bReply = 0;
-  }
 }
 
 


### PR DESCRIPTION
Part of what I posted on CloudSQLite forum (Excluding logs and callstack):
My interpretation of what took place is that a client triggered a prefetch and during that prefetch the client was forcefully shutdown(unrelated to anything CloudSQLite). Daemon calls bdDisconnectClient without issue during the forceful shutdown. A block finishes downloading so the daemon goes to reply, it gets a send() failure and tries to call bdDisconnectClient again. I guess the daemon does not think the send() failure occurred due to potentially already being disconnected?

Reply from CloudSQLite team: 
"Thanks for looking into this. I think your analysis is correct. The bug has already happened by the time send() is called though - we can't depend on a closed file-descriptor being invalid as unix systems tend to reuse file-descriptor values pretty quickly.

Should now be fixed here:"