### PR TITLE
Remove automatic save changes on closing DgnDb

### DIFF
--- a/iModelJsNodeAddon/IModelJsNative.cpp
+++ b/iModelJsNodeAddon/IModelJsNative.cpp
@@ -1056,9 +1056,6 @@ struct NativeDgnDb : BeObjectWrap<NativeDgnDb>, SQLiteOps
         if (!m_dgndb.IsValid())
             return;
 
-        if (m_dgndb->Txns().HasChanges())
-            m_dgndb->SaveChanges();
-
         DgnDbPtr dgndb = m_dgndb;
         ClearDgnDb();
         dgndb->CloseDb();

--- a/iModelJsNodeAddon/IModelJsNative.cpp
+++ b/iModelJsNodeAddon/IModelJsNative.cpp
@@ -2086,7 +2086,7 @@ struct NativeDgnDb : BeObjectWrap<NativeDgnDb>, SQLiteOps
         return Napi::String::New(info.Env(), xml.c_str());
         }
 
-    void CloseIModel(NapiInfoCR info) { CloseDgnDb(false); }
+    void CloseFile(NapiInfoCR info) { CloseDgnDb(false); }
 
     Napi::Value CreateClassViewsInDb(NapiInfoCR info) {
         RequireDbIsOpen(info);
@@ -2514,7 +2514,7 @@ struct NativeDgnDb : BeObjectWrap<NativeDgnDb>, SQLiteOps
             InstanceMethod("cancelTo", &NativeDgnDb::CancelTo),
             InstanceMethod("classIdToName", &NativeDgnDb::ClassIdToName),
             InstanceMethod("classNameToId", &NativeDgnDb::ClassNameToId),
-            InstanceMethod("closeIModel", &NativeDgnDb::CloseIModel),
+            InstanceMethod("closeFile", &NativeDgnDb::CloseFile),
             InstanceMethod("completeCreateChangeset", &NativeDgnDb::CompleteCreateChangeset),
             InstanceMethod("computeProjectExtents", &NativeDgnDb::ComputeProjectExtents),
             InstanceMethod("concurrentQueryExecute", &NativeDgnDb::ConcurrentQueryExecute),

--- a/iModelJsNodeAddon/api_package/ts/src/NativeLibrary.ts
+++ b/iModelJsNodeAddon/api_package/ts/src/NativeLibrary.ts
@@ -502,7 +502,7 @@ export declare namespace IModelJsNative {
     public cancelTo(txnId: TxnIdString): IModelStatus;
     public classIdToName(idString: string): string;
     public classNameToId(className: string): Id64String;
-    public closeIModel(): void;
+    public closeFile(): void;
     public completeCreateChangeset(arg: { index: number }): void;
     public computeProjectExtents(wantFullExtents: boolean, wantOutlierIds: boolean): { extents: Range3dProps, fullExtents?: Range3dProps, outliers?: Id64Array };
     public concurrentQueryExecute(request: DbRequest, onResponse: ConcurrentQuery.OnResponse): void;

--- a/iModelJsNodeAddon/api_package/ts/src/test/DgnDb.test.ts
+++ b/iModelJsNodeAddon/api_package/ts/src/test/DgnDb.test.ts
@@ -27,7 +27,7 @@ describe("basic tests", () => {
   });
 
   after((done) => {
-    dgndb.closeIModel();
+    dgndb.closeFile();
     done();
   });
 
@@ -90,7 +90,7 @@ describe("basic tests", () => {
     assert.equal(localInfo?.id, sharedInfo?.id);
     assert.equal(localInfo?.dataVer, sharedInfo?.dataVer);
     assert.equal(localInfo?.dataVer, "0x2");
-    iModelDb.closeIModel();
+    iModelDb.closeFile();
 
     // create first briefcase
     const b0Uri = path.join(baseDir, "b0.bim");
@@ -169,9 +169,9 @@ describe("basic tests", () => {
     b0.saveChanges();
     b1.saveChanges();
     b2.saveChanges();
-    b0.closeIModel();
-    b1.closeIModel();
-    b2.closeIModel();
+    b0.closeFile();
+    b1.closeFile();
+    b2.closeFile();
   });
 
   // verify that throwing javascript exceptions from C++ works
@@ -335,7 +335,7 @@ describe("basic tests", () => {
     withWal.enableWalMode();
     withWal.performCheckpoint();
     withWal.setAutoCheckpointThreshold(2000);
-    withWal.closeIModel();
+    withWal.closeFile();
   });
 
   it("testGetSchemaProps", async () => {
@@ -497,11 +497,11 @@ describe("basic tests", () => {
 
     const dbForProfileUpgrade = openDgnDb(testFile, { profile: ProfileOptions.Upgrade, schemaLockHeld: true });
     dbForProfileUpgrade.saveChanges();
-    dbForProfileUpgrade.closeIModel();
+    dbForProfileUpgrade.closeFile();
 
     const dbForSchemaUpgrade = openDgnDb(testFile, { domain: DomainOptions.Upgrade, schemaLockHeld: true });
     dbForSchemaUpgrade.saveChanges();
-    dbForSchemaUpgrade.closeIModel();
+    dbForSchemaUpgrade.closeFile();
   });
 
   it("import schema with schemaLockHeld flag", async () => {
@@ -552,7 +552,7 @@ describe("basic tests", () => {
     rc = db.importXmlSchemas([generateSchema(20, 20)], { schemaLockHeld: true });
     assert.equal(rc, DbResult.BE_SQLITE_OK);
     db.saveChanges();
-    db.closeIModel();
+    db.closeFile();
   });
 
   it("ecsql query", async () => {
@@ -1056,6 +1056,6 @@ describe("basic tests", () => {
     expect(schemaXmlStr!.includes(propStr)).to.be.true;
     expect(schemaXmlStr!.includes(propCatStr)).to.be.true;
 
-    testDb.closeIModel();
+    testDb.closeFile();
   });
 });

--- a/iModelJsNodeAddon/api_package/ts/src/test/ECDb.test.ts
+++ b/iModelJsNodeAddon/api_package/ts/src/test/ECDb.test.ts
@@ -63,7 +63,7 @@ describe("concurrent query tests", () => {
   });
 
   afterEach((done) => {
-    conn.closeIModel();
+    conn.closeFile();
     done();
   });
   it("reset config", async () => {

--- a/iModelJsNodeAddon/api_package/ts/src/test/EmbedFont.test.ts
+++ b/iModelJsNodeAddon/api_package/ts/src/test/EmbedFont.test.ts
@@ -57,6 +57,6 @@ describe("embed fonts", () => {
     if (os.platform() === "win32") // Embedding system fonts is only supported on windows.
       tempDgnDb.embedFont({ systemFont: "times new roman", compress: true });
 
-    tempDgnDb.closeIModel();
+    tempDgnDb.closeFile();
   });
 });

--- a/iModelJsNodeAddon/api_package/ts/src/test/EmbeddedFile.test.ts
+++ b/iModelJsNodeAddon/api_package/ts/src/test/EmbeddedFile.test.ts
@@ -71,7 +71,7 @@ describe("embedded files", () => {
     testEmbed(tempDgnDb);
     expect(tempDgnDb.hasUnsavedChanges()).to.be.false;
     expect(tempDgnDb.hasPendingTxns()).to.be.false;
-    tempDgnDb.closeIModel();
+    tempDgnDb.closeFile();
   });
 
   it("BlobIO", () => {

--- a/iModelJsNodeAddon/api_package/ts/src/test/SqlStatement.test.ts
+++ b/iModelJsNodeAddon/api_package/ts/src/test/SqlStatement.test.ts
@@ -18,7 +18,7 @@ describe("SQLite statements", () => {
   });
 
   after((done) => {
-    dgndb.closeIModel();
+    dgndb.closeFile();
     done();
   });
 

--- a/iModelJsNodeAddon/api_package/ts/src/test/importSchema.test.ts
+++ b/iModelJsNodeAddon/api_package/ts/src/test/importSchema.test.ts
@@ -82,7 +82,7 @@ describe("ImportSchema", () => {
     db.setITwinId(Guid.empty);
     db.resetBriefcaseId(0);
     db.saveChanges();
-    db.closeIModel();
+    db.closeFile();
 
     db.openIModel(dbpath, OpenMode.ReadWrite);
 

--- a/iModelJsNodeAddon/api_package/ts/src/test/importSchema.test.ts
+++ b/iModelJsNodeAddon/api_package/ts/src/test/importSchema.test.ts
@@ -139,5 +139,7 @@ describe("ImportSchema", () => {
     expect("BisCore:InformationRecordElement").eq(fooInfoClassV98.baseClasses[0]);
     expect(fooInfoClassV98.properties).hasOwnProperty("propertyFoo");
     expect(fooInfoClassV98.properties).hasOwnProperty("propertyBar");
+
+    db.saveChanges();
   });
 });


### PR DESCRIPTION
This pull request introduces changes to the iModel closing mechanism. Now, closing an iModel file no longer automatically saves changes. Users must explicitly call the `saveChanges` function before closing the iModel. Additionally, the `closeIModel` API has been renamed to `closeFile` for improved clarity.

itwinjs-core: https://github.com/iTwin/itwinjs-core/pull/6232