### PR TITLE
Presentation: Fix property value merging for properties of different classes

### DIFF
--- a/iModelCore/ECPresentation/Source/Content/ContentQueryResultsReader.cpp
+++ b/iModelCore/ECPresentation/Source/Content/ContentQueryResultsReader.cpp
@@ -233,6 +233,8 @@ static void ReadValues(ContentItemBuilder& item, int& sqlColumnIndex, ECSqlState
             ContentDescriptor::ECPropertiesField const& propertiesField = *field->AsPropertiesField();
             if (ContentDescriptor::Property const* matchingProperty = contract.FindMatchingProperty(propertiesField, item.GetRecordClass()))
                 item.AddValue(fieldName.c_str(), matchingProperty->GetProperty(), statement.GetValue(sqlColumnIndex));
+            else
+                item.AddNull(fieldName.c_str(), nullptr);
             }
         ++sqlColumnIndex;
         }

--- a/iModelCore/ECPresentation/Tests/NonPublished/Integration/Content/ContentIntegrationTests.cpp
+++ b/iModelCore/ECPresentation/Tests/NonPublished/Integration/Content/ContentIntegrationTests.cpp
@@ -10461,7 +10461,7 @@ TEST_F(RulesDrivenECPresentationManagerContentTests, MergesPrimitivePropertyFiel
     rules->AddPresentationRule(*rule);
 
     // validate descriptor
-    ContentDescriptorCPtr descriptor = GetValidatedResponse(m_manager->GetContentDescriptor(AsyncContentDescriptorRequestParams::Create(s_project->GetECDb(), 
+    ContentDescriptorCPtr descriptor = GetValidatedResponse(m_manager->GetContentDescriptor(AsyncContentDescriptorRequestParams::Create(s_project->GetECDb(),
         rules->GetRuleSetId(), RulesetVariables(), nullptr, (int)ContentFlags::MergeResults, *KeySet::Create())));
     ASSERT_TRUE(descriptor.IsValid());
     EXPECT_EQ(1, descriptor->GetVisibleFields().size());
@@ -10479,7 +10479,7 @@ TEST_F(RulesDrivenECPresentationManagerContentTests, MergesPrimitivePropertyFiel
     expectedValues.Parse(Utf8PrintfString(R"(
         {
         "%s": "test"
-        })", 
+        })",
         FIELD_NAME(classA, "Prop")).c_str());
     EXPECT_EQ(expectedValues, record->GetValues())
         << "Expected: \r\n" << BeRapidJsonUtilities::ToPrettyString(expectedValues) << "\r\n"
@@ -10632,7 +10632,7 @@ TEST_F(RulesDrivenECPresentationManagerContentTests, MergesPrimitivePropertyFiel
     // validate descriptor
     ContentDescriptorCPtr descriptor = GetValidatedResponse(m_manager->GetContentDescriptor(AsyncContentDescriptorRequestParams::Create(s_project->GetECDb(),
         rules->GetRuleSetId(), RulesetVariables(), nullptr, (int)ContentFlags::MergeResults, *KeySet::Create())));
-    ASSERT_TRUE(descriptor.IsValid());+
+    ASSERT_TRUE(descriptor.IsValid());
     EXPECT_EQ(2, descriptor->GetVisibleFields().size());
 
     // request for content
@@ -10650,7 +10650,7 @@ TEST_F(RulesDrivenECPresentationManagerContentTests, MergesPrimitivePropertyFiel
         "%s": null,
         "%s": null
         })",
-        FIELD_NAME(classA, "PropA"), 
+        FIELD_NAME(classA, "PropA"),
         FIELD_NAME(classB, "PropB")
     ).c_str());
     EXPECT_EQ(expectedValues, record->GetValues())


### PR DESCRIPTION
Fixes https://github.com/iTwin/imodel-native/issues/586.

This is a follow-up of https://github.com/iTwin/imodel-native/pull/587, which didn't fully fix the problem, because it didn't handle the situation when fields with properties of different classes are being merged. 