### PR TITLE
Provide `errorNumber` to "aborted" and "schema not found" errors

### DIFF
--- a/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/DgnPlatformErrors.h
+++ b/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/DgnPlatformErrors.h
@@ -92,6 +92,7 @@ enum class DgnDbStatus : int
     WrongModel             = DGNDB_ERROR_BASE + 64,
     ConstraintNotUnique    = DGNDB_ERROR_BASE + 65,
     NoGeoLocation          = DGNDB_ERROR_BASE + 66,
+    Aborted                = DGNDB_ERROR_BASE + 72,
     };
 
 //! Status Values for DgnViewport methods

--- a/iModelJsNodeAddon/api_package/ts/src/test/DgnDb.test.ts
+++ b/iModelJsNodeAddon/api_package/ts/src/test/DgnDb.test.ts
@@ -356,14 +356,14 @@ describe("basic tests", () => {
 
   it("testGetSchemaProps", async () => {
     assert.isTrue(dgndb.isOpen());
-    expect(() => dgndb.getSchemaProps("DoesNotExist")).to.throw("schema not found");
+    expect(() => dgndb.getSchemaProps("DoesNotExist")).to.throw("schema not found").with.property("errorNumber", IModelStatus.NotFound);
     const props = dgndb.getSchemaProps("BisCore");
     expect(props.name).equal("BisCore");
   });
 
   it("testGetSchemaPropsAsync", async () => {
     assert.isTrue(dgndb.isOpen());
-    await expect(dgndb.getSchemaPropsAsync("DoesNotExist")).rejectedWith("schema not found");
+    await expect(dgndb.getSchemaPropsAsync("DoesNotExist")).rejectedWith("schema not found").eventually.with.property("errorNumber", IModelStatus.NotFound);
     const props = await dgndb.getSchemaPropsAsync("BisCore");
     expect(props.name).equal("BisCore");
   });


### PR DESCRIPTION
This will help us better identify status codes in RPC layer.