### PR TITLE
Fix compiler error with VS2022/Debug

### DIFF
--- a/iModelCore/Bentley/PublicAPI/Bentley/WString.h
+++ b/iModelCore/Bentley/PublicAPI/Bentley/WString.h
@@ -255,15 +255,13 @@ public:
     // A "safe" version of swscanf. Actually, all this does is make sure you don't use "%s" in your format string - that's not safe
     // due to buffer overrun and should be avoided.
     template<typename... Args> static int Swscanf_safe(const wchar_t* buffer, const wchar_t* format, Args&&... args) {
-
-      // Use string_views if possible
+      // Use string_view if possible, to avoid compiler error C2064 with VS2022/Debug
       #if BENTLEY_CPLUSPLUS >= 201103L // C++17
         BeAssert(std::wstring_view(format).find(L"%s") == std::wstring::npos && "%s is unsafe, do not use sscanf for that purpose");
       #elif
         // The lambda is because of a compiler error with just the straight expression. It does not seem to like the temporary variable in the template.
         BeAssert([](const wchar_t* format) {return (std::wstring::npos == std::wstring(format).find(L"%s") && "%s is unsafe, do not use sscanf for that purpose");}(format));
-      #endif
-        
+      #endif        
 PUSH_DISABLE_DEPRECATION_WARNINGS
         return swscanf(buffer, format, std::forward<Args>(args)...);
 POP_DISABLE_DEPRECATION_WARNINGS
@@ -507,15 +505,13 @@ public:
     // A "safe" version of sscanf. Actually, all this does is make sure you don't use "%s" in your format string - that's not safe
     // due to buffer overrun and should be avoided.
     template<typename... Args> static int Sscanf_safe(const char* const buffer, const char* const format, Args&&... args) {
-
-      // Use string_views if possible
+      // Use string_view if possible, to avoid compiler error C2064 with VS2022/Debug
       #if BENTLEY_CPLUSPLUS >= 201103L // C++17
         BeAssert(std::string_view(format).find("%s") == std::string::npos && "%s is unsafe, do not use sscanf for that purpose");
       #elif
         // The lambda is because of a compiler error with just the straight expression. It does not seem to like the temporary variable in the template.
         BeAssert([](const char* const format) {return (std::string::npos == std::string(format).find("%s") && "%s is unsafe, do not use sscanf for that purpose");}(format));
-      #endif
-     
+      #endif     
 PUSH_DISABLE_DEPRECATION_WARNINGS // this is safe, because we're sure the format string doesn't use
         return sscanf(buffer, format, std::forward<Args>(args)...);
 POP_DISABLE_DEPRECATION_WARNINGS

--- a/iModelCore/Bentley/PublicAPI/Bentley/WString.h
+++ b/iModelCore/Bentley/PublicAPI/Bentley/WString.h
@@ -255,8 +255,17 @@ public:
     // A "safe" version of swscanf. Actually, all this does is make sure you don't use "%s" in your format string - that's not safe
     // due to buffer overrun and should be avoided.
     template<typename... Args> static int Swscanf_safe(const wchar_t* buffer, const wchar_t* format, Args&&... args) {
+
+      // Use static assert and string_views if possible
+      #if BENTLEY_CPLUSPLUS >= 201103L
+        BeAssert(std::wstring_view(format).find(L"%s") == std::wstring::npos && "%s is unsafe, do not use sscanf for that purpose");
+      #elif
         // The lambda is because of a compiler error with just the straight expression. It does not seem to like the temporary variable in the template.
         BeAssert([](const wchar_t* format) {return (std::wstring::npos == std::wstring(format).find(L"%s") && "%s is unsafe, do not use sscanf for that purpose");}(format));
+      #endif
+
+      // The lambda is because of a compiler error with just the straight expression. It does not seem to like the temporary variable in the template.
+        
 PUSH_DISABLE_DEPRECATION_WARNINGS
         return swscanf(buffer, format, std::forward<Args>(args)...);
 POP_DISABLE_DEPRECATION_WARNINGS
@@ -500,9 +509,15 @@ public:
     // A "safe" version of sscanf. Actually, all this does is make sure you don't use "%s" in your format string - that's not safe
     // due to buffer overrun and should be avoided.
     template<typename... Args> static int Sscanf_safe(const char* const buffer, const char* const format, Args&&... args) {
-        // NOTE: When we use C++17 this can be string_view and become a static_assert
+
+      // Use static assert and string_views if possible
+      #if BENTLEY_CPLUSPLUS >= 201103L
+        BeAssert(std::string_view(format).find("%s") == std::string::npos && "%s is unsafe, do not use sscanf for that purpose");
+      #elif
         // The lambda is because of a compiler error with just the straight expression. It does not seem to like the temporary variable in the template.
         BeAssert([](const char* const format) {return (std::string::npos == std::string(format).find("%s") && "%s is unsafe, do not use sscanf for that purpose");}(format));
+      #endif
+     
 PUSH_DISABLE_DEPRECATION_WARNINGS // this is safe, because we're sure the format string doesn't use
         return sscanf(buffer, format, std::forward<Args>(args)...);
 POP_DISABLE_DEPRECATION_WARNINGS

--- a/iModelCore/Bentley/PublicAPI/Bentley/WString.h
+++ b/iModelCore/Bentley/PublicAPI/Bentley/WString.h
@@ -256,7 +256,7 @@ public:
     // due to buffer overrun and should be avoided.
     template<typename... Args> static int Swscanf_safe(const wchar_t* buffer, const wchar_t* format, Args&&... args) {
 
-      // Use static assert and string_views if possible
+      // Use string_views if possible
       #if BENTLEY_CPLUSPLUS >= 201103L // C++17
         BeAssert(std::wstring_view(format).find(L"%s") == std::wstring::npos && "%s is unsafe, do not use sscanf for that purpose");
       #elif
@@ -508,7 +508,7 @@ public:
     // due to buffer overrun and should be avoided.
     template<typename... Args> static int Sscanf_safe(const char* const buffer, const char* const format, Args&&... args) {
 
-      // Use static assert and string_views if possible
+      // Use string_views if possible
       #if BENTLEY_CPLUSPLUS >= 201103L // C++17
         BeAssert(std::string_view(format).find("%s") == std::string::npos && "%s is unsafe, do not use sscanf for that purpose");
       #elif

--- a/iModelCore/Bentley/PublicAPI/Bentley/WString.h
+++ b/iModelCore/Bentley/PublicAPI/Bentley/WString.h
@@ -257,7 +257,7 @@ public:
     template<typename... Args> static int Swscanf_safe(const wchar_t* buffer, const wchar_t* format, Args&&... args) {
 
       // Use static assert and string_views if possible
-      #if BENTLEY_CPLUSPLUS >= 201103L
+      #if BENTLEY_CPLUSPLUS >= 201103L // C++17
         BeAssert(std::wstring_view(format).find(L"%s") == std::wstring::npos && "%s is unsafe, do not use sscanf for that purpose");
       #elif
         // The lambda is because of a compiler error with just the straight expression. It does not seem to like the temporary variable in the template.
@@ -511,7 +511,7 @@ public:
     template<typename... Args> static int Sscanf_safe(const char* const buffer, const char* const format, Args&&... args) {
 
       // Use static assert and string_views if possible
-      #if BENTLEY_CPLUSPLUS >= 201103L
+      #if BENTLEY_CPLUSPLUS >= 201103L // C++17
         BeAssert(std::string_view(format).find("%s") == std::string::npos && "%s is unsafe, do not use sscanf for that purpose");
       #elif
         // The lambda is because of a compiler error with just the straight expression. It does not seem to like the temporary variable in the template.

--- a/iModelCore/Bentley/PublicAPI/Bentley/WString.h
+++ b/iModelCore/Bentley/PublicAPI/Bentley/WString.h
@@ -263,8 +263,6 @@ public:
         // The lambda is because of a compiler error with just the straight expression. It does not seem to like the temporary variable in the template.
         BeAssert([](const wchar_t* format) {return (std::wstring::npos == std::wstring(format).find(L"%s") && "%s is unsafe, do not use sscanf for that purpose");}(format));
       #endif
-
-      // The lambda is because of a compiler error with just the straight expression. It does not seem to like the temporary variable in the template.
         
 PUSH_DISABLE_DEPRECATION_WARNINGS
         return swscanf(buffer, format, std::forward<Args>(args)...);


### PR DESCRIPTION
A compilation error showed up when using VS2022 in debug mode.

(note that it was working fine with VS2019)

I believe that we already encountered this error in that past:

```
template<typename... Args> static int Sscanf_safe(const char* const buffer, const char* const format, Args&&... args) {
// NOTE: When we use C++17 this can be string_view and become a static_assert
// The lambda is because of a compiler error with just the straight expression. It does not seem to like the temporary variable in the template.
BeAssert([](const char* const format) {return (std::string::npos == std::string(format).find("%s") && "%s is unsafe, do not use sscanf for that purpose");}(format));
// ...
}
```

The error is a bit obscure, and seems to occur when calling std::string.find() inside a template function declared in a class that extends std::string, here is a skimmed down version that I used to reproduce the error:

```
struct Test : std::string
{
    template<typename T> static bool test(char* buffer) {
      return std::string(buffer).find("%s") == std::string::npos;
    }
};
> error C2064: term does not evaluate to a function taking 1 arguments
```
strangely, this works fine:
```
struct Test : std::string
{
    template<typename T> static bool test(char* buffer) {
      auto result = std::string(buffer).find("%s");
      return result == std::string::npos;
    }
};

```

We could in theory fix the assert lambda in WString::Sscanf_safe() to declare the std::string.find() results on a separate line, but this seems to me like a patch on top of an patch, and the string_view method is easier to read and understand.

I propose to fix it by using non-lambda assert using string_view, as suggested in the original code, the use of string_view is conditional to the C++ version >= 17, it will fallback to previous behavior otherwise.



