### PR TITLE
Bump `itwinjs-core` dependency version and clean up logging workaround

### DIFF
--- a/iModelJsNodeAddon/api_package/ts/package-lock.json
+++ b/iModelJsNodeAddon/api_package/ts/package-lock.json
@@ -8,10 +8,10 @@
       "name": "imodeljs-native-typescript-api",
       "version": "0.0.1",
       "devDependencies": {
-        "@itwin/build-tools": "^4.2.0-dev.34",
-        "@itwin/core-bentley": "rc",
-        "@itwin/core-common": "^4.2.0-dev.34",
-        "@itwin/core-geometry": "^4.2.0-dev.34",
+        "@itwin/build-tools": "^4.5.0-dev.29",
+        "@itwin/core-bentley": "^4.5.0-dev.29",
+        "@itwin/core-common": "^4.5.0-dev.29",
+        "@itwin/core-geometry": "^4.5.0-dev.29",
         "@itwin/eslint-plugin": "^3.7.0-dev.8",
         "@types/chai": "^4.3.6",
         "@types/chai-as-promised": "^7.1.6",
@@ -30,7 +30,7 @@
         "typescript": "^4.9.5"
       },
       "engines": {
-        "node": ">=10.11.0 <17.0"
+        "node": ">=18.0 <21.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -248,9 +248,9 @@
       "dev": true
     },
     "node_modules/@itwin/build-tools": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@itwin/build-tools/-/build-tools-4.4.2.tgz",
-      "integrity": "sha512-9KOGg6NSxMTe2U+fhW2CS9JO31zD2u/ZYSXSwYf2B6VEyq8GR1QmDDOKmGPUaNFkAk/asGzeT0Ob3oq4YJv5jg==",
+      "version": "4.5.0-dev.29",
+      "resolved": "https://registry.npmjs.org/@itwin/build-tools/-/build-tools-4.5.0-dev.29.tgz",
+      "integrity": "sha512-tiIj8rllJA7NlqEoD3W3GT9307TpPE1iITCpR/sjroKu8pXzNQh5QH05oAdfbHLwZdIgxgc8dM7nS9Nu+XpliQ==",
       "dev": true,
       "dependencies": {
         "@microsoft/api-extractor": "~7.36.4",
@@ -302,32 +302,32 @@
       }
     },
     "node_modules/@itwin/core-bentley": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@itwin/core-bentley/-/core-bentley-4.4.2.tgz",
-      "integrity": "sha512-tRlmgugkQhamTkYQiYrh09R78EknppHwN6lACf+IVtdbKZSF+taTC2Qda+h7XtxPs9w6FYnFlnZtpx0Ftoaqsg==",
+      "version": "4.5.0-dev.29",
+      "resolved": "https://registry.npmjs.org/@itwin/core-bentley/-/core-bentley-4.5.0-dev.29.tgz",
+      "integrity": "sha512-JyQouLGb17nE66ewBODHV5IfJ8lkAjqrJpT5LD7tfDY9CURYoAHSsaLNDb0Pnp1IN3Ae5IVWo+Cgp8mgjdcBXw==",
       "dev": true
     },
     "node_modules/@itwin/core-common": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@itwin/core-common/-/core-common-4.4.2.tgz",
-      "integrity": "sha512-ujDMXlVPCgGKVWPXXkpPw6A/W8exJm3NsPc3w8d7wmeQivvXIZqWr6Zv+wfN9PToYHcmiK5gNQmUl5YOBaqlDA==",
+      "version": "4.5.0-dev.29",
+      "resolved": "https://registry.npmjs.org/@itwin/core-common/-/core-common-4.5.0-dev.29.tgz",
+      "integrity": "sha512-gYYvEF72jDJEgn8B0EqmUGkpgtFjwMaTbHudLFZ70dnU3Vzmnd9SaqunJ+9iIbafypAbOm/oUkk++28zDKmGrQ==",
       "dev": true,
       "dependencies": {
         "flatbuffers": "~1.12.0",
         "js-base64": "^3.6.1"
       },
       "peerDependencies": {
-        "@itwin/core-bentley": "^4.4.2",
-        "@itwin/core-geometry": "^4.4.2"
+        "@itwin/core-bentley": "^4.5.0-dev.29",
+        "@itwin/core-geometry": "^4.5.0-dev.29"
       }
     },
     "node_modules/@itwin/core-geometry": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@itwin/core-geometry/-/core-geometry-4.4.2.tgz",
