### PR TITLE
Presentation: Increase statement cache size

### DIFF
--- a/iModelCore/ECPresentation/Source/Connection.cpp
+++ b/iModelCore/ECPresentation/Source/Connection.cpp
@@ -7,7 +7,7 @@
 #include <Bentley/BeThreadLocalStorage.h>
 #include <Bentley/BeThread.h>
 
-#define STATEMENT_CACHE_SIZE 50
+#define STATEMENT_CACHE_SIZE 200
 
 /*---------------------------------------------------------------------------------**//**
 * @bsimethod


### PR DESCRIPTION
We have a situation where content is being requested for a large set of elements and the number of related classes is > 100. This means that getting properties for an element includes running > 100 smaller queries to get related properties. The statement cache was too small to accommodate all these queries and we were spending a lot of time re-preparing them. Increased the cache size...