### PR TITLE
Optimize schema load performance having CustomAttribute from pruned schemas

### DIFF
--- a/iModelCore/ecobjects/src/ECCustomAttribute.cpp
+++ b/iModelCore/ecobjects/src/ECCustomAttribute.cpp
@@ -459,9 +459,11 @@ CustomAttributeReadStatus IECCustomAttributeContainer::ReadCustomAttributes (pug
                 // In EC3 we will fail to load the schema if any invalid custom attributes are found, for EC2 schemas we will skip the invalid attributes and continue to load the schema
                 if (containerSchema.OriginalECXmlVersionAtLeast(ECVersion::V3_0))
                     {
+                    SchemaKey caSchemaKey;
+                    if (ECObjectsStatus::Success != SchemaKey::ParseSchemaFullName(caSchemaKey, ns.c_str()))
+                        return CustomAttributeReadStatus::InvalidCustomAttributes;
                     // In EC3, skip the custom attribute if it belongs to a pruned schema
-                    Utf8String caClassName = ns.substr(0, ns.find('.'));
-                    if (schemaContext.GetSchemasToPrune().end() != std::find(schemaContext.GetSchemasToPrune().begin(), schemaContext.GetSchemasToPrune().end(), caClassName.c_str()))
+                    if (schemaContext.GetSchemasToPrune().end() != std::find(schemaContext.GetSchemasToPrune().begin(), schemaContext.GetSchemasToPrune().end(), caSchemaKey.GetName().c_str()))
                         status = CustomAttributeReadStatus::SkippedCustomAttributes;
                     else
                         status = CustomAttributeReadStatus::InvalidCustomAttributes;

--- a/iModelCore/ecobjects/src/ECCustomAttribute.cpp
+++ b/iModelCore/ecobjects/src/ECCustomAttribute.cpp
@@ -458,7 +458,14 @@ CustomAttributeReadStatus IECCustomAttributeContainer::ReadCustomAttributes (pug
                 {
                 // In EC3 we will fail to load the schema if any invalid custom attributes are found, for EC2 schemas we will skip the invalid attributes and continue to load the schema
                 if (containerSchema.OriginalECXmlVersionAtLeast(ECVersion::V3_0))
-                    status = CustomAttributeReadStatus::InvalidCustomAttributes;
+                    {
+                    // In EC3, skip the custom attribute if it belongs to a pruned schema
+                    Utf8String caClassName = ns.substr(0, ns.find('.'));
+                    if (schemaContext.GetSchemasToPrune().end() != std::find(schemaContext.GetSchemasToPrune().begin(), schemaContext.GetSchemasToPrune().end(), caClassName.c_str()))
+                        status = CustomAttributeReadStatus::SkippedCustomAttributes;
+                    else
+                        status = CustomAttributeReadStatus::InvalidCustomAttributes;
+                    }
                 else if (CustomAttributeReadStatus::Success == status)
                     status = CustomAttributeReadStatus::SkippedCustomAttributes;
                 }

--- a/iModelCore/ecobjects/src/ECcontext.cpp
+++ b/iModelCore/ecobjects/src/ECcontext.cpp
@@ -401,7 +401,7 @@ public:
 
         if (m_schemaContext.GetSchemasToPrune().end() != std::find(m_schemaContext.GetSchemasToPrune().begin(), m_schemaContext.GetSchemasToPrune().end(), key.GetName()))
             {
-            LOG.errorv("CustomAttributeInstanceReadContext - Custom attribute schema %s is one of the schemas that are to be pruned. Skipping fallback mechanism.", key.GetFullSchemaName().c_str());
+            LOG.warningv("CustomAttributeInstanceReadContext - Custom attribute schema %s is one of the schemas that are to be pruned. Skipping fallback mechanism.", key.GetFullSchemaName().c_str());
             return nullptr;
             }
 

--- a/iModelCore/ecobjects/src/ECcontext.cpp
+++ b/iModelCore/ecobjects/src/ECcontext.cpp
@@ -399,6 +399,12 @@ public:
         if (it != references.end())
             return it->second.get();
 
+        if (m_schemaContext.GetSchemasToPrune().end() != std::find(m_schemaContext.GetSchemasToPrune().begin(), m_schemaContext.GetSchemasToPrune().end(), key.GetName()))
+            {
+            LOG.errorv("CustomAttributeInstanceReadContext - Custom attribute schema %s is one of the schemas that are to be pruned. Skipping fallback mechanism.", key.GetFullSchemaName().c_str());
+            return nullptr;
+            }
+
         LOG.errorv("CustomAttributeInstanceReadContext - Custom attribute schema %s not found in referenced schemas of %s. Trying fallback mechanism.", key.GetFullSchemaName().c_str(), m_containerSchema.GetFullSchemaName().c_str());
 
         SchemaKey nonConstKey(key);

--- a/iModelCore/ecobjects/src/ECcontext.cpp
+++ b/iModelCore/ecobjects/src/ECcontext.cpp
@@ -401,7 +401,7 @@ public:
 
         if (m_schemaContext.GetSchemasToPrune().end() != std::find(m_schemaContext.GetSchemasToPrune().begin(), m_schemaContext.GetSchemasToPrune().end(), key.GetName()))
             {
-            LOG.warningv("CustomAttributeInstanceReadContext - Custom attribute schema %s is one of the schemas that are to be pruned. Skipping fallback mechanism.", key.GetFullSchemaName().c_str());
+            LOG.infov("Skipping loading of the custom attribute because its schema %s is being pruned.", key.GetFullSchemaName().c_str());
             return nullptr;
             }
 

--- a/iModelCore/ecobjects/test/NonPublished/SchemaDeserializationTests.cpp
+++ b/iModelCore/ecobjects/test/NonPublished/SchemaDeserializationTests.cpp
@@ -1607,6 +1607,46 @@ TEST_F(SchemaDeserializationTest, PruneSchemas)
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //---------------+---------------+---------------+---------------+---------------+-------
+TEST_F(SchemaDeserializationTest, PruneCAFromPrunedEC32Schemas)
+    {
+    ECSchemaReadContextPtr context = ECSchemaReadContext::CreateContext();
+    context->GetSchemasToPrune() = bvector<Utf8String>{"RefSchema"};
+    context->SetResolveConflicts(true);
+
+    Utf8CP refSchemaXml = R"xml(<?xml version="1.0" encoding="UTF-8"?>
+            <ECSchema schemaName="RefSchema" alias="rs" version="01.00.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+                <ECCustomAttributeClass typeName="TestCustomAttr">
+                </ECCustomAttributeClass>
+            </ECSchema>)xml";
+
+    Utf8CP schemaXml = R"xml(<?xml version="1.0" encoding="UTF-8"?>
+            <ECSchema schemaName="Test" alias="ts" version="01.00.01" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+                <ECSchemaReference name="RefSchema" version="01.00.00" alias="rs" />
+                <ECCustomAttributes>
+                    <TestCustomAttr xmlns="RefSchema.01.00.00" />
+                </ECCustomAttributes>
+            </ECSchema>)xml";
+
+    StringSchemaLocater locater;
+    locater.AddSchemaString(SchemaKey("RefSchema", 1, 0, 0), refSchemaXml);
+    locater.AddSchemaString(SchemaKey("Test", 1, 0, 1), schemaXml);
+    context->AddSchemaLocater(locater);
+
+    SchemaKey refSchemaKey("RefSchema", 1, 0, 0);
+    ECSchemaPtr refSchema = context->LocateSchema(refSchemaKey, SchemaMatchType::Latest);
+    ASSERT_TRUE(refSchema.IsValid());
+
+    SchemaKey testKey("Test", 1, 0, 1);
+    ECSchemaPtr schema = context->LocateSchema(testKey, SchemaMatchType::Latest);
+    ASSERT_TRUE(schema.IsValid());
+
+    EXPECT_FALSE(schema->GetCustomAttributeContainer().GetCustomAttribute("RefSchema", "TestCustomAttr").IsValid())
+        << "custom attribute applied to referencing RefSchema should be pruned";
+    }
+
+//---------------------------------------------------------------------------------------
+// @bsimethod
+//---------------+---------------+---------------+---------------+---------------+-------
 TEST_F(SchemaDeserializationTest, AliasesForPruneSchemasAreResetForEachSchema)
     {
     ECSchemaReadContextPtr context = ECSchemaReadContext::CreateContext();

--- a/iModelCore/ecobjects/test/Performance/PerformanceSchemaDeserializationTests.cpp
+++ b/iModelCore/ecobjects/test/Performance/PerformanceSchemaDeserializationTests.cpp
@@ -70,14 +70,16 @@ Utf8String GenerateMainSchema(size_t numberOfCAClasses)
     for (size_t i = 0; i < numberOfCAClasses; i++) 
         {
         Utf8PrintfString caClassName("CustomAttrClass%zu", i);
-        innerXml = innerXml + "<ECCustomAttributes>\n" + "<" + caClassName + " xmlns=\"" + refSchemaName + ".01.01.01\" />\n" + "</ECCustomAttributes>\n";
+        innerXml = innerXml + "<" + caClassName + " xmlns=\"" + refSchemaName + ".01.01.01\" />\n";
         }
     
     Utf8PrintfString schemaXml = Utf8PrintfString(
         R"xml(<?xml version="1.0" encoding="UTF-8"?>
             <ECSchema schemaName="%s" description="%s" alias="ts" version="01.01.01" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
                 <ECSchemaReference name="%s" version="01.01.01" alias="RefS" />
-            %s
+                <ECCustomAttributes>
+                    %s
+                </ECCustomAttributes>
             </ECSchema>
         )xml", schemaName.c_str(), description.c_str(), refSchemaName.c_str(), innerXml.c_str());
 

--- a/iModelCore/ecobjects/test/Performance/PerformanceSchemaDeserializationTests.cpp
+++ b/iModelCore/ecobjects/test/Performance/PerformanceSchemaDeserializationTests.cpp
@@ -1,0 +1,102 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the repository root for full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+#include "../ECObjectsTestPCH.h"
+#include "PerformanceTestFixture.h"
+
+#include <Bentley/BeTimeUtilities.h>
+
+USING_NAMESPACE_BENTLEY_EC
+
+BEGIN_BENTLEY_ECN_TEST_NAMESPACE
+
+struct ECSchemaDeserializationTests : PerformanceTestFixture
+{
+
+void DeserializeSchema(size_t numberOfCAClasses)
+    {
+    Utf8PrintfString refSchemaName("RefSchema_%zuCA", numberOfCAClasses);
+    ECSchemaReadContextPtr context = ECSchemaReadContext::CreateContext();
+    context->GetSchemasToPrune() = bvector<Utf8String>{refSchemaName};
+    context->SetResolveConflicts(true);
+
+    ECSchemaPtr refSchema;
+    Utf8String refSchemaXml = GenerateRefSchema(numberOfCAClasses);
+    StopWatch refSchemaTimer("Deserialization", true);
+    ASSERT_EQ(SchemaReadStatus::Success, ECSchema::ReadFromXmlString(refSchema, refSchemaXml.c_str(), *context));
+    refSchemaTimer.Stop();
+    ASSERT_TRUE(refSchema.IsValid());
+    PERFORMANCELOG.infov("Time to load the reference Schema with %zu custom attribute classes: %.17g", numberOfCAClasses, refSchemaTimer.GetElapsedSeconds());
+    LOGPERFDB(TEST_FIXTURE_NAME, refSchema->GetDescription().c_str(), refSchemaTimer.GetElapsedSeconds(), Utf8PrintfString("Loading ref schema having %zu custom attributes", numberOfCAClasses).c_str());
+
+    ECSchemaPtr schema;
+    Utf8String schemaXml = GenerateMainSchema(numberOfCAClasses);
+    StopWatch schemaTimer("Deserialization", true);
+    ASSERT_EQ(SchemaReadStatus::Success, ECSchema::ReadFromXmlString(schema, schemaXml.c_str(), *context));
+    schemaTimer.Stop();
+    ASSERT_TRUE(schema.IsValid());
+    PERFORMANCELOG.infov("Time to load the Schema with %zu custom attribute classes: %.17g; However CA schema is in pruned achemas list", numberOfCAClasses, schemaTimer.GetElapsedSeconds());
+    LOGPERFDB(TEST_FIXTURE_NAME, schema->GetDescription().c_str(), schemaTimer.GetElapsedSeconds(), Utf8PrintfString("Loading schema having %zu custom attributes from pruned schema", numberOfCAClasses).c_str());
+    }
+
+Utf8String GenerateRefSchema(size_t numberOfCAClasses)
+    {
+    Utf8PrintfString schemaName("RefSchema_%zuCA", numberOfCAClasses);
+    Utf8PrintfString description("Ref schema with %zu Custom Attribute Classes", numberOfCAClasses);
+    Utf8String innerXml = "";
+    for (size_t i = 0; i < numberOfCAClasses; i++) 
+        {
+        Utf8PrintfString caClassName("CustomAttrClass%zu", i);
+        innerXml += "<ECCustomAttributeClass typeName=\"" + caClassName + "\" />\n";
+        }
+    
+    Utf8PrintfString schemaXml = Utf8PrintfString(
+        R"xml(<?xml version="1.0" encoding="UTF-8"?>
+            <ECSchema schemaName="%s" description="%s" alias="RefS" version="01.01.01" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+            %s
+            </ECSchema>
+        )xml", schemaName.c_str(), description.c_str(), innerXml.c_str());
+
+    return schemaXml;
+    }
+
+Utf8String GenerateMainSchema(size_t numberOfCAClasses)
+    {
+    Utf8PrintfString schemaName("TestSchema_%zuCA", numberOfCAClasses);
+    Utf8PrintfString refSchemaName("RefSchema_%zuCA", numberOfCAClasses);
+    Utf8PrintfString description("Test schema with %zu Custom Attribute Classes", numberOfCAClasses);
+    Utf8String innerXml = "";
+    for (size_t i = 0; i < numberOfCAClasses; i++) 
+        {
+        Utf8PrintfString caClassName("CustomAttrClass%zu", i);
+        innerXml = innerXml + "<ECCustomAttributes>\n" + "<" + caClassName + " xmlns=\"" + refSchemaName + ".01.01.01\" />\n" + "</ECCustomAttributes>\n";
+        }
+    
+    Utf8PrintfString schemaXml = Utf8PrintfString(
+        R"xml(<?xml version="1.0" encoding="UTF-8"?>
+            <ECSchema schemaName="%s" description="%s" alias="ts" version="01.01.01" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+                <ECSchemaReference name="%s" version="01.01.01" alias="RefS" />
+            %s
+            </ECSchema>
+        )xml", schemaName.c_str(), description.c_str(), refSchemaName.c_str(), innerXml.c_str());
+
+    return schemaXml;
+    }
+};
+
+/*---------------------------------------------------------------------------------**//**
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+TEST_F(ECSchemaDeserializationTests, DeserializeHavingCAFromPrunedSchema)
+    {
+    DeserializeSchema(1 /*=numberOfCAClasses*/);
+    DeserializeSchema(10 /*=numberOfCAClasses*/);
+    DeserializeSchema(100 /*=numberOfCAClasses*/);
+    DeserializeSchema(1000 /*=numberOfCAClasses*/);
+    DeserializeSchema(5000 /*=numberOfCAClasses*/);
+    DeserializeSchema(8000 /*=numberOfCAClasses*/);
+    DeserializeSchema(10000 /*=numberOfCAClasses*/);
+    }
+
+END_BENTLEY_ECN_TEST_NAMESPACE


### PR DESCRIPTION
This pull request addresses a performance bottleneck in schema loading. The code now checks if a schema, defining custom attributes, is in the pruned schemas list before attempting to locate them.