### PR TITLE
Presentation: Fix merging null content values

### DIFF
--- a/iModelCore/ECPresentation/Source/Content/ContentItemBuilder.cpp
+++ b/iModelCore/ECPresentation/Source/Content/ContentItemBuilder.cpp
@@ -222,6 +222,14 @@ ECClassCP ContentItemBuilder::GetRecordClass() const
 /*---------------------------------------------------------------------------------**//**
 // @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/
+void ContentItemBuilder::OnFieldHandled(Utf8CP name)
+    {
+    if (m_handledFields.end() == m_handledFields.find(name))    
+        m_handledFields.Insert(name, { false });
+    }
+/*---------------------------------------------------------------------------------**//**
+// @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
 void ContentItemBuilder::_AddValue(Utf8CP name, rapidjson::Value&& value, rapidjson::Value&& displayValue, ECPropertyCP)
     {
     m_values.second->AddMember(rapidjson::Value(name, m_values.second->GetAllocator()), value, m_values.second->GetAllocator());
@@ -236,6 +244,7 @@ void ContentItemBuilder::AddNull(Utf8CP name, ECPropertyCP prop)
         return;
 
     _AddValue(name, rapidjson::Value(), rapidjson::Value(), prop);
+    OnFieldHandled(name);
     }
 /*---------------------------------------------------------------------------------**//**
 // @bsimethod
@@ -247,6 +256,7 @@ void ContentItemBuilder::AddValue(Utf8CP name, Utf8CP rawAndDisplayValue, ECProp
 
     if (rawAndDisplayValue)
         _AddValue(name, rapidjson::Value(rawAndDisplayValue, m_values.second->GetAllocator()), rapidjson::Value(rawAndDisplayValue, m_displayValues.second->GetAllocator()), prop);
+    OnFieldHandled(name);
     }
 /*---------------------------------------------------------------------------------**//**
 // @bsimethod
@@ -258,9 +268,10 @@ void ContentItemBuilder::AddValue(Utf8CP name, ECPropertyCR ecProperty, IECSqlVa
 
     if (value.IsNull())
         {
-        // only add nulls for structs and arrays (need that later for checking if they were loaded)
+        // only add nulls for structs and arrays (need them in resulting ContentItem for ContentProvider to know if they were loaded)
         if (ecProperty.GetIsStruct() || ecProperty.GetIsArray())
             AddNull(name, &ecProperty);
+        OnFieldHandled(name);
         return;
         }
 
@@ -299,6 +310,7 @@ void ContentItemBuilder::AddValue(Utf8CP name, ECPropertyCR ecProperty, IECSqlVa
                 &ecProperty);
             }
         }
+    OnFieldHandled(name);
     }
 /*---------------------------------------------------------------------------------**//**
 // @bsimethod
@@ -307,7 +319,10 @@ void ContentItemBuilder::_AddEmptyNestedContentValue(Utf8CP name)
     {
     auto iter = m_nestedContentValues.find(name);
     if (m_nestedContentValues.end() == iter)
+        {
         m_nestedContentValues.insert(std::make_pair(name, NestedContentValues()));
+        OnFieldHandled(name);
+        }
     }
 /*---------------------------------------------------------------------------------**//**
 // @bsimethod
@@ -316,7 +331,10 @@ ContentItemBuilder& ContentItemBuilder::_AddNestedContentValue(Utf8CP name, ECIn
     {
     auto iter = m_nestedContentValues.find(name);
     if (m_nestedContentValues.end() == iter)
+        {
         iter = m_nestedContentValues.insert(std::make_pair(name, NestedContentValues())).first;
+        OnFieldHandled(name);
+        }
     iter->second.values.push_back(_CreateNestedContentItemBuilder());
     iter->second.values.back()->SetPrimaryKey(key);
     iter->second.values.back()->GetExtendedData().MergeWith(GetExtendedData());
@@ -370,7 +388,7 @@ ContentSetItemPtr ContentItemBuilder::BuildItem()
     bmap<Utf8String, bvector<ContentSetItemPtr>> nestedContentItems;
     for (auto const& entry : m_nestedContentValues)
         {
-        if (GetMergedFieldNames().end() != GetMergedFieldNames().find(entry.first))
+        if (GetHandledFields()[entry.first].isMerged)
             {
             GetValues().AddMember(rapidjson::Value(entry.first.c_str(), GetValues().GetAllocator()), rapidjson::Value(), GetValues().GetAllocator());
             GetDisplayValues().AddMember(rapidjson::Value(entry.first.c_str(), GetDisplayValues().GetAllocator()), rapidjson::Value(s_variesStr.c_str(), GetDisplayValues().GetAllocator()), GetDisplayValues().GetAllocator());
@@ -386,8 +404,15 @@ ContentSetItemPtr ContentItemBuilder::BuildItem()
         label = s_emptyLabel.get();
         }
 
+    bvector<Utf8String> mergedFieldNames;
+    for (auto const& f : m_handledFields)
+        {
+        if (f.second.isMerged)
+            mergedFieldNames.push_back(f.first);
+        }
+
     auto item = ContentSetItem::Create(inputKeys, primaryKeys, *label, m_imageId, nestedContentItems,
-        std::move(m_values), std::move(m_displayValues), ContainerHelpers::TransformContainer<bvector<Utf8String>>(m_mergedFieldNames),
+        std::move(m_values), std::move(m_displayValues), mergedFieldNames,
         ContentSetItem::FieldPropertyInstanceKeyMap()); // wip_field_instance_keys
     item->SetClass(GetRecordClass());
     ContentSetItemExtendedData(*item).MergeWith(m_extendedData);
@@ -482,7 +507,8 @@ void MergingContentItemBuilder::_SetRelatedInstanceKeys(bvector<ContentSetItemEx
 +---------------+---------------+---------------+---------------+---------------+------*/
 ContentItemBuilder::BeforeAddValueStatus MergingContentItemBuilder::_OnBeforeAddValue(Utf8CP name)
     {
-    if (GetMergedFieldNames().end() != GetMergedFieldNames().find(name))
+    auto fieldIter = GetHandledFields().find(name);
+    if (fieldIter != GetHandledFields().end() && fieldIter->second.isMerged)
         return BeforeAddValueStatus::Skip;
     return BeforeAddValueStatus::Continue;
     }
