### PR TITLE
check that db is not null before checking if it's open in RequireDbIsOpen

### DIFF
--- a/iModelJsNodeAddon/IModelJsNative.cpp
+++ b/iModelJsNodeAddon/IModelJsNative.cpp
@@ -301,7 +301,8 @@ struct SQLiteOps {
     }
 
     void RequireDbIsOpen(NapiInfoCR info) {
-        if (!_GetMyDb()->IsDbOpen())
+        const auto* db = _GetMyDb();
+        if (db == nullptr || _GetMyDb()->IsDbOpen())
             BeNapi::ThrowJsException(info.Env(), "db is not open");
     }
     void RequireDbIsWritable(NapiInfoCR info) {

--- a/iModelJsNodeAddon/IModelJsNative.cpp
+++ b/iModelJsNodeAddon/IModelJsNative.cpp
@@ -302,7 +302,7 @@ struct SQLiteOps {
 
     void RequireDbIsOpen(NapiInfoCR info) {
         const auto* db = _GetMyDb();
-        if (db == nullptr || _GetMyDb()->IsDbOpen())
+        if (db == nullptr || !_GetMyDb()->IsDbOpen())
             BeNapi::ThrowJsException(info.Env(), "db is not open");
     }
     void RequireDbIsWritable(NapiInfoCR info) {

--- a/iModelJsNodeAddon/IModelJsNative.cpp
+++ b/iModelJsNodeAddon/IModelJsNative.cpp
@@ -311,7 +311,8 @@ struct SQLiteOps {
     }
 
     Napi::Value IsOpen(NapiInfoCR info) {
-        return Napi::Boolean::New(info.Env(), _GetMyDb()->IsDbOpen());
+        auto db = _GetMyDb();
+        return Napi::Boolean::New(info.Env(), nullptr != db && db->IsDbOpen());
     }
 
     Napi::Value IsReadonly(NapiInfoCR info) {

--- a/iModelJsNodeAddon/IModelJsNative.cpp
+++ b/iModelJsNodeAddon/IModelJsNative.cpp
@@ -302,7 +302,7 @@ struct SQLiteOps {
 
     void RequireDbIsOpen(NapiInfoCR info) {
         const auto* db = _GetMyDb();
-        if (db == nullptr || !_GetMyDb()->IsDbOpen())
+        if (db == nullptr || !db->IsDbOpen())
             BeNapi::ThrowJsException(info.Env(), "db is not open");
     }
     void RequireDbIsWritable(NapiInfoCR info) {


### PR DESCRIPTION
Was getting a [crash](https://bentley-systems-inc.sentry.io/issues/4660238515/events/b0fc6d3c977441d5b4ce990b5949d72c/?project=1520306) from this in tests of my application. This will now throw a javascript error about an invalid/closed db instead of dereferencing a null pointer.

Since `RequireDbIsOpen` is called by most users of `_GetMyDb` (e.g. `GetOpenedDb`), I expect this to be a sufficient change. We could however also change more code and always check for nullness of the result of `_GetMyDb` before using it. Or consider something else.