### PR TITLE
don't segfault, return nullptr if `fkView` was null during change iteration

### DIFF
--- a/iModelCore/ECDb/ECDb/ChangeIteratorImpl.cpp
+++ b/iModelCore/ECDb/ECDb/ChangeIteratorImpl.cpp
@@ -598,6 +598,9 @@ DbColumn const* ChangeIterator::TableClassMap::EndTableRelationshipMap::GetForei
         return it->second;
 
     auto fkView = ForeignKeyPartitionView::CreateReadonly(ecdb.Schemas().Main(), relationshipClass);
+    if (fkView == nullptr)
+        return nullptr;
+
     ForeignKeyPartitionView::Partition const* firstPartition = fkView->GetPartitions(true, true).front();
     if (!firstPartition)
         return nullptr;


### PR DESCRIPTION
short term fix for https://github.com/iTwin/itwinjs-backlog/issues/997,

> The crash happened because the change summary attempted to locate classmap for the foreign key relationship but the RelECClassId represents a link table relationship and it returned null.
>
> It should be noted all these invalid relationship seem to be deleted or fixed as they do not appear in tip level imodel.

[full explanation of what happened](https://github.com/iTwin/itwinjs-backlog/issues/997#issuecomment-1845410536)

