### PR TITLE
Ported from imodel02: Need to define CRASHPAD_FLOCK_ALWAYS_SUPPORTED …

### DIFF
--- a/iModelCore/libsrc/crashpad/client_windows.mki
+++ b/iModelCore/libsrc/crashpad/client_windows.mki
@@ -49,6 +49,9 @@ nameToDefine = _UNICODE
 nameToDefine = CRASHPAD_ZLIB_SOURCE_EXTERNAL
 %include cdefapnd.mki
 
+nameToDefine = CRASHPAD_FLOCK_ALWAYS_SUPPORTED
+%include cdefapnd.mki
+
 #----------------------------------------------------------------------------------------------------------------------------------------------------
 %include MultiCppCompileRule.mki
 


### PR DESCRIPTION
…on Windows.