### PR TITLE
Fix crash when closing cached connection try to remove sql functions

### DIFF
--- a/iModelCore/ECDb/ECDb/ConcurrentQueryManagerImpl.cpp
+++ b/iModelCore/ECDb/ECDb/ConcurrentQueryManagerImpl.cpp
@@ -195,15 +195,6 @@ void CachedConnection::UpdateSqlFunctions(ConnectionAction action) {
                     m_db.AddFunction(*info.GetFunction());
             }
         }
-    } else { // closing
-        for (auto& info : GetPrimaryDbSqlFunctions()) {
-            DbFunction *tmpFunc;
-            if (m_db.TryGetSqlFunction(tmpFunc, info.GetName().c_str(), info.GetNumArgs())) {
-                if (tmpFunc == info.GetFunction() && dynamic_cast<RTreeMatchFunction*>(info.GetFunction()) == nullptr) {
-                    m_db.RemoveFunction(*tmpFunc);
-                }
-            }
-        }
     }
 }
 

--- a/iModelCore/ECDb/ECDb/ConcurrentQueryManagerImpl.cpp
+++ b/iModelCore/ECDb/ECDb/ConcurrentQueryManagerImpl.cpp
@@ -204,6 +204,9 @@ void CachedConnection::UpdateSqlFunctions(ConnectionAction action) {
 std::vector<CachedConnection::FunctionInfo> CachedConnection::GetPrimaryDbSqlFunctions() const {
     std::vector<FunctionInfo> funcs;
     std::regex funcFilter("^imodel_\\w*", std::regex_constants::ECMAScript | std::regex_constants::icase);
+    if (!m_cache.GetPrimaryDb().IsDbOpen())
+        return funcs;
+
     for(auto func : m_cache.GetPrimaryDb().GetSqlFunctions()) {
         FunctionInfo info(func->GetName(), func->GetNumArgs(), func);
         if (std::regex_match(info.GetName(), funcFilter)) {


### PR DESCRIPTION
The crash is caused by close primary connection by the time cache connection is closed. The fix is to not attempt to remove sql functions as they already deleted when primary connection was closed.

[Sentry.io crash](https://bentley-systems-inc.sentry.io/issues/4887884042/?alert_rule_id=9206371&alert_timestamp=1705584695496&alert_type=email&notification_uuid=a6c12c4f-03cb-4b14-8ccd-363d900f10c3&project=1520306&referrer=alert_email) `EXCEPTION_ACCESS_VIOLATION_READ / 0x254d0e38928`