@@ -491,17 +517,17 @@ ContentItemBuilder::BeforeAddValueStatus MergingContentItemBuilder::_OnBeforeAdd
 +---------------+---------------+---------------+---------------+---------------+------*/
 void MergingContentItemBuilder::_AddValue(Utf8CP name, rapidjson::Value&& value, rapidjson::Value&& displayValue, ECPropertyCP prop)
     {
-    if (!GetValues().HasMember(name))
+    auto fieldIter = GetHandledFields().find(name);
+    if (fieldIter == GetHandledFields().end())
         {
         ContentItemBuilder::_AddValue(name, std::move(value), std::move(displayValue), prop);
+        OnFieldHandled(name);
         return;
         }
 
-    if (!GetValues().HasMember(name) || !GetDisplayValues().HasMember(name))
-        DIAGNOSTICS_HANDLE_FAILURE(DiagnosticsCategory::Content, Utf8PrintfString("Attempting to merge value, but target is not set. Property name: '%s'", name));
-
-    RapidJsonValueR existingValue = GetValues()[name];
-    RapidJsonValueR existingDisplayValue = GetDisplayValues()[name];
+    static rapidjson::Value const s_nullValue;
+    RapidJsonValueCR existingValue = GetValues().HasMember(name) ? GetValues()[name] : s_nullValue;
+    RapidJsonValueCR existingDisplayValue = GetDisplayValues().HasMember(name) ? GetDisplayValues()[name] : s_nullValue;
 
     if (prop && prop->GetIsNavigation())
         {
@@ -515,19 +541,27 @@ void MergingContentItemBuilder::_AddValue(Utf8CP name, rapidjson::Value&& value,
         return;
         }
 
-    existingValue.SetNull();
+    // at this point we know the values are different... persist that
     static Utf8PrintfString const s_variesStr(CONTENTRECORD_MERGED_VALUE_FORMAT, CommonStrings::LABEL_VARIES);
-    existingDisplayValue.SetString(s_variesStr.c_str(), GetDisplayValues().GetAllocator());
-    GetMergedFieldNames().insert(name);
+    if (GetValues().HasMember(name))
+        GetValues()[name].SetNull();
+    else
+        GetValues().AddMember(rapidjson::Value(name, GetValues().GetAllocator()), rapidjson::Value(), GetValues().GetAllocator());
+    if (GetDisplayValues().HasMember(name))
+        GetDisplayValues()[name].SetString(s_variesStr.c_str(), GetDisplayValues().GetAllocator());
+    else
+        GetDisplayValues().AddMember(rapidjson::Value(name, GetDisplayValues().GetAllocator()), rapidjson::Value(s_variesStr.c_str(), GetDisplayValues().GetAllocator()), GetDisplayValues().GetAllocator());
+    fieldIter->second.isMerged = true;
     }
 /*---------------------------------------------------------------------------------**//**
+// Note: this method assumes the given field is already in handled fields map.
 // @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/
 void MergingContentItemBuilder::SetNestedContentValuesAsMerged(Utf8CP name, NestedContentValues& values)
     {
     values.values.clear();
     values.capturedCount = (size_t)0;
-    GetMergedFieldNames().insert(name);
+    GetHandledFields()[name].isMerged = true;
     }
 /*---------------------------------------------------------------------------------**//**
 // @bsimethod
@@ -600,7 +634,7 @@ void MergingContentItemBuilder::_CaptureNestedContentValueCounts()
     {
     for (auto& entry : GetNestedContentValues())
         {
-        if (GetMergedFieldNames().end() != GetMergedFieldNames().find(entry.first))
+        if (GetHandledFields()[entry.first].isMerged)
             {
             // nothing to do it the value is already set as merged
             DIAGNOSTICS_ASSERT_SOFT(DiagnosticsCategory::Content, entry.second.values.empty(), Utf8PrintfString("Field is merged, but still has values. Field name: '%s'", entry.first.c_str()));

--- a/iModelCore/ECPresentation/Source/Content/ContentItemBuilder.h
+++ b/iModelCore/ECPresentation/Source/Content/ContentItemBuilder.h
@@ -207,6 +207,8 @@ private:
     ContentValueHelpers() {}
 public:
     static NavigationPropertyValue ParseNavigationPropertyValue(IECSqlValue const& value, SchemaManagerCR schemas);
+    static void SetRapidJsonValue(RapidJsonValueR targetObject, Utf8CP memberName, rapidjson::Value&& value, rapidjson::Document::AllocatorType&);
+    static void SetRapidJsonValue(RapidJsonValueR targetObject, Utf8CP memberName, rapidjson::Value const& value, rapidjson::Document::AllocatorType&);
 };
 
 END_BENTLEY_ECPRESENTATION_NAMESPACE

--- a/iModelCore/ECPresentation/Source/Content/ContentItemBuilder.h
+++ b/iModelCore/ECPresentation/Source/Content/ContentItemBuilder.h
@@ -67,6 +67,11 @@ struct ContentItemBuilder
         bset<ECInstanceKey> readInstanceKeys;
         };
 
+    struct HandledFieldAttributes
+        {
+        bool isMerged = false;
+        };
+
 private:
     std::shared_ptr<Context> m_context;
     SchemaManagerCR m_schemaManager;
@@ -78,7 +83,7 @@ private:
     std::pair<std::unique_ptr<rapidjson::Document::AllocatorType>, std::unique_ptr<rapidjson::Document>> m_values;
     std::pair<std::unique_ptr<rapidjson::Document::AllocatorType>, std::unique_ptr<rapidjson::Document>> m_displayValues;
     std::map<Utf8String, NestedContentValues> m_nestedContentValues;
-    bset<Utf8String> m_mergedFieldNames;
+    bmap<Utf8String, HandledFieldAttributes> m_handledFields;
     LabelDefinitionCPtr m_displayLabel;
     Utf8String m_imageId;
     ContentSetItemExtendedData m_extendedData;
@@ -88,11 +93,12 @@ protected:
     ContentValuesFormatter const& GetValuesFormatter() const { return m_formatter; }
     bvector<ECInstanceKey>& GetPrimaryKeysR() { return m_primaryKeys; }
     bvector<ECInstanceKey>& GetInputKeysR() { return m_inputKeys; }
-    bset<Utf8String>& GetMergedFieldNames() { return m_mergedFieldNames; }
+    bmap<Utf8String, HandledFieldAttributes>& GetHandledFields() { return m_handledFields; }
     rapidjson::Document& GetValues() { return *m_values.second; }
     rapidjson::Document& GetDisplayValues() { return *m_displayValues.second; }
     std::map<Utf8String, NestedContentValues>& GetNestedContentValues() { return m_nestedContentValues; }
     void InvalidateInstanceClass() { m_primaryInstanceClass = nullptr; m_determinedPrimaryInstanceClass = false; }
+    void OnFieldHandled(Utf8CP name);
 
 protected:
     virtual ItemReadAction _GetActionForPrimaryKey(ECInstanceKeyCR key) const;
@@ -141,7 +147,7 @@ public:
     void SetImageId(Utf8String id) { _SetImageId(id); }
     Utf8StringCR GetImageId() const { return m_imageId; }
 
-    bset<Utf8String> const& GetMergedFieldNames() const { return m_mergedFieldNames; }
+    bmap<Utf8String, HandledFieldAttributes> const& GetHandledFields() const { return m_handledFields; }
 
     void SetRelatedInstanceKeys(bvector<ContentSetItemExtendedData::RelatedInstanceKey> const& keys) { _SetRelatedInstanceKeys(keys); }
     ContentSetItemExtendedData& GetExtendedData() { return m_extendedData; }

--- a/iModelCore/ECPresentation/Source/Content/ContentProviders.cpp
+++ b/iModelCore/ECPresentation/Source/Content/ContentProviders.cpp
@@ -205,7 +205,7 @@ static void MergePrimaryKeys(bvector<ContentSetItemPtr> const& targetSetItems, b
 /*---------------------------------------------------------------------------------**//**
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/
-static void MergeField(RapidJsonValueR targetValue, RapidJsonValueR targetDisplayValue,
+static void MergeFieldValue(RapidJsonValueR targetValue, RapidJsonValueR targetDisplayValue,
     rapidjson::Document::AllocatorType& targetDisplayValueAllocator)
     {
     targetValue.SetNull();
@@ -216,13 +216,13 @@ static void MergeField(RapidJsonValueR targetValue, RapidJsonValueR targetDispla
 /*---------------------------------------------------------------------------------**//**
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/
-static bool MergeContent(RapidJsonValueR targetValues, RapidJsonValueR targetDisplayValues,
+static bool TryMergeContent(RapidJsonValueR targetValues, RapidJsonValueR targetDisplayValues,
     rapidjson::Document::AllocatorType& targetDisplayValuesAllocator, RapidJsonValueCR source)
     {
     if (targetValues != source)
         {
         // values are different - set the "varies" string
-        MergeField(targetValues, targetDisplayValues, targetDisplayValuesAllocator);
+        MergeFieldValue(targetValues, targetDisplayValues, targetDisplayValuesAllocator);
         return true;
         }
     return false;
@@ -231,9 +231,9 @@ static bool MergeContent(RapidJsonValueR targetValues, RapidJsonValueR targetDis
 /*---------------------------------------------------------------------------------**//**
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/
-static bool MergeContent(rapidjson::Document& targetValues, rapidjson::Document& targetDisplayValues, RapidJsonValueCR source)
+static bool TryMergeContent(rapidjson::Document& targetValues, rapidjson::Document& targetDisplayValues, RapidJsonValueCR source)
     {
-    return MergeContent(targetValues, targetDisplayValues, targetDisplayValues.GetAllocator(), source);
+    return TryMergeContent(targetValues, targetDisplayValues, targetDisplayValues.GetAllocator(), source);
     }
 
 /*---------------------------------------------------------------------------------**//**
@@ -252,30 +252,7 @@ static bool MergeContentSetItems(bvector<ContentSetItemPtr> const& targetSetItem
         RapidJsonValueR lhsValues = targetSetItems[i]->GetValues();
         RapidJsonValueCR rhsValues = sourceSetItems[i]->GetValues();
         if (lhsValues != rhsValues)
-            {
-            if (1 < targetSetItems.size())
-                {
-                // values are only merged if there is one item in contentSetItems vector
-                return true;
-                }
-
-            if (!lhsValues.IsObject() || !rhsValues.IsObject())
-                DIAGNOSTICS_HANDLE_FAILURE(DiagnosticsCategory::Content, "Both LHS and RHS should be JSON objects but are not");
-
-            RapidJsonDocumentR lhsDisplayValues = targetSetItems[i]->GetDisplayValues();
-            for (rapidjson::Value::ConstMemberIterator iterator = lhsValues.MemberBegin(); iterator != lhsValues.MemberEnd(); ++iterator)
-                {
-                Utf8CP fieldName = iterator->name.GetString();
-                if (!lhsValues.HasMember(fieldName) || !rhsValues.HasMember(fieldName))
-                    DIAGNOSTICS_HANDLE_FAILURE(DiagnosticsCategory::Content, Utf8PrintfString("Either LHS or RHS doesn't have a value for: '%s'", fieldName));
-
-                if (!targetSetItems[i]->IsMerged(fieldName) && lhsValues[fieldName] != rhsValues[fieldName])
-                    {
-                    targetSetItems[i]->GetMergedFieldNames().push_back(fieldName);
-                    MergeField(lhsValues[fieldName], lhsDisplayValues[fieldName], lhsDisplayValues.GetAllocator());
-                    }
-                }
-            }
+            return true;
         }
 
     MergePrimaryKeys(targetSetItems, sourceSetItems);
@@ -349,14 +326,12 @@ void ContentProvider::LoadNestedContentFieldValue(ContentSetItemR item, ContentD
                     contentDisplayValues = std::move(instanceDisplayValues);
                     firstPass = false;
                     }
-                else if (MergeContent(contentValues, contentDisplayValues, instanceValues))
+                else if (TryMergeContent(contentValues, contentDisplayValues, instanceValues))
                     {
                     // if detected different values during merge, stop
                     DIAGNOSTICS_DEV_LOG(DiagnosticsCategory::Content, LOG_TRACE, "Detected different composite content values.");
-                    if (item.GetValues().HasMember(fieldName))
-                        item.GetValues()[fieldName].CopyFrom(contentValues, item.GetValues().GetAllocator());
-                    if (item.GetDisplayValues().HasMember(fieldName))
-                        item.GetDisplayValues()[fieldName].CopyFrom(contentDisplayValues, item.GetDisplayValues().GetAllocator());
+                    ContentValueHelpers::SetRapidJsonValue(item.GetValues(), fieldName, contentValues, item.GetValues().GetAllocator());
+                    ContentValueHelpers::SetRapidJsonValue(item.GetDisplayValues(), fieldName, contentDisplayValues, item.GetDisplayValues().GetAllocator());
                     item.GetMergedFieldNames().push_back(fieldName);
                     break;
                     }
@@ -385,7 +360,7 @@ void ContentProvider::LoadNestedContentFieldValue(ContentSetItemR item, ContentD
             {
             if (mergeAllField)
                 {
-                MergeField(contentValues, contentDisplayValues, contentDisplayValues.GetAllocator());
+                MergeFieldValue(contentValues, contentDisplayValues, contentDisplayValues.GetAllocator());
                 DIAGNOSTICS_DEV_LOG(DiagnosticsCategory::Content, LOG_TRACE, "Merged the whole related content field value.");
                 }
             else
@@ -407,19 +382,19 @@ void ContentProvider::LoadNestedContentFieldValue(ContentSetItemR item, ContentD
         if (item.GetDisplayValues().HasMember(fieldName) || item.GetValues().HasMember(fieldName))
             {
             DIAGNOSTICS_DEV_LOG(DiagnosticsCategory::Content, LOG_TRACE, "Successfully loaded nested content.");
-            if (item.GetMergedFieldNames().end() == std::find(item.GetMergedFieldNames().begin(), item.GetMergedFieldNames().end(), fieldName))
+            if (!ContainerHelpers::Contains(item.GetMergedFieldNames(), [fieldName](Utf8StringCR mergedFieldName){return 0 == strcmp(mergedFieldName.c_str(), fieldName);}))
                 {
                 // note: only need to do this if the field is not yet set as merged
                 RapidJsonValueR values = item.GetValues()[fieldName];
                 RapidJsonValueR displayValues = item.GetDisplayValues()[fieldName];
-                bool areValuesDifferent = MergeContent(values, displayValues, item.GetDisplayValues().GetAllocator(), contentValues);
+                bool areValuesDifferent = TryMergeContent(values, displayValues, item.GetDisplayValues().GetAllocator(), contentValues);
                 if (areValuesDifferent)
                     item.GetMergedFieldNames().push_back(fieldName);
                 }
             }
         else
             {
-            DIAGNOSTICS_DEV_LOG(DiagnosticsCategory::Content, LOG_TRACE, "Nested content is not loaded - add NULL values");
+            DIAGNOSTICS_DEV_LOG(DiagnosticsCategory::Content, LOG_TRACE, "Nested content is not loaded - just add loaded values");
             item.GetDisplayValues().AddMember(rapidjson::Value(fieldName, item.GetDisplayValues().GetAllocator()),
                 rapidjson::Value(contentDisplayValues, item.GetDisplayValues().GetAllocator()), item.GetDisplayValues().GetAllocator());
             item.GetValues().AddMember(rapidjson::Value(fieldName, item.GetValues().GetAllocator()),


### PR DESCRIPTION
Fixes https://github.com/iTwin/imodel-native/issues/586.
Fixes a regression caused by https://github.com/iTwin/imodel-native/pull/582. 

The values were not detected as being different if one one of them was `null` and the other - not. The null value didn't get into the values map (an optimization made in the mentioned pr), then when handling the non-null value we didn't know anything about an already handled value and whether it's different from the current one.