### PR TITLE
Remove GH token in begin release pipeline [buildNum:2024.02.22.13]

### DIFF
--- a/build/begin_addon_release.yml
+++ b/build/begin_addon_release.yml
@@ -11,9 +11,6 @@ trigger:
 
 pr: none
 
-variables:
-- group: imodel-native secret variables
-
 stages:
 - stage: queue_bump_version
   displayName: Queue bump-version.yml
@@ -26,9 +23,6 @@ stages:
     steps:
       - checkout: self
         persistCredentials: true
-      - task: NodeTool@0
-        inputs:
-          versionSpec: '18.x'
 
       - bash: az devops configure --defaults organization=$(System.TeamFoundationCollectionUri) project=$(System.TeamProject)
         displayName: Setup Azure CLI
@@ -51,8 +45,6 @@ stages:
             if [[ $(Build.SourceVersionMessage) != *"$noCi"* ]]; then
               echo "##vso[task.setvariable variable=SKIP_ADDON;isoutput=true]true"
             fi
-        env:
-          GITHUB_TOKEN: $(GH_TOKEN)
         displayName: get build num from commit
         name: getBuildNum
 


### PR DESCRIPTION
GH token was needed for testing, but in this context it is not necessary since we don't need to use the GH apis. If we decided to open a PR description or comments then it would be needed again.