### PR TITLE
Remove unused variable from BeDirectoryIterator::WalkDirsAndMatch()

### DIFF
--- a/iModelCore/Bentley/PublicAPI/Bentley/BeDirectoryIterator.h
+++ b/iModelCore/Bentley/PublicAPI/Bentley/BeDirectoryIterator.h
@@ -48,9 +48,6 @@ public:
     //! Return all filenames that match a wildcard expression in the specified directory
     static void WalkDirsAndMatch (bvector<BeFileName>& matches, BeFileNameCR topDir, WCharCP glob, bool recursive)
         {
-        BeFileName topDirPrefix (topDir);
-        topDirPrefix.AppendSeparator();
-
         BeFileName entryName;
         bool        isDir;
         for (BeDirectoryIterator dirs (topDir); dirs.GetCurrentEntry (entryName, isDir) == SUCCESS; dirs.ToNext())


### PR DESCRIPTION
topDirPrefix variable is not used in BeDirectoryIterator::WalkDirsAndMatch() static method and may be removed there.