### PR TITLE
Fix evolution test failure due to 4.0.0.1 test files

### DIFF
--- a/iModelCore/iModelPlatform/Tests/DgnProject/Compatibility/IModelCompatibilityTests.cpp
+++ b/iModelCore/iModelPlatform/Tests/DgnProject/Compatibility/IModelCompatibilityTests.cpp
@@ -2123,7 +2123,7 @@ TEST_F(IModelCompatibilityTestFixture, UpgradeDomainIModelToEC32)
     IModelEvolutionTestsDomain::GetDomain().SetRequired(DgnDomain::Required::No);
     }
 
-TEST_F(IModelCompatibilityTestFixture, MajorSchemaUpgradeDeleteSchemaItems)
+TEST_F(IModelCompatibilityTestFixture, MajorSchemaUpgradeDeleteClassPropertyAndEnums)
     {
     for (const auto& testFile : DgnDbProfile::Get().GetAllVersionsOfTestFile(TESTIMODEL_EMPTY))
         {
@@ -2147,9 +2147,6 @@ TEST_F(IModelCompatibilityTestFixture, MajorSchemaUpgradeDeleteSchemaItems)
                                 <ECSchemaReference name="ECDbMap" version="02.00" alias="ecdbmap"/>
                                 <ECSchemaReference name="BisCore" version="01.00" alias="bis"/>
 
-                                <KindOfQuantity typeName='TestKoQ' description='TestKoQ' displayLabel='TestKoQ' persistenceUnit='CM' relativeError='.5' presentationUnits='FT;CM' />
-                                <KindOfQuantity typeName='AnotherTestKoQ' description='AnotherTestKoQ' displayLabel='AnotherTestKoQ' persistenceUnit='M' relativeError='.5' presentationUnits='FT;M' />
-
                                 <ECEnumeration typeName='UnstrictEnumInt' backingTypeName='int' isStrict='False'>
                                     <ECEnumerator value = '0' displayLabel = 'txt' />
                                     <ECEnumerator value = '1' displayLabel = 'bat' />
@@ -2170,14 +2167,171 @@ TEST_F(IModelCompatibilityTestFixture, MajorSchemaUpgradeDeleteSchemaItems)
 
                                 <ECEntityClass typeName="TestClass" >
                                     <BaseClass>bis:PhysicalElement</BaseClass>
+                                    <ECProperty propertyName="StringProp" typeName="string" />
+                                    <ECProperty propertyName="IntProp" typeName="int" />
+
+                                    <ECProperty propertyName="UnstrictEnumIntProp" typeName="UnstrictEnumInt" />
+                                    <ECProperty propertyName="UnstrictEnumStringProp" typeName="UnstrictEnumString" />
+                                    <ECProperty propertyName="StrictEnumIntProp" typeName="StrictEnumInt" />
+                                    <ECProperty propertyName="StrictEnumStringProp" typeName="StrictEnumString" />
+                                </ECEntityClass>
+                                <ECEntityClass typeName="SubClassToDelete" >
+                                    <BaseClass>TestClass</BaseClass>
+                                    <ECProperty propertyName="SubProp" typeName="int" />
+                                </ECEntityClass>
+
+                                <ECEntityClass typeName="TestClassToDelete" >
+                                    <BaseClass>bis:PhysicalElement</BaseClass>
+                                    <ECProperty propertyName="NameProp" typeName="string " />
+                                </ECEntityClass>
+                            </ECSchema>)xml"));
+            ASSERT_NE(deserializationCtx, nullptr) << testDbPtr->GetDescription();
+            ASSERT_EQ(SchemaStatus::Success, dgnDb.ImportSchemas(deserializationCtx->GetCache().GetSchemas())) << testDbPtr->GetDescription();
+
+            // Check that the data has been setup correctly
+            auto schema = dgnDb.Schemas().GetSchema("TestSchema");
+            ASSERT_NE(schema, nullptr);
+
+            auto testClass = schema->GetClassCP("TestClass");
+            ASSERT_NE(testClass, nullptr);
+            
+            EXPECT_NE(schema->GetEnumerationCP("UnstrictEnumInt"), nullptr);
+            EXPECT_NE(schema->GetEnumerationCP("UnstrictEnumString"), nullptr);
+            EXPECT_NE(schema->GetEnumerationCP("StrictEnumInt"), nullptr);
+            EXPECT_NE(schema->GetEnumerationCP("StrictEnumString"), nullptr);
+
+            auto stringProp = testClass->GetPropertyP("StringProp");
+            ASSERT_NE(stringProp, nullptr);
+
+            auto intProp = testClass->GetPropertyP("IntProp");
+            ASSERT_NE(intProp, nullptr);
+
+            auto enumProp1 = testClass->GetPropertyP("UnstrictEnumIntProp");
+            ASSERT_NE(enumProp1, nullptr);
+            EXPECT_NE(enumProp1->GetTypeFullName(), "int");
+
+            auto enumProp2 = testClass->GetPropertyP("UnstrictEnumStringProp");
+            ASSERT_NE(enumProp2, nullptr);
+            EXPECT_NE(enumProp2->GetTypeFullName(), "string");
+
+            auto enumProp3 = testClass->GetPropertyP("StrictEnumIntProp");
+            ASSERT_NE(enumProp3, nullptr);
+            EXPECT_NE(enumProp3->GetTypeFullName(), "int");
+
+            auto enumProp4 = testClass->GetPropertyP("StrictEnumStringProp");
+            ASSERT_NE(enumProp4, nullptr);
+            EXPECT_NE(enumProp4->GetTypeFullName(), "string");
+
+            EXPECT_NE(schema->GetClassCP("TestClassToDelete"), nullptr);
+            EXPECT_NE(schema->GetClassCP("SubClassToDelete"), nullptr);
+
+            // Perform major schema change by deleting property and class
+            auto deserializationCtxUpdate = TestFileCreator::DeserializeSchema(testDbPtr->GetDb(), SchemaItem(R"xml(<?xml version="1.0" encoding="utf-8" ?>
+                            <ECSchema schemaName="TestSchema" alias="ts" version="2.0" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.1">
+                                <ECSchemaReference name="ECDbMap" version="02.00" alias="ecdbmap"/>
+                                <ECSchemaReference name="CoreCustomAttributes" version="01.00" alias="CoreCA" />
+                                <ECSchemaReference name="BisCore" version="01.00" alias="bis"/>
+                                
+                                <ECCustomAttributes>
+                                    <DynamicSchema xmlns = 'CoreCustomAttributes.01.00' />
+                                </ECCustomAttributes>
+
+                                <ECEntityClass typeName="TestClass" >
+                                    <BaseClass>bis:PhysicalElement</BaseClass>
+                                    <ECProperty propertyName="StringProp" typeName="string" />
+
+                                    <ECProperty propertyName="UnstrictEnumIntProp" typeName="int" />
+                                    <ECProperty propertyName="UnstrictEnumStringProp" typeName="string" />
+                                    <ECProperty propertyName="StrictEnumIntProp" typeName="int" />
+                                    <ECProperty propertyName="StrictEnumStringProp" typeName="string" />
+                                </ECEntityClass>
+                            </ECSchema>)xml"));
+            ASSERT_NE(deserializationCtxUpdate, nullptr) << testDbPtr->GetDescription();
+            ASSERT_EQ(SchemaStatus::Success, dgnDb.ImportSchemas(deserializationCtxUpdate->GetCache().GetSchemas())) << testDbPtr->GetDescription();
+
+            schema = dgnDb.Schemas().GetSchema("TestSchema");
+            ASSERT_NE(schema, nullptr);
+
+            testClass = schema->GetClassCP("TestClass");
+            ASSERT_NE(testClass, nullptr);
+
+            // All enums should be deleted
+            EXPECT_EQ(schema->GetEnumerationCP("UnstrictEnumInt"), nullptr);
+            EXPECT_EQ(schema->GetEnumerationCP("UnstrictEnumString"), nullptr);
+            EXPECT_EQ(schema->GetEnumerationCP("StrictEnumInt"), nullptr);
+            EXPECT_EQ(schema->GetEnumerationCP("StrictEnumString"), nullptr);
+
+            // Property "StringProp" should exist
+            stringProp = testClass->GetPropertyP("StringProp");
+            ASSERT_NE(stringProp, nullptr);
+
+            // Property "IntProp" should be deleted
+            EXPECT_EQ(testClass->GetPropertyP("IntProp"), nullptr);
+
+            // Properties should not have enum type names
+            enumProp1 = testClass->GetPropertyP("UnstrictEnumIntProp");
+            ASSERT_NE(enumProp1, nullptr);
+            EXPECT_EQ(enumProp1->GetTypeFullName(), "int");
+
+            enumProp2 = testClass->GetPropertyP("UnstrictEnumStringProp");
+            ASSERT_NE(enumProp2, nullptr);
+            EXPECT_EQ(enumProp2->GetTypeFullName(), "string");
+
+            enumProp3 = testClass->GetPropertyP("StrictEnumIntProp");
+            ASSERT_NE(enumProp3, nullptr);
+            EXPECT_EQ(enumProp3->GetTypeFullName(), "int");
+
+            enumProp4 = testClass->GetPropertyP("StrictEnumStringProp");
+            ASSERT_NE(enumProp4, nullptr);
+            EXPECT_EQ(enumProp4->GetTypeFullName(), "string");
+
+            // Classes "TestClassToDelete" and "SubClassToDelete" were deleted
+            EXPECT_EQ(schema->GetClassCP("TestClassToDelete"), nullptr);
+            EXPECT_EQ(schema->GetClassCP("SubClassToDelete"), nullptr);
+
+            ASSERT_EQ(BE_SQLITE_OK, dgnDb.AbandonChanges());
+            }
+        }
+    }
+
+TEST_F(IModelCompatibilityTestFixture, MajorSchemaUpgradeDeleteKoQs)
+    {
+    for (const auto& testFile : DgnDbProfile::Get().GetAllVersionsOfTestFile(TESTIMODEL_EMPTY))
+        {
+        for (std::unique_ptr<TestIModel> testDbPtr : TestIModel::GetPermutationsFor(testFile))
+            {
+            TestIModel& testDb = *testDbPtr;
+            const auto openStat = testDb.Open();
+            const auto& params = static_cast<DgnDb::OpenParams const&> (testDb.GetOpenParams());
+
+            if (params.IsReadonly())
+                continue;
+
+            //schema import is possible to newer ECDb profile files or files that don't support EC3.2 as the profile version is automatically upgraded
+            ASSERT_EQ(BE_SQLITE_OK, openStat) << testDb.GetDescription();
+
+            DgnDbR dgnDb = testDb.GetDgnDb();
+
+            // Profile version 4.0.0.1 doesn't support ECXML 3.2 schemas.
+            // This test requires the schema SchemaUpgradeCustomAttributes which provides the CA AllowUnitChange which is used when removing a KOQ from a property.
+            // As SchemaUpgradeCustomAttributes.1.0.0 is ECXML 3.2, it cannot be used by 4.0.0.1 profile version, and hence the 4.0.0.1 test file is skipped.
+            if (dgnDb.GetECDbProfileVersion().CompareTo(ProfileVersion(4, 0, 0, 1)) == 0)
+                continue;
+
+            // Setup test schema
+            auto deserializationCtx = TestFileCreator::DeserializeSchema(testDbPtr->GetDb(), SchemaItem(R"xml(<?xml version="1.0" encoding="utf-8" ?>
+                            <ECSchema schemaName="TestSchema" alias="ts" version="1.0" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.1">
+                                <ECSchemaReference name="ECDbMap" version="02.00" alias="ecdbmap"/>
+                                <ECSchemaReference name="BisCore" version="01.00" alias="bis"/>
+
+                                <KindOfQuantity typeName='TestKoQ' description='TestKoQ' displayLabel='TestKoQ' persistenceUnit='CM' relativeError='.5' presentationUnits='FT;CM' />
+                                <KindOfQuantity typeName='AnotherTestKoQ' description='AnotherTestKoQ' displayLabel='AnotherTestKoQ' persistenceUnit='M' relativeError='.5' presentationUnits='FT;M' />
+
+                                <ECEntityClass typeName="TestClass" >
+                                    <BaseClass>bis:PhysicalElement</BaseClass>
                                     <ECProperty propertyName="FirstProp" typeName="int" kindOfQuantity='TestKoQ' />
                                     <ECProperty propertyName="SecondProp" typeName="int" kindOfQuantity='AnotherTestKoQ' />
                                     <ECProperty propertyName="ThirdProp" typeName="int" />
-
-                                    <ECProperty propertyName="Property1" typeName="UnstrictEnumInt" />
-                                    <ECProperty propertyName="Property2" typeName="UnstrictEnumString" />
-                                    <ECProperty propertyName="Property3" typeName="StrictEnumInt" />
-                                    <ECProperty propertyName="Property4" typeName="StrictEnumString" />
                                 </ECEntityClass>
                                 <ECEntityClass typeName="SubClassToDelete" >
                                     <BaseClass>TestClass</BaseClass>
@@ -2201,11 +2355,6 @@ TEST_F(IModelCompatibilityTestFixture, MajorSchemaUpgradeDeleteSchemaItems)
 
             EXPECT_NE(testClass->GetSchema().GetKindOfQuantityCP("TestKoQ"), nullptr);
             EXPECT_NE(testClass->GetSchema().GetKindOfQuantityCP("AnotherTestKoQ"), nullptr);
-            
-            EXPECT_NE(schema->GetEnumerationCP("UnstrictEnumInt"), nullptr);
-            EXPECT_NE(schema->GetEnumerationCP("UnstrictEnumString"), nullptr);
-            EXPECT_NE(schema->GetEnumerationCP("StrictEnumInt"), nullptr);
-            EXPECT_NE(schema->GetEnumerationCP("StrictEnumString"), nullptr);
 
             auto firstProp = testClass->GetPropertyP("FirstProp");
             ASSERT_NE(firstProp, nullptr);
@@ -2218,22 +2367,6 @@ TEST_F(IModelCompatibilityTestFixture, MajorSchemaUpgradeDeleteSchemaItems)
             EXPECT_STREQ(anotherKoq->GetFullName().c_str(), "TestSchema:AnotherTestKoQ");
 
             EXPECT_NE(testClass->GetPropertyP("ThirdProp"), nullptr);
-
-            auto enumProp1 = testClass->GetPropertyP("Property1");
-            ASSERT_NE(enumProp1, nullptr);
-            EXPECT_NE(enumProp1->GetTypeFullName(), "int");
-
-            auto enumProp2 = testClass->GetPropertyP("Property2");
-            ASSERT_NE(enumProp2, nullptr);
-            EXPECT_NE(enumProp2->GetTypeFullName(), "string");
-
-            auto enumProp3 = testClass->GetPropertyP("Property3");
-            ASSERT_NE(enumProp3, nullptr);
-            EXPECT_NE(enumProp3->GetTypeFullName(), "int");
-
-            auto enumProp4 = testClass->GetPropertyP("Property4");
-            ASSERT_NE(enumProp4, nullptr);
-            EXPECT_NE(enumProp4->GetTypeFullName(), "string");
 
             EXPECT_NE(schema->GetClassCP("TestClassToDelete"), nullptr);
             EXPECT_NE(schema->GetClassCP("SubClassToDelete"), nullptr);
@@ -2263,11 +2396,6 @@ TEST_F(IModelCompatibilityTestFixture, MajorSchemaUpgradeDeleteSchemaItems)
                                         </ECCustomAttributes>
                                     </ECProperty>
                                     <ECProperty propertyName="SecondProp" typeName="string" kindOfQuantity='AnotherTestKoQ' />
-
-                                    <ECProperty propertyName="Property1" typeName="int" />
-                                    <ECProperty propertyName="Property2" typeName="string" />
-                                    <ECProperty propertyName="Property3" typeName="int" />
-                                    <ECProperty propertyName="Property4" typeName="string" />
                                 </ECEntityClass>
                             </ECSchema>)xml"));
             ASSERT_NE(deserializationCtxUpdate, nullptr) << testDbPtr->GetDescription();
@@ -2283,12 +2411,6 @@ TEST_F(IModelCompatibilityTestFixture, MajorSchemaUpgradeDeleteSchemaItems)
             EXPECT_EQ(testClass->GetSchema().GetKindOfQuantityCP("TestKoQ"), nullptr);
             EXPECT_NE(testClass->GetSchema().GetKindOfQuantityCP("AnotherTestKoQ"), nullptr);
 
-            // All enums should be deleted
-            EXPECT_EQ(schema->GetEnumerationCP("UnstrictEnumInt"), nullptr);
-            EXPECT_EQ(schema->GetEnumerationCP("UnstrictEnumString"), nullptr);
-            EXPECT_EQ(schema->GetEnumerationCP("StrictEnumInt"), nullptr);
-            EXPECT_EQ(schema->GetEnumerationCP("StrictEnumString"), nullptr);
-
             // Property "FirstProp" should exist and no longer have KoQ "TestKoQ"
             firstProp = testClass->GetPropertyP("FirstProp");
             ASSERT_NE(firstProp, nullptr);
@@ -2303,23 +2425,6 @@ TEST_F(IModelCompatibilityTestFixture, MajorSchemaUpgradeDeleteSchemaItems)
 
             // Property "ThirdProp" should be deleted
             EXPECT_EQ(testClass->GetPropertyP("ThirdProp"), nullptr);
-
-            // Properties should not have enum type names
-            enumProp1 = testClass->GetPropertyP("Property1");
-            ASSERT_NE(enumProp1, nullptr);
-            EXPECT_EQ(enumProp1->GetTypeFullName(), "int");
-
-            enumProp2 = testClass->GetPropertyP("Property2");
-            ASSERT_NE(enumProp2, nullptr);
-            EXPECT_EQ(enumProp2->GetTypeFullName(), "string");
-
-            enumProp3 = testClass->GetPropertyP("Property3");
-            ASSERT_NE(enumProp3, nullptr);
-            EXPECT_EQ(enumProp3->GetTypeFullName(), "int");
-
-            enumProp4 = testClass->GetPropertyP("Property4");
-            ASSERT_NE(enumProp4, nullptr);
-            EXPECT_EQ(enumProp4->GetTypeFullName(), "string");
 
             // Classes "TestClassToDelete" and "SubClassToDelete" were deleted
             EXPECT_EQ(schema->GetClassCP("TestClassToDelete"), nullptr);


### PR DESCRIPTION
To delete KoQs, we need to use the Custom Attribute "AllowUnitChange" which is in the schema "SchemaUpgradeCustomAttributes.1.0.0".
The schema "SchemaUpgradeCustomAttributes.1.0.0" is ECXML 3.2 which is not supported by profile version 4.0.0.1, which is what caused the evolution tests to fail for the 4.0.0.1 profile version test files.
I've split out the KoQ deletion into a separate test case which skips over the 4.0.0.1 test files.