### PR TITLE
Fix JS logging leading to a crash on mobile

### DIFF
--- a/iModelCore/BeSQLite/CloudSqlite.cpp
+++ b/iModelCore/BeSQLite/CloudSqlite.cpp
@@ -87,7 +87,6 @@ void CloudCache::ReadGuid() {
     Db::CreateParams params;
     params.m_failIfDbExists = false;
     params.m_rawSQLite = true;
-    params.m_startDefaultTxn = DefaultTxn::No;
 
     if (BE_SQLITE_OK != localStoreDb.CreateNewDb(guidFile, params))
         return;
@@ -100,7 +99,7 @@ void CloudCache::ReadGuid() {
     stat = stmt.Step();
     BeAssert(stat == BE_SQLITE_DONE);
     stmt.Finalize();
-    localStoreDb.TryExecuteSql("COMMIT");
+    localStoreDb.SaveChanges();
     localStoreDb.CloseDb();
 }
 

--- a/iModelCore/BeSQLite/CloudSqlite.cpp
+++ b/iModelCore/BeSQLite/CloudSqlite.cpp
@@ -71,6 +71,7 @@ void CloudCache::ReadGuid() {
     Db::OpenParams openParams(Db::OpenMode::Readonly, DefaultTxn::No);
     openParams.SetImmutable();
     openParams.m_rawSQLite = true;
+    params.m_startDefaultTxn = DefaultTxn::No;
 
     auto stat = localStoreDb.OpenBeSQLiteDb(guidFile, openParams);
     if (BE_SQLITE_OK == stat) {
@@ -99,7 +100,7 @@ void CloudCache::ReadGuid() {
     stat = stmt.Step();
     BeAssert(stat == BE_SQLITE_DONE);
     stmt.Finalize();
-    localStoreDb.SaveChanges();
+    localStoreDb.TryExecuteSql("COMMIT");
     localStoreDb.CloseDb();
 }
 

--- a/iModelCore/BeSQLite/CloudSqlite.cpp
+++ b/iModelCore/BeSQLite/CloudSqlite.cpp
@@ -71,7 +71,6 @@ void CloudCache::ReadGuid() {
     Db::OpenParams openParams(Db::OpenMode::Readonly, DefaultTxn::No);
     openParams.SetImmutable();
     openParams.m_rawSQLite = true;
-    params.m_startDefaultTxn = DefaultTxn::No;
 
     auto stat = localStoreDb.OpenBeSQLiteDb(guidFile, openParams);
     if (BE_SQLITE_OK == stat) {
@@ -88,6 +87,7 @@ void CloudCache::ReadGuid() {
     Db::CreateParams params;
     params.m_failIfDbExists = false;
     params.m_rawSQLite = true;
+    params.m_startDefaultTxn = DefaultTxn::No;
 
     if (BE_SQLITE_OK != localStoreDb.CreateNewDb(guidFile, params))
         return;

--- a/iModelJsNodeAddon/JsLogger.cpp
+++ b/iModelJsNodeAddon/JsLogger.cpp
@@ -143,10 +143,6 @@ void JsLogger::LogMessage(Utf8CP category, SEVERITY sev, Utf8CP msg) {
 
 bool JsLogger::IsSeverityEnabled(Utf8CP category, SEVERITY sev) {
     BeMutexHolder lock(m_deferredLogMutex);
-    if (canUseJavaScript()) {
-        // Process the deferred log messages every chance we get.
-        processDeferred();
-    }
     return isEnabled(category, sev);
 }
 

--- a/iModelJsNodeAddon/JsLogger.cpp
+++ b/iModelJsNodeAddon/JsLogger.cpp
@@ -102,9 +102,12 @@ void JsLogger::processDeferred() {
         try {
             logToJs(message.m_category.c_str(), message.m_severity, message.m_message.c_str());
         } catch (...) {
-            // Logging to JS did not work (probably due to backend logging being redirected to the
-            // frontend and the backend and frontend not currently being connected). Try again
+            // Logging to JS did not work, so leave m_deferredLogging alone so we can try again
             // later.
+            // logToJs triggers the backend JavaScript logging functionality. That functionality
+            // allows for custom log functions. Those custom log functions may throw an exception,
+            // and if they do so, that exception gets propogated to here. Catch that here so that
+            // we don't throw a C++ exception from this function.
             return;
         }
     }
@@ -128,9 +131,10 @@ void JsLogger::LogMessage(Utf8CP category, SEVERITY sev, Utf8CP msg) {
             return;
         } catch (...) {
             // Push to deferred below, because JS log failed.
-            // On mobile, it seems to fail if called when backend logging is redirected to the
-            // frontend, and the backend and frontend are not connected at the time of the log
-            // message.
+            // logToJs triggers the backend JavaScript logging functionality. That functionality
+            // allows for custom log functions. Those custom log functions may throw an exception,
+            // and if they do so, that exception gets propogated to here. Catch that here so that
+            // we don't throw a C++ exception from this function.
         }
     }
     // save this message in memory so it can be logged later on the JavaScript thread


### PR DESCRIPTION
On mobile devices where backend logging is configured to forward to the frontend, doing a JS log too early in the startup process results in an unhandled exception due to the fact that the frontend and backend are not yet connected. Catch that exception when it happens and store the failed log message in the list of deferred log messages. Also process the list of deferred log messages any time IsSeverityEnabled is called so that you don't have to wait for an enabled severity message to be logged before the deferred ones get processed.