### PR TITLE
Added new flag to allow class and property deletions with a minor schema increment

### DIFF
--- a/iModelCore/ECDb/CHANGES.md
+++ b/iModelCore/ECDb/CHANGES.md
@@ -7,6 +7,17 @@ This document including important changes to syntax or file format.
 | Profile | `4.0.0.4` |
 | ECSQL   | `1.2.9.1` |
 
+## `10/25/2023`: Enable property and class deletion without a Major Version increment required
+
+* Added new schema import option "AlwaysAllowDeletions".
+* "AlwaysAllowDeletions" needs to be set when trying to delete properties or classes without incrementing the major version.
+* If "AlwaysAllowDeletions" is set, properties and classes can be deleted with a major version increment as well.
+* If "AlwaysAllowDeletions" is *NOT* set, deleting properties and classes with a major version increment can only be done for dynamic schemas as specified [here](#5162023-enable-property-and-class-deletion-property-type-change-for-dynamic-schemas-with-a-major-schema-update).
+* Criteria for which classes or properties can be deleted is listed [here](#5162023-enable-property-and-class-deletion-property-type-change-for-dynamic-schemas-with-a-major-schema-update)
+* This option is effective for dynamic and non-dynamic schemas.
+
+> Note: Deleting properties/classes will lead to data loss. The user setting this import option is responsible for ensuring the class instances and data are okay for deletion when the new schema is being imported.
+
 ## `10/24/2023`: Pragma integrity_check(check_nav_class_ids) now checks if the navigation property represents a valid ClassId for the relationship
 
 ECsql version updated `1.2.9.0` -> `1.2.9.1`
@@ -181,6 +192,35 @@ On the other hand, the following query makes `Foo` optional by adding `?` at the
   * `PRAGMA checksum(ecdb_map)`: Compute SHA1 checksum for not null data in ec_* table that hold mapping.
   * `PRAGMA checksum(sqlite_schema)`: Compute SHA1 checksum over ddl store in sqlite_master for all facets.
 
+## `5/16/2023`: Enable property and class deletion, property type change for dynamic schemas with a major schema update
+
+* Added new schema import option "AllowMajorSchemaUpgradeForDynamicSchemas".
+    1. "AllowMajorSchemaUpgradeForDynamicSchemas" takes precedence over the "DisallowMajorSchemaUpgrade" import option, but only for dynamic schemas.
+    2. If major schema upgrades have been disabled by using the import option "DisallowMajorSchemaUpgrade" and the user wants to perform a major schema upgrade on a dynamic schema, the new option "AllowMajorSchemaUpgradeForDynamicSchemas" needs to be added to enable the upgrade.
+    3. "AllowMajorSchemaUpgradeForDynamicSchemas" has no effect on schemas that are not dynamic.
+
+* Enable deletion of properties in dynamic schemas with a major schema upgrade.
+    1. Properties can be deleted only if they belong to an ECClass which is mapped to a shared column.
+    2. Navigation properties cannot be deleted.
+    3. When a property is deleted with a major schema upgrade, the data that it contains is set to NULL.
+
+* Enable deletion of classes in dynamic schemas with a major schema upgrade.
+    1. Classes can only be deleted from a dynamic schema with a major schema upgrade only if:
+        1. The class does not have a derived class.
+        2. The class is not an ECStructClass.
+        3. The class is not an ECRelationshipClass with a Foreign Key mapped.
+        4. The class has not been specified in a relationship constraint.
+    2. If the class to be deleted has instances present, all the instances are deleted as well.
+
+* Enable property type change in dynamic schemas with a major schema upgrade.
+    1. Changing property type from a primitive type to another primitive type is now supported with a major schema upgrade.
+    2. Type can be changed in any combination from the primitive set { int, long, double, binary, boolean, datetime }.
+    3. Type change for composite primitive types Point2d and Point3d is NOT supported.
+    4. Type change to and from an un-strict enum that has a different primitive type is now supported.
+    5. Type change to a strict enum of a different primitive type is NOT supported.
+    6. When a property type is changed, the data will not change/update as per the new primitive type specified.
+    7. It is the user's responsibility to handle the data changes required when a property's type is changed to a different primitive type.
+
 ## `5/3/2023`: Enhanced Instance properties
 
 * ECSQL version changed from `1.1.0.0` -> `1.2.0.0`
@@ -305,32 +345,3 @@ For primitive types that has single value, following will return typed value whi
        1. **Minor**: Any breaking change to `Runtime` e.g. Removing support for a previously accessible sql function or change it in a way where it will not work as before. In this case `Prepare()` phase may or may not detect a failure but result are not as expected as it use to in previous version. e.g. Remove a sql function or change required argument or format of its return value.
        2. **Sub1**:  Backward compatible change to `Syntax`. For example adding new syntax but not breaking any existing.
        3. **Sub2**:  Backward compatible change to `Runtime`. For example adding a new sql function.
-
-## `5/16/2023`: Enable property and class deletion, property type change for dynamic schemas with a major schema update
-
-* Added new schema import option "AllowMajorSchemaUpgradeForDynamicSchemas".
-    1. "AllowMajorSchemaUpgradeForDynamicSchemas" takes precedence over the "DisallowMajorSchemaUpgrade" import option, but only for dynamic schemas.
-    2. If major schema upgrades have been disabled by using the import option "DisallowMajorSchemaUpgrade" and the user wants to perform a major schema upgrade on a dynamic schema, the new option "AllowMajorSchemaUpgradeForDynamicSchemas" needs to be added to enable the upgrade.
-    3. "AllowMajorSchemaUpgradeForDynamicSchemas" has no effect on schemas that are not dynamic.
-
-* Enable deletion of properties in dynamic schemas with a major schema upgrade.
-    1. Properties can be deleted only if they belong to an ECClass which is mapped to a shared column.
-    2. Navigation properties cannot be deleted.
-    3. When a property is deleted with a major schema upgrade, the data that it contains is set to NULL.
-
-* Enable deletion of classes in dynamic schemas with a major schema upgrade.
-    1. Classes can only be deleted from a dynamic schema with a major schema upgrade only if:
-        1. The class does not have a derived class.
-        2. The class is not an ECStructClass.
-        3. The class is not an ECRelationshipClass with a Foreign Key mapped.
-        4. The class has not been specified in a relationship constraint.
-    2. If the class to be deleted has instances present, all the instances are deleted as well.
-
-* Enable property type change in dynamic schemas with a major schema upgrade.
-    1. Changing property type from a primitive type to another primitive type is now supported with a major schema upgrade.
-    2. Type can be changed in any combination from the primitive set { int, long, double, binary, boolean, datetime }.
-    3. Type change for composite primitive types Point2d and Point3d is NOT supported.
-    4. Type change to and from an un-strict enum that has a different primitive type is now supported.
-    5. Type change to a strict enum of a different primitive type is NOT supported.
-    6. When a property type is changed, the data will not change/update as per the new primitive type specified.
-    7. It is the user's responsibility to handle the data changes required when a property's type is changed to a different primitive type.

--- a/iModelCore/ECDb/ECDb/SchemaManagerDispatcher.cpp
+++ b/iModelCore/ECDb/ECDb/SchemaManagerDispatcher.cpp
@@ -2001,7 +2001,7 @@ BentleyStatus MainSchemaManager::PurgeOrphanTables(SchemaImportContext& ctx) con
     if (tablesToDrop.empty())
         return SUCCESS;
 
-    if (Enum::Contains(ctx.GetOptions(), SchemaManager::SchemaImportOptions::DisallowMajorSchemaUpgrade))
+    if (Enum::Contains(ctx.GetOptions(), SchemaManager::SchemaImportOptions::DisallowMajorSchemaUpgrade) && !Enum::Contains(ctx.GetOptions(), SchemaManager::SchemaImportOptions::AlwaysAllowDeletions))
         {
         Utf8String tableNames;
         bool isFirstTable = true;

--- a/iModelCore/ECDb/ECDb/SchemaWriter.h
+++ b/iModelCore/ECDb/ECDb/SchemaWriter.h
@@ -159,6 +159,7 @@ struct SchemaWriter final
 
             bool AreMajorSchemaVersionChangesAllowed() const { return !Enum::Contains(m_importCtx.GetOptions(), SchemaManager::SchemaImportOptions::DisallowMajorSchemaUpgrade); }
             bool IsMajorSchemaVersionChangeAllowedForDynamicSchemas() const { return Enum::Contains(m_importCtx.GetOptions(), SchemaManager::SchemaImportOptions::AllowMajorSchemaUpgradeForDynamicSchemas); }
+            bool IsAlwaysAllowDeletionsEnabled() const { return Enum::Contains(m_importCtx.GetOptions(), SchemaManager::SchemaImportOptions::AlwaysAllowDeletions); }
             bool IgnoreIllegalDeletionsAndModifications() const { return Enum::Contains(m_importCtx.GetOptions(), SchemaManager::SchemaImportOptions::DoNotFailForDeletionsOrModifications); }
             bool IsMajorSchemaVersionChange(ECN::ECSchemaId schemaId) const { return m_schemasWithMajorVersionChange.find(schemaId) != m_schemasWithMajorVersionChange.end(); }
             bool IsEC32AvailableInFile() const { return m_ec32AvailableInFile; }

--- a/iModelCore/ECDb/PublicAPI/ECDb/SchemaManager.h
+++ b/iModelCore/ECDb/PublicAPI/ECDb/SchemaManager.h
@@ -412,8 +412,9 @@ struct SchemaManager final : ECN::IECSchemaLocater, ECN::IECClassLocater
             DoNotFailSchemaValidationForLegacyIssues    = 1 << 0,   //! Not needed by regular caller
             DisallowMajorSchemaUpgrade                  = 1 << 1,   //! If specified, schema upgrades where the major version has changed, are not supported.
             DoNotFailForDeletionsOrModifications        = 1 << 2,   //! This is for the case of domain schemas that differ between files even though the schema name and versions are unchanged.  In such a case, we only want to merge in acceptable changes, not delete anything
-            AllowDataTransformDuringSchemaUpgrade       = 1 << 4,   //! The allow schema upgrade to transform data if needed.
-            AllowMajorSchemaUpgradeForDynamicSchemas    = 1 << 5,   //! If specified, schema upgrades where the major version has changed are only supported for dynamic schemas. Takes precedence over DisallowMajorSchemaUpgrade.
+            AllowDataTransformDuringSchemaUpgrade       = 1 << 3,   //! The allow schema upgrade to transform data if needed.
+            AllowMajorSchemaUpgradeForDynamicSchemas    = 1 << 4,   //! If specified, schema upgrades where the major version has changed are only supported for dynamic schemas. Takes precedence over DisallowMajorSchemaUpgrade.
+            AlwaysAllowDeletions                        = 1 << 5,   //! If specified, properties and classes can be deleted from a schema without a major version increment required.
             };
 #if !defined (DOCUMENTATION_GENERATOR)
         struct Dispatcher;

--- a/iModelCore/ECDb/Tests/NonPublished/SchemaManagerTests.cpp
+++ b/iModelCore/ECDb/Tests/NonPublished/SchemaManagerTests.cpp
@@ -240,11 +240,15 @@ TEST_F(SchemaManagerTests, SchemaImportOptionsDoNotOverlap)
     ASSERT_EQ(0, (int)(SchemaManager::SchemaImportOptions::None & SchemaManager::SchemaImportOptions::DisallowMajorSchemaUpgrade));
     ASSERT_EQ(0, (int)(SchemaManager::SchemaImportOptions::None & SchemaManager::SchemaImportOptions::DoNotFailForDeletionsOrModifications));
     ASSERT_EQ(0, (int)(SchemaManager::SchemaImportOptions::None & SchemaManager::SchemaImportOptions::AllowMajorSchemaUpgradeForDynamicSchemas));
+    ASSERT_EQ(0, (int)(SchemaManager::SchemaImportOptions::None & SchemaManager::SchemaImportOptions::AlwaysAllowDeletions));
     ASSERT_EQ(0, (int)(SchemaManager::SchemaImportOptions::DoNotFailSchemaValidationForLegacyIssues & SchemaManager::SchemaImportOptions::DisallowMajorSchemaUpgrade));
     ASSERT_EQ(0, (int)(SchemaManager::SchemaImportOptions::DoNotFailSchemaValidationForLegacyIssues & SchemaManager::SchemaImportOptions::DoNotFailForDeletionsOrModifications));
     ASSERT_EQ(0, (int)(SchemaManager::SchemaImportOptions::DoNotFailSchemaValidationForLegacyIssues & SchemaManager::SchemaImportOptions::AllowMajorSchemaUpgradeForDynamicSchemas));
+    ASSERT_EQ(0, (int)(SchemaManager::SchemaImportOptions::DoNotFailSchemaValidationForLegacyIssues & SchemaManager::SchemaImportOptions::AlwaysAllowDeletions));
     ASSERT_EQ(0, (int)(SchemaManager::SchemaImportOptions::DisallowMajorSchemaUpgrade & SchemaManager::SchemaImportOptions::DoNotFailForDeletionsOrModifications));
     ASSERT_EQ(0, (int)(SchemaManager::SchemaImportOptions::DisallowMajorSchemaUpgrade & SchemaManager::SchemaImportOptions::AllowMajorSchemaUpgradeForDynamicSchemas));
+    ASSERT_EQ(0, (int)(SchemaManager::SchemaImportOptions::DisallowMajorSchemaUpgrade & SchemaManager::SchemaImportOptions::AlwaysAllowDeletions));
+    ASSERT_EQ(0, (int)(SchemaManager::SchemaImportOptions::AllowMajorSchemaUpgradeForDynamicSchemas & SchemaManager::SchemaImportOptions::AlwaysAllowDeletions));
     }
 
 //---------------------------------------------------------------------------------------

--- a/iModelCore/ECDb/Tests/NonPublished/SchemaUpgradeTests.cpp
+++ b/iModelCore/ECDb/Tests/NonPublished/SchemaUpgradeTests.cpp
@@ -14046,8 +14046,7 @@ TEST_F(SchemaUpgradeTestFixture, DisallowMajorSchemaUpgrade)
     EXPECT_EQ(ERROR, assertImport(newSchema, "2.0", SchemaManager::SchemaImportOptions::DisallowMajorSchemaUpgrade)) << "Deleting a property on a shared column";
     EXPECT_EQ(SUCCESS, assertImport(newSchema, "2.0", SchemaManager::SchemaImportOptions::AllowMajorSchemaUpgradeForDynamicSchemas)) << "Deleting a property on a shared column";
     EXPECT_EQ(ERROR, assertImport(newSchema, "2.0", SchemaManager::SchemaImportOptions::DisallowMajorSchemaUpgrade | SchemaManager::SchemaImportOptions::AllowMajorSchemaUpgradeForDynamicSchemas)) << "Deleting a property on a shared column";
-    EXPECT_EQ(SUCCESS, assertImport(newSchema, "2.0", SchemaManager::SchemaImportOptions::AlwaysAllowDeletions)) << "Deleting a property on a shared column";
-    EXPECT_EQ(SUCCESS, assertImport(newSchema, "2.0", SchemaManager::SchemaImportOptions::DisallowMajorSchemaUpgrade | SchemaManager::SchemaImportOptions::AllowMajorSchemaUpgradeForDynamicSchemas | SchemaManager::SchemaImportOptions::AlwaysAllowDeletions)) << "Deleting a property on a shared column should succeed without major schema version increment if the Schema Import Option AlwaysAllowDeletions is given";
+    EXPECT_EQ(ERROR, assertImport(newSchema, "2.0", SchemaManager::SchemaImportOptions::DisallowMajorSchemaUpgrade | SchemaManager::SchemaImportOptions::AllowMajorSchemaUpgradeForDynamicSchemas | SchemaManager::SchemaImportOptions::AlwaysAllowDeletions)) << "Deleting a property on a shared column should succeed without major schema version increment if the Schema Import Option AlwaysAllowDeletions is given";
 
     //Deleting a class
     newSchema = R"xml(<?xml version="1.0" encoding="utf-8" ?>
@@ -14077,8 +14076,7 @@ TEST_F(SchemaUpgradeTestFixture, DisallowMajorSchemaUpgrade)
     EXPECT_EQ(ERROR, assertImport(newSchema, "2.0", SchemaManager::SchemaImportOptions::DisallowMajorSchemaUpgrade)) << "Deleting a class";
     EXPECT_EQ(SUCCESS, assertImport(newSchema, "2.0", SchemaManager::SchemaImportOptions::AllowMajorSchemaUpgradeForDynamicSchemas)) << "Deleting a class";
     EXPECT_EQ(ERROR, assertImport(newSchema, "2.0", SchemaManager::SchemaImportOptions::DisallowMajorSchemaUpgrade | SchemaManager::SchemaImportOptions::AllowMajorSchemaUpgradeForDynamicSchemas)) << "Deleting a class";
-    EXPECT_EQ(SUCCESS, assertImport(newSchema, "2.0", SchemaManager::SchemaImportOptions::AlwaysAllowDeletions)) << "Deleting a class";
-    EXPECT_EQ(SUCCESS, assertImport(newSchema, "2.0", SchemaManager::SchemaImportOptions::DisallowMajorSchemaUpgrade | SchemaManager::SchemaImportOptions::AllowMajorSchemaUpgradeForDynamicSchemas | SchemaManager::SchemaImportOptions::AlwaysAllowDeletions)) << "Deleting a class";
+    EXPECT_EQ(ERROR, assertImport(newSchema, "2.0", SchemaManager::SchemaImportOptions::DisallowMajorSchemaUpgrade | SchemaManager::SchemaImportOptions::AllowMajorSchemaUpgradeForDynamicSchemas | SchemaManager::SchemaImportOptions::AlwaysAllowDeletions)) << "Deleting a class";
 
     //adding IsNullable constraint
     newSchema = R"xml(<?xml version="1.0" encoding="utf-8" ?>
@@ -17226,15 +17224,14 @@ TEST_F(SchemaUpgradeTestFixture, MajorSchemaUpgradeDeletePropertyAndClass)
             { __LINE__, "1.1.0", SchemaManager::SchemaImportOptions::AlwaysAllowDeletions, SUCCESS },
             { __LINE__, "1.1.0", SchemaManager::SchemaImportOptions::DisallowMajorSchemaUpgrade | SchemaManager::SchemaImportOptions::AllowMajorSchemaUpgradeForDynamicSchemas, ERROR },
             { __LINE__, "1.1.0", SchemaManager::SchemaImportOptions::DisallowMajorSchemaUpgrade | SchemaManager::SchemaImportOptions::AlwaysAllowDeletions, SUCCESS },
-            { __LINE__, "1.1.0", SchemaManager::SchemaImportOptions::DisallowMajorSchemaUpgrade | SchemaManager::SchemaImportOptions::AlwaysAllowDeletions | SchemaManager::SchemaImportOptions::AllowMajorSchemaUpgradeForDynamicSchemas, SUCCESS },
+            { __LINE__, "1.1.0", SchemaManager::SchemaImportOptions::DisallowMajorSchemaUpgrade | SchemaManager::SchemaImportOptions::AllowMajorSchemaUpgradeForDynamicSchemas | SchemaManager::SchemaImportOptions::AlwaysAllowDeletions, SUCCESS },
 
             { __LINE__, "2.0.0", SchemaManager::SchemaImportOptions::None, SUCCESS },
             { __LINE__, "2.0.0", SchemaManager::SchemaImportOptions::DisallowMajorSchemaUpgrade, ERROR },
             { __LINE__, "2.0.0", SchemaManager::SchemaImportOptions::AllowMajorSchemaUpgradeForDynamicSchemas, SUCCESS },
-            { __LINE__, "2.0.0", SchemaManager::SchemaImportOptions::AlwaysAllowDeletions, SUCCESS },
             { __LINE__, "2.0.0", SchemaManager::SchemaImportOptions::DisallowMajorSchemaUpgrade | SchemaManager::SchemaImportOptions::AllowMajorSchemaUpgradeForDynamicSchemas, SUCCESS },
-            { __LINE__, "2.0.0", SchemaManager::SchemaImportOptions::DisallowMajorSchemaUpgrade | SchemaManager::SchemaImportOptions::AlwaysAllowDeletions, SUCCESS },
-            { __LINE__, "2.0.0", SchemaManager::SchemaImportOptions::DisallowMajorSchemaUpgrade | SchemaManager::SchemaImportOptions::AlwaysAllowDeletions | SchemaManager::SchemaImportOptions::AllowMajorSchemaUpgradeForDynamicSchemas, SUCCESS },
+            { __LINE__, "2.0.0", SchemaManager::SchemaImportOptions::DisallowMajorSchemaUpgrade | SchemaManager::SchemaImportOptions::AlwaysAllowDeletions, ERROR },
+            { __LINE__, "2.0.0", SchemaManager::SchemaImportOptions::DisallowMajorSchemaUpgrade | SchemaManager::SchemaImportOptions::AllowMajorSchemaUpgradeForDynamicSchemas | SchemaManager::SchemaImportOptions::AlwaysAllowDeletions, SUCCESS },
         })
         {
         Utf8PrintfString errorMsg("Test case at line %d has failed.\n", lineNumber);

--- a/iModelCore/ECDb/Tests/NonPublished/SchemaUpgradeTests.cpp
+++ b/iModelCore/ECDb/Tests/NonPublished/SchemaUpgradeTests.cpp
@@ -14039,11 +14039,15 @@ TEST_F(SchemaUpgradeTestFixture, DisallowMajorSchemaUpgrade)
     EXPECT_EQ(ERROR, assertImport(newSchema, "1.1", SchemaManager::SchemaImportOptions::DisallowMajorSchemaUpgrade)) << "Deleting a property on a shared column (must fail because it requires the major schema version to be incremented)";
     EXPECT_EQ(ERROR, assertImport(newSchema, "1.1", SchemaManager::SchemaImportOptions::AllowMajorSchemaUpgradeForDynamicSchemas)) << "Deleting a property on a shared column (must fail because it requires the major schema version to be incremented)";
     EXPECT_EQ(ERROR, assertImport(newSchema, "1.1", SchemaManager::SchemaImportOptions::DisallowMajorSchemaUpgrade | SchemaManager::SchemaImportOptions::AllowMajorSchemaUpgradeForDynamicSchemas)) << "Deleting a property on a shared column (must fail because it requires the major schema version to be incremented)";
+    EXPECT_EQ(SUCCESS, assertImport(newSchema, "1.1", SchemaManager::SchemaImportOptions::AlwaysAllowDeletions)) << "Deleting a property on a shared column should succeed without major schema version increment if the Schema Import Option AlwaysAllowDeletions is given";
+    EXPECT_EQ(SUCCESS, assertImport(newSchema, "1.1", SchemaManager::SchemaImportOptions::DisallowMajorSchemaUpgrade | SchemaManager::SchemaImportOptions::AllowMajorSchemaUpgradeForDynamicSchemas | SchemaManager::SchemaImportOptions::AlwaysAllowDeletions)) << "Deleting a property on a shared column should succeed without major schema version increment if the Schema Import Option AlwaysAllowDeletions is given";
 
     EXPECT_EQ(SUCCESS, assertImport(newSchema, "2.0", SchemaManager::SchemaImportOptions::None)) << "Deleting a property on a shared column";
     EXPECT_EQ(ERROR, assertImport(newSchema, "2.0", SchemaManager::SchemaImportOptions::DisallowMajorSchemaUpgrade)) << "Deleting a property on a shared column";
     EXPECT_EQ(SUCCESS, assertImport(newSchema, "2.0", SchemaManager::SchemaImportOptions::AllowMajorSchemaUpgradeForDynamicSchemas)) << "Deleting a property on a shared column";
     EXPECT_EQ(ERROR, assertImport(newSchema, "2.0", SchemaManager::SchemaImportOptions::DisallowMajorSchemaUpgrade | SchemaManager::SchemaImportOptions::AllowMajorSchemaUpgradeForDynamicSchemas)) << "Deleting a property on a shared column";
+    EXPECT_EQ(SUCCESS, assertImport(newSchema, "2.0", SchemaManager::SchemaImportOptions::AlwaysAllowDeletions)) << "Deleting a property on a shared column";
+    EXPECT_EQ(SUCCESS, assertImport(newSchema, "2.0", SchemaManager::SchemaImportOptions::DisallowMajorSchemaUpgrade | SchemaManager::SchemaImportOptions::AllowMajorSchemaUpgradeForDynamicSchemas | SchemaManager::SchemaImportOptions::AlwaysAllowDeletions)) << "Deleting a property on a shared column should succeed without major schema version increment if the Schema Import Option AlwaysAllowDeletions is given";
 
     //Deleting a class
     newSchema = R"xml(<?xml version="1.0" encoding="utf-8" ?>
@@ -14066,11 +14070,15 @@ TEST_F(SchemaUpgradeTestFixture, DisallowMajorSchemaUpgrade)
     EXPECT_EQ(ERROR, assertImport(newSchema, "1.1", SchemaManager::SchemaImportOptions::DisallowMajorSchemaUpgrade)) << "Deleting a class (must fail because it requires the major schema version to be incremented)";
     EXPECT_EQ(ERROR, assertImport(newSchema, "1.1", SchemaManager::SchemaImportOptions::AllowMajorSchemaUpgradeForDynamicSchemas)) << "Deleting a class (must fail because it requires the major schema version to be incremented)";
     EXPECT_EQ(ERROR, assertImport(newSchema, "1.1", SchemaManager::SchemaImportOptions::DisallowMajorSchemaUpgrade | SchemaManager::SchemaImportOptions::AllowMajorSchemaUpgradeForDynamicSchemas)) << "Deleting a class (must fail because it requires the major schema version to be incremented)";
+    EXPECT_EQ(SUCCESS, assertImport(newSchema, "1.1", SchemaManager::SchemaImportOptions::AlwaysAllowDeletions)) << "Deleting a class should succeed without major schema version increment if the Schema Import Option AlwaysAllowDeletions is given";
+    EXPECT_EQ(SUCCESS, assertImport(newSchema, "1.1", SchemaManager::SchemaImportOptions::DisallowMajorSchemaUpgrade | SchemaManager::SchemaImportOptions::AllowMajorSchemaUpgradeForDynamicSchemas | SchemaManager::SchemaImportOptions::AlwaysAllowDeletions)) << "Deleting a class should succeed without major schema version increment if the Schema Import Option AlwaysAllowDeletions is given";
 
     EXPECT_EQ(SUCCESS, assertImport(newSchema, "2.0", SchemaManager::SchemaImportOptions::None)) << "Deleting a class";
     EXPECT_EQ(ERROR, assertImport(newSchema, "2.0", SchemaManager::SchemaImportOptions::DisallowMajorSchemaUpgrade)) << "Deleting a class";
     EXPECT_EQ(SUCCESS, assertImport(newSchema, "2.0", SchemaManager::SchemaImportOptions::AllowMajorSchemaUpgradeForDynamicSchemas)) << "Deleting a class";
     EXPECT_EQ(ERROR, assertImport(newSchema, "2.0", SchemaManager::SchemaImportOptions::DisallowMajorSchemaUpgrade | SchemaManager::SchemaImportOptions::AllowMajorSchemaUpgradeForDynamicSchemas)) << "Deleting a class";
+    EXPECT_EQ(SUCCESS, assertImport(newSchema, "2.0", SchemaManager::SchemaImportOptions::AlwaysAllowDeletions)) << "Deleting a class";
+    EXPECT_EQ(SUCCESS, assertImport(newSchema, "2.0", SchemaManager::SchemaImportOptions::DisallowMajorSchemaUpgrade | SchemaManager::SchemaImportOptions::AllowMajorSchemaUpgradeForDynamicSchemas | SchemaManager::SchemaImportOptions::AlwaysAllowDeletions)) << "Deleting a class";
 
     //adding IsNullable constraint
     newSchema = R"xml(<?xml version="1.0" encoding="utf-8" ?>
@@ -17215,23 +17223,29 @@ TEST_F(SchemaUpgradeTestFixture, MajorSchemaUpgradeDeletePropertyAndClass)
             { __LINE__, "1.1.0", SchemaManager::SchemaImportOptions::None, ERROR },
             { __LINE__, "1.1.0", SchemaManager::SchemaImportOptions::DisallowMajorSchemaUpgrade, ERROR },
             { __LINE__, "1.1.0", SchemaManager::SchemaImportOptions::AllowMajorSchemaUpgradeForDynamicSchemas, ERROR },
+            { __LINE__, "1.1.0", SchemaManager::SchemaImportOptions::AlwaysAllowDeletions, SUCCESS },
             { __LINE__, "1.1.0", SchemaManager::SchemaImportOptions::DisallowMajorSchemaUpgrade | SchemaManager::SchemaImportOptions::AllowMajorSchemaUpgradeForDynamicSchemas, ERROR },
+            { __LINE__, "1.1.0", SchemaManager::SchemaImportOptions::DisallowMajorSchemaUpgrade | SchemaManager::SchemaImportOptions::AlwaysAllowDeletions, SUCCESS },
+            { __LINE__, "1.1.0", SchemaManager::SchemaImportOptions::DisallowMajorSchemaUpgrade | SchemaManager::SchemaImportOptions::AlwaysAllowDeletions | SchemaManager::SchemaImportOptions::AllowMajorSchemaUpgradeForDynamicSchemas, SUCCESS },
 
             { __LINE__, "2.0.0", SchemaManager::SchemaImportOptions::None, SUCCESS },
             { __LINE__, "2.0.0", SchemaManager::SchemaImportOptions::DisallowMajorSchemaUpgrade, ERROR },
             { __LINE__, "2.0.0", SchemaManager::SchemaImportOptions::AllowMajorSchemaUpgradeForDynamicSchemas, SUCCESS },
+            { __LINE__, "2.0.0", SchemaManager::SchemaImportOptions::AlwaysAllowDeletions, SUCCESS },
             { __LINE__, "2.0.0", SchemaManager::SchemaImportOptions::DisallowMajorSchemaUpgrade | SchemaManager::SchemaImportOptions::AllowMajorSchemaUpgradeForDynamicSchemas, SUCCESS },
+            { __LINE__, "2.0.0", SchemaManager::SchemaImportOptions::DisallowMajorSchemaUpgrade | SchemaManager::SchemaImportOptions::AlwaysAllowDeletions, SUCCESS },
+            { __LINE__, "2.0.0", SchemaManager::SchemaImportOptions::DisallowMajorSchemaUpgrade | SchemaManager::SchemaImportOptions::AlwaysAllowDeletions | SchemaManager::SchemaImportOptions::AllowMajorSchemaUpgradeForDynamicSchemas, SUCCESS },
         })
         {
         Utf8PrintfString errorMsg("Test case at line %d has failed.\n", lineNumber);
 
         EXPECT_EQ(expectedResult, GetHelper().ImportSchema(SchemaItem(Utf8PrintfString(majorSchemaChange, newSchemaVersion)), importOptions)) << errorMsg;
+        auto testClass = m_ecdb.Schemas().GetClass("TestSchema", "TestClass");
+        ASSERT_NE(testClass, nullptr) << errorMsg;
+
         if (expectedResult == SUCCESS)
             {
             // Check if property "Code" was deleted
-            auto testClass = m_ecdb.Schemas().GetClass("TestSchema", "TestClass");
-            ASSERT_NE(testClass, nullptr) << errorMsg;
-
             EXPECT_NE(testClass->GetPropertyP("Name"), nullptr) << errorMsg;
             EXPECT_EQ(testClass->GetPropertyP("Code"), nullptr) << errorMsg;
 
@@ -17239,7 +17253,16 @@ TEST_F(SchemaUpgradeTestFixture, MajorSchemaUpgradeDeletePropertyAndClass)
             EXPECT_EQ(m_ecdb.Schemas().GetClass("TestSchema", "TestClassToDelete"), nullptr) << errorMsg;
             EXPECT_EQ(m_ecdb.Schemas().GetClass("TestSchema", "SubClassToDelete"), nullptr) << errorMsg;
             }
+        else
+            {
+            EXPECT_NE(testClass->GetPropertyP("Name"), nullptr);
+            EXPECT_NE(testClass->GetPropertyP("Code"), nullptr);
+
+            EXPECT_NE(m_ecdb.Schemas().GetClass("TestSchema", "TestClassToDelete"), nullptr);
+            EXPECT_NE(m_ecdb.Schemas().GetClass("TestSchema", "SubClassToDelete"), nullptr);
+            }
         ASSERT_EQ(BE_SQLITE_OK, m_ecdb.AbandonChanges()) << errorMsg;
+        m_ecdb.ClearECDbCache();
         ASSERT_EQ(BE_SQLITE_OK, ReopenECDb()) << errorMsg;
         }
     }

