### PR TITLE
Fix for import issue while building the iModel Evolution Tests

### DIFF
--- a/iModelCore/iModelPlatform/Tests/DgnProject/Compatibility/CompatibilityRunner/PrepareCurrentTestRunner.mke
+++ b/iModelCore/iModelPlatform/Tests/DgnProject/Compatibility/CompatibilityRunner/PrepareCurrentTestRunner.mke
@@ -14,4 +14,4 @@ CURRENTTESTRUNNER_TESTFILES_DIR = $(CURRENTTESTRUNNER_RUN_DIR)/TestFiles
 always:
     ~mkdir $(TESTFILES_DIR)
     ~mkdir $(CURRENTTESTRUNNER_TESTFILES_DIR)
-    python Tests/DgnProject/Compatibility/CompatibilityRunner/PrepareCurrentTestRunner.py $(TESTFILES_DIR) $(CURRENTTESTRUNNER_TESTFILES_DIR)
+    $(BBPYTHONCMD) Tests/DgnProject/Compatibility/CompatibilityRunner/PrepareCurrentTestRunner.py $(TESTFILES_DIR) $(CURRENTTESTRUNNER_TESTFILES_DIR)

--- a/iModelCore/iModelPlatform/Tests/DgnProject/Compatibility/CompatibilityRunner/PreparePulledTestRunners.mke
+++ b/iModelCore/iModelPlatform/Tests/DgnProject/Compatibility/CompatibilityRunner/PreparePulledTestRunners.mke
@@ -14,4 +14,4 @@ always:
     ~mkdir $(TESTRUNNERS_NUGET_DIR)
     ~mkdir $(TESTFILES_DIR)
     ~mkdir $(NEWFILES_DIR)
-    python Tests/DgnProject/Compatibility/CompatibilityRunner/PreparePulledTestRunners.py $(TESTRUNNERS_NUGET_DIR) $(TESTRUNNERS_SANDBOXDIR) $(TESTFILES_DIR) $(NEWFILES_DIR)
+    $(BBPYTHONCMD) Tests/DgnProject/Compatibility/CompatibilityRunner/PreparePulledTestRunners.py $(TESTRUNNERS_NUGET_DIR) $(TESTRUNNERS_SANDBOXDIR) $(TESTFILES_DIR) $(NEWFILES_DIR)

--- a/iModelCore/iModelPlatform/Tests/DgnProject/Compatibility/CompatibilityRunner/PrepareTestFilesNugetPackaging.mke
+++ b/iModelCore/iModelPlatform/Tests/DgnProject/Compatibility/CompatibilityRunner/PrepareTestFilesNugetPackaging.mke
@@ -26,5 +26,5 @@ COPYDIR_OUTPUT = $(CacheDir)
 
 always:
     ~mkdir $(ContextDir)
-    python $(SrcRoot)bsicommon/build/CopyWithSymlinks.py $(CacheDir) $(ContextDir)
+    $(BBPYTHONCMD) $(SrcRoot)bsicommon/build/CopyWithSymlinks.py $(CacheDir) $(ContextDir)
     

--- a/iModelCore/iModelPlatform/Tests/DgnProject/Compatibility/CompatibilityRunner/PullNugets.mke
+++ b/iModelCore/iModelPlatform/Tests/DgnProject/Compatibility/CompatibilityRunner/PullNugets.mke
@@ -20,5 +20,5 @@ always:
     ~mkdir $(TESTFILES_NUGET_DIR)
     ~mkdir $(TESTRUNNERS_NUGET_DIR)
     ~mkdir $(TESTFILES_DIR)
-    python Tests/DgnProject/Compatibility/CompatibilityRunner/PullNugets.py $(NUGET_SRC_DIR) $(ARTEFACTS_ROOTDIR) $(NUGET_DIR) $(SrcRoot)BentleyBuild/bentleybuild
+    $(BBPYTHONCMD) Tests/DgnProject/Compatibility/CompatibilityRunner/PullNugets.py $(NUGET_SRC_DIR) $(ARTEFACTS_ROOTDIR) $(NUGET_DIR) $(SrcRoot)BentleyBuild/bentleybuild
     $(SrcRoot)bsicommon/build/CopyWithSymlinks.py $(NUGET_SRC_DIR) $(TESTRUNNERS_NUGET_DIR)

--- a/iModelCore/iModelPlatform/Tests/DgnProject/Compatibility/CompatibilityRunner/RunPulledTestRunners.mke
+++ b/iModelCore/iModelPlatform/Tests/DgnProject/Compatibility/CompatibilityRunner/RunPulledTestRunners.mke
@@ -10,4 +10,4 @@
 %include $(SrcRoot)imodel-native/iModelCore/iModelPlatform/Tests/DgnProject/Compatibility/CompatibilityRunner/common.mki
 
 always:
-    python $(SrcRoot)/imodel-native/iModelCore/iModelPlatform/Tests/DgnProject/Compatibility/CompatibilityRunner/RunPulledTestRunners.py $(TESTRUNNERS_SANDBOXDIR)
+    $(BBPYTHONCMD) $(SrcRoot)/imodel-native/iModelCore/iModelPlatform/Tests/DgnProject/Compatibility/CompatibilityRunner/RunPulledTestRunners.py $(TESTRUNNERS_SANDBOXDIR)


### PR DESCRIPTION
After the recent changes to `strategy.py`, the build has started failing with the following error:
```
python Tests\DgnProject\Compatibility\CompatibilityRunner\PullNugets.py D:\vsts_a\49\bbsrc\\nuget\iModelEvolutionTests\ D:\vsts_a\49\b\Winx64\iModelEvolutionTests D:\vsts_a\49\b\Winx64\iModelEvolutionTests\Nugets D:\vsts_a\49\bbsrc\BentleyBuild\bentleybuild
Traceback (most recent call last):
  File "Tests\DgnProject\Compatibility\CompatibilityRunner\PullNugets.py", line 13, in <module>
    from bblib import globalvars, nugetpkg, strategy, symlinks
  File "D:\vsts_a\49\bbsrc\bentleybuild\bblib\strategy.py", line 2005
    def AddEnvIfNotThere (envVar: str, value: str):
                                ^
SyntaxError: invalid syntax
BBMake: call trace
    line:   24, D:\vsts_a\49\bbsrc\imodel-native\iModelCore\iModelPlatform\Tests\DgnProject\Compatibility\CompatibilityRunner\PullNugets.mke
Mon Oct 30 03:41:16 2023, elapsed time: 0:01

```