### PR TITLE
CloudSQLite update: Fixes so that things work with SQLITE_DIRECT_OVERFLOW_READ.

### DIFF
--- a/iModelCore/BeSQLite/SQLite/blockcachevfs.c
+++ b/iModelCore/BeSQLite/SQLite/blockcachevfs.c
@@ -1442,7 +1442,6 @@ static int bcvfsReadWriteDatabase(
     assert( bWrite==0 );
     return SQLITE_IOERR_SHORT_READ;
   }
-  assert( (iAmt & (iAmt-1))==0 );
 
   /* Take the VFS mutex and do three things under its cover:
   **


### PR DESCRIPTION
https://sqlite.org/cloudsqlite/forumpost/7c554f886d

"Hi Nick,
I think it's compiling with -DSQLITE_DIRECT_OVERFLOW_READ that is exposing the bug. Should now be fixed here:
https://sqlite.org/cloudsqlite/info/f6145230ca6bf01882ca
Thanks,
Dan."