--- a/iModelCore/iModelPlatform/DgnCore/DgnDbSchema.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/DgnDbSchema.cpp
@@ -663,7 +663,7 @@ SchemaStatus DgnDb::ImportV8LegacySchemas(bvector<ECSchemaCP> const& schemas, si
     if (schemasToImport.empty())
         return SchemaStatus::Success;
 
-    SchemaManager::SchemaImportOptions options = SchemaManager::SchemaImportOptions::DoNotFailSchemaValidationForLegacyIssues | SchemaManager::SchemaImportOptions::DoNotFailForDeletionsOrModifications;
+    SchemaManager::SchemaImportOptions options = IsAlwaysAllowDeletionsEnabled() ? SchemaManager::SchemaImportOptions::AlwaysAllowDeletions : SchemaManager::SchemaImportOptions::DoNotFailSchemaValidationForLegacyIssues | SchemaManager::SchemaImportOptions::DoNotFailForDeletionsOrModifications;
     return Domains().DoImportSchemas(schemasToImport, options);
     }
 

--- a/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/DgnDb.h
+++ b/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/DgnDb.h
@@ -210,6 +210,7 @@ struct DgnDb : RefCounted<BeSQLite::EC::ECDb>, BeSQLite::EC::ECDb::IECDbCacheCle
 private:
     BeSQLite::BeBriefcaseBasedIdSequence m_elementIdSequence;
     int m_purgeOperation = 0;
