### PR TITLE
[backport] Polyface and RotMatrix fixes

### DIFF
--- a/iModelCore/GeomLibs/PublicAPI/Geom/rotmatrix.h
+++ b/iModelCore/GeomLibs/PublicAPI/Geom/rotmatrix.h
@@ -1279,15 +1279,23 @@ double ConditionNumber () const;
 //flex|| || bool matrix.OffDiagonalSignedRange (outMinValue, outMaxValue) || bool matrix.OffDiagonalAbsRange (outMinValue, outMaxValue) ||
 //flex|| || a = matrix.SumSquares () || a = matrix.SumDiagonalSquares () || a = matrix.SumOffDiagonalSquares () ||
 //flex|| || a = matrix.MaxAbs () || a = matrix.MaxDiff () ||
-//
+
 //!
 //! @description Tests if a matrix is the identity matrix.
+//! @remarks An absolute tolerance of 1.0e-12 is used to compare matrix entries.
 //! @return true if matrix is approximately an identity.
 //!
 bool IsIdentity () const;
 
 //!
-//! @description Tests if a matrix has small offdiagonal entries compared to
+//! @description Tests if a matrix is the identity matrix.
+//! @param [in] tol absolute tolerance for comparing matrix entries.
+//! @return true if matrix is approximately an identity.
+//!
+bool IsIdentity(double tol) const;
+
+//!
+//! @description Tests if a matrix has small off-diagonal entries compared to
 //!                   diagonals.   The specific test condition is that the
 //!                   largest off diagonal absolute value is less than a tight tolerance
 //!                   fraction times the largest diagonal entry.
@@ -1296,9 +1304,9 @@ bool IsIdentity () const;
 bool IsDiagonal () const;
 
 //!
-//! @description Tests if a matrix has (nearly) equal diagaonal entries and
+//! @description Tests if a matrix has (nearly) equal diagonal entries and
 //!           (nearly) zero off diagonals.  Tests use a tight relative tolerance.
-//! @param [out] maxScale the largest diagaonal entry
+//! @param [out] maxScale the largest diagonal entry
 //! @return true if matrix is approximately diagonal
 //!
 bool IsUniformScale
@@ -1427,11 +1435,10 @@ bool IsRigid () const;
 bool IsOrthogonal () const;
 
 //!
-//! @description Test if this instance matrix has orthonormal columns, i.e. its columns
-//! are all perpendicular to one another.
+//! @description Test if this instance matrix has orthonormal columns, i.e. its columns are all perpendicular to one another.
+//! @remarks Internally, an absolute tolerance of 1.0e-12 is passed into IsIdentity.
 //! @param [out] columns matrix containing the unit vectors along the columns.
-//! @param [out] axisScales  point whose x, y, and z components are the magnitudes of the
-//!           original columns.
+//! @param [out] axisScales xyz components are the magnitudes of the original columns.
 //! @param [out] axisRatio smallest axis length divided by largest.
 //! @return true if the matrix is orthonormal.
 //!
@@ -1443,11 +1450,26 @@ double          &axisRatio
 ) const;
 
 //!
+//! @description Test if this instance matrix has orthonormal columns, i.e. its columns are all perpendicular to one another.
+//! @param [out] columns matrix containing the unit vectors along the columns.
+//! @param [out] axisScales xyz components are the magnitudes of the original columns.
+//! @param [out] axisRatio smallest axis length divided by largest.
+//! @param [in] tol absolute tolerance passed into IsIdentity.
+//! @return true if the matrix is orthonormal.
+//!
+bool IsOrthonormal
+(
+RotMatrixR      columns,
+DVec3dR         axisScales,
+double          &axisRatio,
+double          tol
+) const;
+
+//!
 //! @description Test if this instance matrix is composed of only rigid rotation and scaling.
-//! @param [out] columns  matrix containing the unit vectors along the columns.
-//! @param [out] scale largest axis scale factor.  If function value is true,
-//!       the min scale is the same.  Use areColumnsOrthonormal to get
-//!       separate column scales.
+//! @remarks Internally, an absolute tolerance of 1.0e-12 is passed into IsOrthonormal.
+//! @param [out] columns matrix containing normalized instance columns.
+//! @param [out] scale largest column magnitude. If this function returns true, all instance columns have the same magnitude. Use IsOrthonormal to get separate column scales.
 //! @return true if the matrix is orthonormal.
 //!
 bool IsRigidScale
@@ -1457,17 +1479,30 @@ double          &scale
 ) const;
 
 //!