-      "integrity": "sha512-Hff/XyU1sz2ZfqDMOB6Z58w2aDjBVWZj0UB4SM73by/ZdhMKK38WAiT+1wC7GRGMCSL+R/kLy68DuQ27X2pbeQ==",
+      "version": "4.5.0-dev.29",
+      "resolved": "https://registry.npmjs.org/@itwin/core-geometry/-/core-geometry-4.5.0-dev.29.tgz",
+      "integrity": "sha512-Heq8+a4H+gH9lmNu4GbMgTpa72X7C8xTWA22Xqzu2tzQ37+Jz1Oku7Ids6qVNUGCdKc2LqW06YjbwD9N4fGZZg==",
       "dev": true,
       "dependencies": {
-        "@itwin/core-bentley": "4.4.2",
+        "@itwin/core-bentley": "4.5.0-dev.29",
         "flatbuffers": "~1.12.0"
       }
     },
@@ -2615,20 +2615,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",

--- a/iModelJsNodeAddon/api_package/ts/package.json
+++ b/iModelJsNodeAddon/api_package/ts/package.json
@@ -4,7 +4,7 @@
   "description": "TypeScript API of imodeljs-native",
   "private": true,
   "engines": {
-    "node": ">=10.11.0 <17.0"
+    "node": ">=18.0 <21.0"
   },
   "scripts": {
     "build": "tsc 1>&2",
@@ -16,10 +16,10 @@
     "test": "node ./lib/test/index.js"
   },
   "devDependencies": {
-    "@itwin/build-tools": "^4.2.0-dev.34",
-    "@itwin/core-bentley": "rc",
-    "@itwin/core-common": "^4.2.0-dev.34",
-    "@itwin/core-geometry": "^4.2.0-dev.34",
+    "@itwin/build-tools": "^4.5.0-dev.29",
+    "@itwin/core-bentley": "^4.5.0-dev.29",
+    "@itwin/core-common": "^4.5.0-dev.29",
+    "@itwin/core-geometry": "^4.5.0-dev.29",
     "@itwin/eslint-plugin": "^3.7.0-dev.8",
     "@types/chai": "^4.3.6",
     "@types/chai-as-promised": "^7.1.6",

--- a/iModelJsNodeAddon/api_package/ts/src/test/index.ts
+++ b/iModelJsNodeAddon/api_package/ts/src/test/index.ts
@@ -36,23 +36,7 @@ chaiuse(chaiAsPromised);
 
 Logger.initializeToConsole();
 Logger.setLevelDefault(LogLevel.Error);
-iModelJsNative.logger = {
-  // note: using private Logger fields is temporary until the version of `@itwin/core-bentley` is updated
-  // to a version where Logger has them public
-  get minLevel() {
-    return (Logger as any)._minLevel;
-  },
-  get categoryFilter() {
-    return [...((Logger as any)._categoryFilter as Map<string, LogLevel>).entries()].reduce(
-      (categoryFilter, [categoryName, logLevel]) => ({ ...categoryFilter, [categoryName]: logLevel }),
-      {},
-    );
-  },
-  logTrace: (c, m) => Logger.logTrace(c, m),
-  logInfo: (c, m) => Logger.logInfo(c, m),
-  logWarning: (c, m) => Logger.logWarning(c, m),
-  logError: (c, m) => Logger.logError(c, m),
-};
+iModelJsNative.logger = Logger;
 
 export function openDgnDb(filename: string, upgradeOptions?: UpgradeOptions & IModelJsNative.SchemaImportOptions) {
   const db = new iModelJsNative.DgnDb();


### PR DESCRIPTION
Closes https://github.com/iTwin/imodel-native/issues/649