### PR TITLE
Ignore current latest evolution test runner which will be replaced by a new one

### DIFF
--- a/iModelCore/iModelPlatform/Tests/DgnProject/Compatibility/CompatibilityRunner/PullNugets.py
+++ b/iModelCore/iModelPlatform/Tests/DgnProject/Compatibility/CompatibilityRunner/PullNugets.py
@@ -63,7 +63,7 @@ def pullAllNugets(path, pathToNugetPuller, name, minimumVersion=None, ignoreVers
         # ignore versions older than the passed minimum or if in the ignore set (until they have been deleted from the nuget server)
         if (minimumVersion and LooseVersion(v) < LooseVersion(minimumVersion)) or (ignoreVersionsSet and v in ignoreVersionsSet):
             continue
-        # Dowload and save all versions
+        # Download and save all versions
         localDir = path
         DownloadPackage(address, name, v, localDir, nugetSource.GetAuthenticationHeader(), packageObj)
 
@@ -142,9 +142,9 @@ def main():
     imodel02MinimumNugetVersion = "2019.2.2.1"
     imodel02IgnoreNugetVersions = {"2019.4.20.1"}
 
-    # Profile version upgrade 2.0.0.5_4.0.0.3_3.1.0.2
+    # Profile version upgrade 2.0.0.6_4.0.0.4_3.1.0.2
     imodelNativeMinimumNugetVersion = "2023.3.28.3"
-    imodelNativeIgnoreNugetVersions = {"2023.1.23.4", "2023.2.1.2", "2023.3.7.4"}
+    imodelNativeIgnoreNugetVersions = {"2023.1.23.4", "2023.2.1.2", "2023.3.7.4", "2023.10.24.2"}
 
     # The current EC3.3 tests won't work because they need to have the latest version of the CoreCA schema.
     # ec33MinimumNugetVersion = "2019.4.1.1"


### PR DESCRIPTION
We're releasing the new BisCore 1.0.17 soon which will be import restricted to the upcoming 4.0.0.5 ECDb profile version.

New evolution and ECDb tests have been added to main to test the read/write compatibility of older test files.
Before we increment the ECDb profile version, we need to replace the current latest imodel native evolution test runner with a new one which contain these tests.

We can't have both the old and new test runner as the time taken to pull each nuget is significant and will increase the turnaround time for builds.

This PR is the first step of ignoring the current latest test runner.

@naveedkhan8067 