-//! @description Test if this instance matrix is composed of only rigid rotation and scaling, allowing negative (mirror) scale
-//! @param [out] columns  descaled matrix.  (Specifically: The original matrix multiplied by the inverse of the scale)
-//! @param [out] scale signed scale of largest magnitude. If function value is true,
-//!       the min scale is the same.  Use areColumnsOrthonormal to get
-//!       separate column scales.
-//! @return true if the matrix is orthonormal (i.e. the return columns are a rotation)
+//! @description Test if this instance matrix is composed of only rigid rotation and scaling, allowing negative (mirror) scale.
+//! @remarks Internally, an absolute tolerance of 1.0e-12 is passed into IsOrthonormal.
+//! @param [out] columns descaled matrix. Specifically: instance columns scaled by the inverse of the returned scale.
+//! @param [out] scale largest column magnitude, negated if mirror. If this function returns true, all instance columns have the same magnitude. Use IsOrthonormal to get separate column scales.
+//! @return true if the matrix is orthonormal (i.e. columns is a rotation)
 //!
 bool IsRigidSignedScale
 (
 RotMatrixR      columns,
 double          &scale
+) const;
+
+//!
+//! @description Test if this instance matrix is composed of only rigid rotation and scaling, allowing negative (mirror) scale.
+//! @param [out] columns descaled matrix. Specifically: instance columns scaled by the inverse of the returned scale.
+//! @param [out] scale largest column magnitude, negated if mirror. If this function returns true, all instance columns have the same magnitude. Use IsOrthonormal to get separate column scales.
+//! @param [in] tol absolute tolerance passed into IsOrthonormal.
+//! @return true if the matrix is orthonormal (i.e. columns is a rotation)
+//!
+bool IsRigidSignedScale
+(
+RotMatrixR      columns,
+double          &scale,
+double          tol
 ) const;
 
 //! Determine if a matrix is close to a pure rotate and scale.

--- a/iModelCore/GeomLibs/geom/src/bspline/bspmisc.cpp
+++ b/iModelCore/GeomLibs/geom/src/bspline/bspmisc.cpp
@@ -156,7 +156,7 @@ BsplineParam*   pParams         // <=> potentially modified only if poles given
     if (badFullKnots)
         {
         /* the whole knot vector is bad; replace it with uniform knots */
-        return bspknot_computeKnotVector (pKnots, pParams, NULL);
+        bspknot_computeKnotVector (pKnots, pParams, NULL);
         }
     else
         {

--- a/iModelCore/GeomLibs/geom/src/polyface/pf_purgeDuplicates.cpp
+++ b/iModelCore/GeomLibs/geom/src/polyface/pf_purgeDuplicates.cpp
@@ -227,4 +227,20 @@ PolyfaceHeaderPtr PolyfaceHeader::CloneWithFacetsInRandomOrder() const
     return shuffledMesh;
     }
 
+PolyfaceHeaderPtr PolyfaceHeader::CloneWithConsistentlyOrientedFacets(DVec3dCP surfaceNormal) const
+    {
+    auto newMesh = PolyfaceHeader::CreateVariableSizeIndexed();
+    
+    // use tight tolerances: we assume the input mesh already shares vertices 
+    MTGFacets* facets = jmdlMTGFacets_grab();
+    bvector<MTGNodeId> meshVertexToNodeId;  // needed to preserve visible edges!
+    if (PolyfaceToMTG(facets, &meshVertexToNodeId, nullptr, *this, true, Angle::SmallAngle(), Angle::SmallAngle(), 1))
+        AddMTGFacetsToIndexedPolyface(facets, *newMesh);
+    jmdlMTGFacets_drop(facets);
+    if (!newMesh->HasFacets())
+        return nullptr;
+    newMesh->ReverseIndicesWithTest(surfaceNormal);
+    return newMesh;
+    }
+
 END_BENTLEY_GEOMETRY_NAMESPACE


### PR DESCRIPTION
Backport from imodel02.

Add new methods needed by connectors:
  * `RotMatrix::IsRigidSignedScale`: new overload that takes a tolerance
  * `PolyfaceQuery::IsFacetOrientationConsistent`: count matching interior edges to determine if a face loop is reversed
  * `PolyfaceHeader::CloneWithConsistentlyOrientedFacets`: create a new mesh with face loops consistently oriented

Also:
*  `mdlBspline_validateCurveKnots`: validate weights even when recomputing knots.
* `RotMatrix::IsRigidScale`: use more accurate test for detecting uniform scales when they are tiny.
