### PR TITLE
Presentation: Fix related distinct values not being picked up in specific cases

### DIFF
--- a/iModelCore/ECPresentation/PublicAPI/ECPresentation/Content.h
+++ b/iModelCore/ECPresentation/PublicAPI/ECPresentation/Content.h
@@ -1020,6 +1020,7 @@ struct EXPORT_VTABLE_ATTRIBUTE ContentDescriptor : RefCountedBase
         std::unordered_set<ECClassCP> m_actualSourceClasses;
         RelationshipMeaning m_relationshipMeaning;
         bool m_isRelationshipField;
+        Utf8String m_specificationIdentifier;
 
     private:
         Utf8String CreateRelationshipName() const;
@@ -1072,6 +1073,9 @@ struct EXPORT_VTABLE_ATTRIBUTE ContentDescriptor : RefCountedBase
         bool IsRelationshipField() const {return m_isRelationshipField;}
         ECClassCR GetRelationshipClass() const {return m_pathFromSelectClassToContentClass.back().GetRelationship().GetClass();}
         Utf8StringCR GetRelationshipClassAlias() const {return m_pathFromSelectClassToContentClass.back().GetRelationship().GetAlias();}
+
+        void SetSpecificationIdentifier(Utf8String value) {m_specificationIdentifier = value;}
+        Utf8StringCR GetSpecificationIdentifier() const {return m_specificationIdentifier;}
     };
 
     //===================================================================================

--- a/iModelCore/ECPresentation/Source/Content/ContentDescriptorBuilder.cpp
+++ b/iModelCore/ECPresentation/Source/Content/ContentDescriptorBuilder.cpp
@@ -1055,7 +1055,7 @@ public:
         // use the field we found
         if (mergeResult.field)
             {
-            if (relatedPropertySpecsStack.back()->ShouldSkipIfDuplicate())
+            if (relatedPropertySpecsStack.back()->ShouldSkipIfDuplicate() && mergeResult.field->GetSpecificationIdentifier() != relatedPropertySpecsStack.back()->GetHash())
                 {
                 DIAGNOSTICS_DEV_LOG(DiagnosticsCategory::Content, LOG_TRACE, "Found a similar related content field and we're skipping duplicate fields - skip creating the related content field.");
                 return { nullptr, nullptr, nullptr };
@@ -1089,6 +1089,7 @@ public:
             fieldAttributes.GetLabel(), pathFromSelectToContentClass, bvector<ContentDescriptor::Field*>(), fieldAttributes.ShouldAutoExpand(),
             ContentDescriptor::Property::DEFAULT_PRIORITY, actualPropertyClass.IsRelationshipClass());
 
+        relatedContentField->SetSpecificationIdentifier(relatedPropertySpecsStack.back()->GetHash());
         relatedContentField->SetActualSourceClasses(actualSourceClasses);
         relatedContentField->SetRelationshipMeaning(relatedPropertySpecsStack.back()->GetRelationshipMeaning());
 


### PR DESCRIPTION
Fixes https://github.com/iTwin/imodel-native/issues/622

Related distinct values were not being picked up when polymorphically selecting properties and related properties spec has `skipIfDuplicate = true`.