+    bool m_alwaysAllowDeletions = false;
 
     void Destroy();
     SchemaStatus PickSchemasToImport(bvector<ECN::ECSchemaCP>& importSchemas, bvector<ECN::ECSchemaCP> const& schemas, bool isImportingFromV8) const;
@@ -520,6 +521,9 @@ public:
     //! the changes if necessary, and then creating a revision.
     //! </ul>
     DGNPLATFORM_EXPORT SchemaStatus ImportV8LegacySchemas(bvector<ECN::ECSchemaCP> const& schemas, size_t* numImported = nullptr);
+
+    DGNPLATFORM_EXPORT void SetAlwaysAllowDeletions(const bool flagStatus) { m_alwaysAllowDeletions = flagStatus; }
+    bool IsAlwaysAllowDeletionsEnabled() const { return m_alwaysAllowDeletions; }
 
     //! Utility method to get the next id in a sequence
     //! @private internal use only


### PR DESCRIPTION
Added a new schema import flag "AlwaysAllowDeletions" which is disabled by default.
User needs to call SetAlwaysAllowDeletions(bool) to enable the flag.

This flag will allow class and property deletion irrespective of whether the major version is incremented.

As of right now, this flag is only checked/used by the DgnDb::ImportV8LegacySchemas().
The normal DgnDb::ImportSchemas() remains unaffected.