### PR TITLE
Allow data transform in legacy v8 imports

### DIFF
--- a/iModelCore/ECDb/ECDb/RemapManager.cpp
+++ b/iModelCore/ECDb/ECDb/RemapManager.cpp
@@ -871,7 +871,7 @@ BentleyStatus RemapManager::UpdateRemappedData(std::vector<RemappedColumnInfo*>&
         if (remapInfo->m_isSameTableName)
             {
                 {
-                const Utf8String desc = SqlPrintfString("update remapped property columns (circular) for %s",remapInfo->ToString().c_str()).GetUtf8CP();
+                const Utf8String desc = SqlPrintfString("Moving remapped data to new column for %s",remapInfo->ToString().c_str()).GetUtf8CP();
                 const Utf8String sql = SqlPrintfString("UPDATE [%s] SET [%s]=[%s] WHERE([ECClassId]=%s)",
                                                        remapInfo->m_newTableName.c_str(),
                                                        remapInfo->m_newColumnName.c_str(),
@@ -882,7 +882,7 @@ BentleyStatus RemapManager::UpdateRemappedData(std::vector<RemappedColumnInfo*>&
                 }
 
                 {
-                const Utf8String desc = SqlPrintfString("update remapped property columns (circular) for %s",remapInfo->ToString().c_str()).GetUtf8CP();
+                const Utf8String desc = SqlPrintfString("Cleaning up old column after remap for %s",remapInfo->ToString().c_str()).GetUtf8CP();
                 const Utf8String sql = SqlPrintfString("UPDATE [%s] SET [%s]=NULL WHERE([ECClassId]=%s)",
                                                        remapInfo->m_newTableName.c_str(),
                                                        remapInfo->m_cleanedMapping.m_columnName.c_str(),
@@ -979,7 +979,7 @@ BentleyStatus RemapManager::UpdateRemappedCircularData(std::vector<std::vector<R
             }
         SqlPrintfString classIdPart(" WHERE([ECClassId]=%s)", first->m_cleanedMapping.m_classId.ToHexStr().c_str());
         updateStmt.append(classIdPart.GetUtf8CP());
-        const Utf8String desc = SqlPrintfString("update remapped property columns (circular) for %s",first->ToString().c_str()).GetUtf8CP();
+        const Utf8String desc = SqlPrintfString("Moving remapped data between columns (circular) for %s",first->ToString().c_str()).GetUtf8CP();
         ctx.GetDataTransform().Append(desc, updateStmt);
         }
 

--- a/iModelCore/iModelPlatform/DgnCore/DgnDbSchema.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/DgnDbSchema.cpp
@@ -667,7 +667,10 @@ SchemaStatus DgnDb::ImportV8LegacySchemas(bvector<ECSchemaCP> const& schemas, si
     if (schemasToImport.empty())
         return SchemaStatus::Success;
 
-    SchemaManager::SchemaImportOptions options = SchemaManager::SchemaImportOptions::DoNotFailSchemaValidationForLegacyIssues | SchemaManager::SchemaImportOptions::DoNotFailForDeletionsOrModifications;
+    SchemaManager::SchemaImportOptions options = SchemaManager::SchemaImportOptions::DoNotFailSchemaValidationForLegacyIssues
+        | SchemaManager::SchemaImportOptions::DoNotFailForDeletionsOrModifications
+        | SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade;
+
     return Domains().DoImportSchemas(schemasToImport, options);
     }
 

--- a/iModelCore/iModelPlatform/Tests/DgnProject/NonPublished/SchemaRemap_Test.cpp
+++ b/iModelCore/iModelPlatform/Tests/DgnProject/NonPublished/SchemaRemap_Test.cpp
@@ -1,0 +1,103 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See COPYRIGHT.md in the repository root for full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+#include "../TestFixture/DgnDbTestFixtures.h"
+
+USING_NAMESPACE_BENTLEY_EC
+
+struct SchemaRemapTest : DgnDbTestFixture
+    {
+    };
+
+//---------------------------------------------------------------------------------------
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+------
+TEST_F(SchemaRemapTest, SchemaRemapChangeClassHierarchyWithV8LegacyImport)
+    {
+    SetupSeedProject();
+    ECN::ECSchemaReadContextPtr context = ECN::ECSchemaReadContext::CreateContext();
+    context->AddSchemaLocater(m_db->GetSchemaLocater());
+
+    ECSchemaPtr schema;
+    ASSERT_EQ(SchemaReadStatus::Success, ECSchema::ReadFromXmlString(schema, R"schema(<?xml version='1.0' encoding='utf-8' ?>
+      <ECSchema schemaName="TestSchema" alias="ts" version="01.00.00" displayLabel="TestSchema" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+        <ECSchemaReference name="BisCore" version="01.00.16" alias="bis"/>
+        <ECEntityClass typeName="A">
+          <BaseClass>bis:PhysicalElement</BaseClass>
+          <ECProperty propertyName="PropA" typeName="string" />
+        </ECEntityClass>
+        <ECEntityClass typeName="C">
+          <BaseClass>A</BaseClass>
+          <ECProperty propertyName="PropC" typeName="string" />
+        </ECEntityClass>
+      </ECSchema>)schema", *context));
+    ASSERT_EQ(SchemaStatus::Success, m_db->ImportV8LegacySchemas({ schema.get() }));
+
+    ECSchemaPtr schemaRemapped;
+    ASSERT_EQ(SchemaReadStatus::Success, ECSchema::ReadFromXmlString(schemaRemapped, R"schema(<?xml version='1.0' encoding='utf-8' ?>
+      <ECSchema schemaName="TestSchema" alias="ts" version="01.01.00" displayLabel="TestSchema" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+        <ECSchemaReference name="BisCore" version="01.00.16" alias="bis"/>
+        <ECEntityClass typeName="A">
+          <BaseClass>bis:PhysicalElement</BaseClass>
+          <ECProperty propertyName="PropA" typeName="string" />
+        </ECEntityClass>
+        <ECEntityClass typeName="B">
+          <BaseClass>A</BaseClass>
+          <ECProperty propertyName="PropB" typeName="string" />
+        </ECEntityClass>
+        <ECEntityClass typeName="C">
+          <BaseClass>B</BaseClass>
+          <ECProperty propertyName="PropC" typeName="string" />
+        </ECEntityClass>
+      </ECSchema>)schema", *context));
+    ASSERT_EQ(SchemaStatus::Success, m_db->ImportV8LegacySchemas({ schemaRemapped.get() }));
+    }
+
+//---------------------------------------------------------------------------------------
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+------
+TEST_F(SchemaRemapTest, SchemaRemapMovePropertyWithV8LegacyImport)
+    {
+    SetupSeedProject();
+    ECN::ECSchemaReadContextPtr context = ECN::ECSchemaReadContext::CreateContext();
+    context->AddSchemaLocater(m_db->GetSchemaLocater());
+
+    const auto schemaXml = R"schema(<?xml version='1.0' encoding='utf-8' ?>
+      <ECSchema schemaName="TestSchema" alias="ts" version="01.00.%d" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+        <ECSchemaReference name="BisCore" version="01.00.16" alias="bis"/>
+        <ECEntityClass typeName="TestClass">
+          <BaseClass>bis:PhysicalElement</BaseClass>
+          %s
+        </ECEntityClass>
+        <ECEntityClass typeName="A">
+          <BaseClass>TestClass</BaseClass>
+          <ECProperty propertyName="MovingProperty" typeName="string" />
+        </ECEntityClass>
+        <ECEntityClass typeName="B">
+          <BaseClass>TestClass</BaseClass>
+          <ECProperty propertyName="PropC1" typeName="string" />
+        </ECEntityClass>
+      </ECSchema>)schema";
+
+    ECSchemaPtr schema;
+    ASSERT_EQ(SchemaReadStatus::Success, ECSchema::ReadFromXmlString(schema, Utf8PrintfString(schemaXml, 0, "").c_str(), *context));
+    ASSERT_EQ(SchemaStatus::Success, m_db->ImportV8LegacySchemas({ schema.get() }));
+
+    const auto testSchema = m_db->Schemas().GetSchema("TestSchema");
+    ASSERT_TRUE(testSchema);
+    const auto testClass = testSchema->GetClassCP("TestClass");
+    ASSERT_TRUE(testClass);
+    ASSERT_FALSE(testClass->GetPropertyP("MovingProperty", false));
+
+    ECSchemaPtr schemaRemapped;
+    ASSERT_EQ(SchemaReadStatus::Success, ECSchema::ReadFromXmlString(schemaRemapped, Utf8PrintfString(schemaXml, 1, R"xml(<ECProperty propertyName="MovingProperty" typeName="string"/>)xml").c_str(), *context));
+    ASSERT_EQ(SchemaStatus::Success, m_db->ImportV8LegacySchemas({ schemaRemapped.get() }));
+
+    const auto remappedSchema = m_db->Schemas().GetSchema("TestSchema");
+    ASSERT_TRUE(remappedSchema);
+    const auto testClassUpdated = remappedSchema->GetClassCP("TestClass");
+    ASSERT_TRUE(testClassUpdated);
+    ASSERT_TRUE(testClassUpdated->GetPropertyP("MovingProperty", false));
+    }


### PR DESCRIPTION
Fixes https://github.com/iTwin/itwinjs-backlog/issues/1007.
Added AllowDataTransformDuringSchemaUpgrade schema import option to the legacy v8 import logic.