### PR TITLE
Try to fix Sentry crash on bad B-spline curve [buildNum:2024.02.21.18]

### DIFF
--- a/iModelCore/GeomLibs/PublicAPI/Geom/MSBsplineCurve.h
+++ b/iModelCore/GeomLibs/PublicAPI/Geom/MSBsplineCurve.h
@@ -1299,6 +1299,8 @@ public:
 
     //! Confirm basic validity
     GEOMDLLIMPEXP bool IsValidGeometry(GeometryValidatorPtr &validator) const;
+    //! Confirm basic validity using default validator
+    GEOMDLLIMPEXP bool IsValidGeometry() const;
 
     //! Compute intersections of a ray with a ruled surface between two curves.
     //! @return false if curves are not compatible.

--- a/iModelCore/GeomLibs/geom/src/CurvePrimitive/CurvePrimitiveBsplineCurve.cpp
+++ b/iModelCore/GeomLibs/geom/src/CurvePrimitive/CurvePrimitiveBsplineCurve.cpp
@@ -319,6 +319,10 @@ bool _AdjustFractionToBreakFraction(double fraction, Rounding::RoundingMode mode
 +--------------------------------------------------------------------------------------*/
 bool _GetMSBsplineCurve(MSBsplineCurveR curve, double fractionA, double fractionB) const override
         {
+        // avoid crashing tile generator on bad data that has snuck in somehow (reported by Sentry)
+        if (!m_curve->IsValidGeometry())
+            return false;
+        
         return SUCCESS == curve.CopySegment (*m_curve,
             m_curve->FractionToKnot (fractionA), m_curve->FractionToKnot (fractionB));
         }

--- a/iModelCore/GeomLibs/geom/src/bspline/bsputil.cpp
+++ b/iModelCore/GeomLibs/geom/src/bspline/bsputil.cpp
@@ -469,6 +469,7 @@ bool MSBsplineCurve::AlmostEqual (MSBsplineCurveCR other, double tolerance) cons
     }
 
 /*--------------------------------------------------------------------*//**
+* @bsimethod
 +----------------------------------------------------------------------*/
 bool MSBsplineCurve::IsValidGeometry (GeometryValidatorPtr &validator) const
     {
@@ -501,6 +502,16 @@ bool MSBsplineCurve::IsValidGeometry (GeometryValidatorPtr &validator) const
             return false;
     return true;
     }
+
+/*--------------------------------------------------------------------*//**
+* @bsimethod
++----------------------------------------------------------------------*/
+bool MSBsplineCurve::IsValidGeometry() const
+    {
+    static GeometryValidatorPtr s_validator = GeometryValidator::Create();
+    return IsValidGeometry(s_validator);
+    }
+
 /*---------------------------------------------------------------------------------**//**
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/

--- a/iModelCore/GeomLibs/geom/test/CurvePrimitiveTest/t_IGeometry.cpp
+++ b/iModelCore/GeomLibs/geom/test/CurvePrimitiveTest/t_IGeometry.cpp
@@ -1015,7 +1015,7 @@ TEST(FlatBuffer, IsNanValues)
     Check::True(cv->GetMSBsplineCurve(myCurve), "GetMSBsplineCurve validates valid curve");
     myCurve.knots = nullptr;    // invalidate it
     cv = ICurvePrimitive::CreateBsplineCurveSwapFromSource(myCurve);
-    Check::False(cv->GetMSBsplineCurve(myCurve), "GetMSBsplineCurve validates invalid curve");
+    Check::False(cv->GetMSBsplineCurve(myCurve), "GetMSBsplineCurve invalidates invalid curve");
 
     bvector<IGeometryPtr> gVectorA {goodGCV, badGCV};
     bvector<IGeometryPtr> gVectorB, gVectorC, gVectorD;

--- a/iModelCore/GeomLibs/geom/test/CurvePrimitiveTest/t_IGeometry.cpp
+++ b/iModelCore/GeomLibs/geom/test/CurvePrimitiveTest/t_IGeometry.cpp
@@ -1010,6 +1010,13 @@ TEST(FlatBuffer, IsNanValues)
     curvePtr3->weights[2] = 1.0;
     Check::True(validator->IsValidGeometry(curvePtr3));
 
+    MSBsplineCurve myCurve;
+    auto cv = ICurvePrimitive::CreateBsplineCurve(curvePtr1);
+    Check::True(cv->GetMSBsplineCurve(myCurve), "GetMSBsplineCurve validates valid curve");
+    myCurve.knots = nullptr;    // invalidate it
+    cv = ICurvePrimitive::CreateBsplineCurveSwapFromSource(myCurve);
+    Check::False(cv->GetMSBsplineCurve(myCurve), "GetMSBsplineCurve validates invalid curve");
+
     bvector<IGeometryPtr> gVectorA {goodGCV, badGCV};
     bvector<IGeometryPtr> gVectorB, gVectorC, gVectorD;
     bvector<Byte> bufferAB;


### PR DESCRIPTION
Hopefully resolves https://github.com/iTwin/imodel-native-internal/issues/388 with paranoid validation.

Without a test case to reproduce this Sentry crash, we don't know how this corrupt B-spline curve is creeping into tile generation.