### PR TITLE
Presentation: Fix creating hierarchy level descriptor in specific cases

### DIFF
--- a/iModelCore/ECPresentation/Source/ECPresentation.vcxproj
+++ b/iModelCore/ECPresentation/Source/ECPresentation.vcxproj
@@ -132,6 +132,7 @@
     <ClInclude Include="ECPresentationPch.h" />
     <ClInclude Include="Hierarchies\DataSourceInfo.h" />
     <ClInclude Include="Hierarchies\HierarchiesComparer.h" />
+    <ClInclude Include="Hierarchies\HierarchiesFiltering.h" />
     <ClInclude Include="Hierarchies\NavigationQuery.h" />
     <ClInclude Include="Hierarchies\NavigationQueryBuilder.h" />
     <ClInclude Include="Hierarchies\NavigationQueryContracts.h" />
@@ -190,6 +191,7 @@
     <ClCompile Include="ECPresentationManager.cpp" />
     <ClCompile Include="ECPresentationPch.cpp" />
     <ClCompile Include="Hierarchies\HierarchiesComparer.cpp" />
+    <ClCompile Include="Hierarchies\HierarchiesFiltering.cpp" />
     <ClCompile Include="Hierarchies\NavigationQuery.cpp" />
     <ClCompile Include="Hierarchies\NavigationQueryBuilder.cpp" />
     <ClCompile Include="Hierarchies\NavigationQueryContracts.cpp" />

--- a/iModelCore/ECPresentation/Source/ECPresentation.vcxproj.filters
+++ b/iModelCore/ECPresentation/Source/ECPresentation.vcxproj.filters
@@ -399,6 +399,9 @@
     <ClInclude Include="..\PublicAPI\ECPresentation\PresentationQuery.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Hierarchies\HierarchiesFiltering.h">
+      <Filter>Source Files\Hierarchies</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Connection.cpp">
@@ -697,6 +700,9 @@
     </ClCompile>
     <ClCompile Include="Content\ContentHelpers.cpp">
       <Filter>Source Files\Content</Filter>
+    </ClCompile>
+    <ClCompile Include="Hierarchies\HierarchiesFiltering.cpp">
+      <Filter>Source Files\Hierarchies</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/iModelCore/ECPresentation/Source/Hierarchies/HierarchiesFiltering.cpp
+++ b/iModelCore/ECPresentation/Source/Hierarchies/HierarchiesFiltering.cpp
@@ -255,12 +255,30 @@ public:
     bool DidFindAnyUnfilterableSpecifications() const {return m_hasIssues;}
 };
 
+/*=================================================================================**//**
+* @bsiclass
++===============+===============+===============+===============+===============+======*/
+struct VisitedSpecsTracker
+{
+private:
+    bset<ChildNodeSpecificationCP>& m_specs;
+    ChildNodeSpecificationCR m_spec;
+public:
+    VisitedSpecsTracker(bset<ChildNodeSpecificationCP>& specs, ChildNodeSpecificationCR spec)
+        : m_specs(specs), m_spec(spec)
+        {
+        m_specs.insert(&m_spec);
+        }
+    ~VisitedSpecsTracker()
+        {
+        m_specs.erase(&m_spec);
+        }
+};
+
 #define ENSURE_NOT_VISITED(set, specCR) \
-    { \
     if (set.end() != set.find(&specCR)) \
         return; \
-    set.insert(&specCR); \
-    }
+    VisitedSpecsTracker _track_specification(set, specCR); \
 
 /*=================================================================================**//**
 * @bsiclass

--- a/iModelCore/ECPresentation/Source/Hierarchies/HierarchiesFiltering.cpp
+++ b/iModelCore/ECPresentation/Source/Hierarchies/HierarchiesFiltering.cpp
@@ -93,15 +93,35 @@ static bvector<ECClassCP> GetRelationshipPathTargetClasses(RepeatableRelationshi
 static void TraverseChildNodeSpecifications(
     PresentationRuleSpecificationVisitorR visitor,
     CustomNodeSpecificationCR specification,
-    TraverseHierarchyRulesProps const& props
+    TraverseHierarchyRulesProps const& props,
+    std::function<void(NavNodeCP)> const& onParentNodeOverride = [](NavNodeCP){}
 )
     {
     auto fakeParentNode = props.GetNodesFactory().CreateCustomNode(props.GetSchemaHelper().GetConnection(), specification.GetHash(), nullptr,
         *LabelDefinition::FromString(specification.GetLabel().c_str()), specification.GetDescription().c_str(), specification.GetImageId().c_str(),
         specification.GetNodeType().c_str(), nullptr);
+    onParentNodeOverride(fakeParentNode.get());
     auto childSpecs = GetDirectChildNodeSpecifications(fakeParentNode.get(), props.GetRulesPreprocessor());
     for (auto const& childSpec : childSpecs)
         childSpec->Accept(visitor);
+    onParentNodeOverride(nullptr);
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+static NavNodeCPtr CreateFakeInstanceNode(
+    TraverseHierarchyRulesProps const& props,
+    Utf8StringCR specificationHash,
+    ECClassId classId,
+    NavNodeCP parentNode
+)
+    {
+    auto node = props.GetNodesFactory().CreateECInstanceNode(props.GetSchemaHelper().GetConnection(), 
+        specificationHash, nullptr, classId, ECInstanceId(), *LabelDefinition::Create());
+    if (parentNode)
+        NavNodeExtendedData(*node).SetVirtualParentIds({ parentNode->GetNodeId() });
+    return node;
     }
 
 /*---------------------------------------------------------------------------------**//**
@@ -110,17 +130,21 @@ static void TraverseChildNodeSpecifications(
 static void TraverseChildNodeSpecifications(
     PresentationRuleSpecificationVisitorR visitor,
     InstanceNodesOfSpecificClassesSpecificationCR specification,
-    TraverseHierarchyRulesProps const& props
+    TraverseHierarchyRulesProps const& props,
+    NavNodeCP parentNode = nullptr,
+    std::function<void(NavNodeCP)> const& onParentNodeOverride = [](NavNodeCP){}
 )
     {
     auto targetClasses = props.GetSchemaHelper().GetECClassesFromClassList(specification.GetClasses(), false);
-    auto fakeParentNodes = ContainerHelpers::TransformContainer<bvector<NavNodeCPtr>>(targetClasses, [&](auto const& targetClass)
+    for (auto const& targetClass : targetClasses)
         {
-        return props.GetNodesFactory().CreateECInstanceNode(props.GetSchemaHelper().GetConnection(), specification.GetHash(), nullptr, targetClass.GetClass().GetId(), ECInstanceId(), *LabelDefinition::Create());
-        });
-    auto childSpecs = GetDirectChildNodeSpecifications(fakeParentNodes, props.GetRulesPreprocessor());
-    for (auto const& childSpec : childSpecs)
-        childSpec->Accept(visitor);
+        auto fakeParentNode = CreateFakeInstanceNode(props, specification.GetHash(), targetClass.GetClass().GetId(), parentNode);
+        onParentNodeOverride(fakeParentNode.get());
+        auto childSpecs = GetDirectChildNodeSpecifications({ fakeParentNode }, props.GetRulesPreprocessor());
+        for (auto const& childSpec : childSpecs)
+            childSpec->Accept(visitor);
+        }
+    onParentNodeOverride(nullptr);
     }
 
 /*---------------------------------------------------------------------------------**//**
@@ -130,17 +154,21 @@ static void TraverseChildNodeSpecifications(
     PresentationRuleSpecificationVisitorR visitor,
     RelatedInstanceNodesSpecificationCR specification,
     RepeatableRelationshipPathSpecification const& pathSpecification,
-    TraverseHierarchyRulesProps const& props
+    TraverseHierarchyRulesProps const& props,
+    NavNodeCP parentNode = nullptr,
+    std::function<void(NavNodeCP)> const& onParentNodeOverride = [](NavNodeCP){}
 )
     {
     auto targetClasses = GetRelationshipPathTargetClasses(pathSpecification, props.GetSchemaHelper());
-    auto fakeParentNodes = ContainerHelpers::TransformContainer<bvector<NavNodeCPtr>>(targetClasses, [&](auto const& targetClass)
+    for (auto const& targetClass : targetClasses)
         {
-        return props.GetNodesFactory().CreateECInstanceNode(props.GetSchemaHelper().GetConnection(), specification.GetHash(), nullptr, targetClass->GetId(), ECInstanceId(), *LabelDefinition::Create());
-        });
-    auto childSpecs = GetDirectChildNodeSpecifications(fakeParentNodes, props.GetRulesPreprocessor());
-    for (auto const& childSpec : childSpecs)
-        childSpec->Accept(visitor);
+        auto fakeParentNode = CreateFakeInstanceNode(props, specification.GetHash(), targetClass->GetId(), parentNode);
+        onParentNodeOverride(fakeParentNode.get());
+        auto childSpecs = GetDirectChildNodeSpecifications({ fakeParentNode }, props.GetRulesPreprocessor());
+        for (auto const& childSpec : childSpecs)
+            childSpec->Accept(visitor);
+        }
+    onParentNodeOverride(nullptr);
     }
 
 /*---------------------------------------------------------------------------------**//**
@@ -149,17 +177,21 @@ static void TraverseChildNodeSpecifications(
 static void TraverseChildNodeSpecifications(
     PresentationRuleSpecificationVisitorR visitor,
     SearchResultInstanceNodesSpecificationCR specification,
-    TraverseHierarchyRulesProps const& props
+    TraverseHierarchyRulesProps const& props,
+    NavNodeCP parentNode = nullptr,
+    std::function<void(NavNodeCP)> const& onParentNodeOverride = [](NavNodeCP){}
 )
     {
     auto queryClasses = GetQuerySpecificationClasses(specification, props.GetSchemaHelper());
-    auto fakeParentNodes = ContainerHelpers::TransformContainer<bvector<NavNodeCPtr>>(queryClasses, [&](auto const& queryClass)
+    for (auto const& queryClass : queryClasses)
         {
-        return props.GetNodesFactory().CreateECInstanceNode(props.GetSchemaHelper().GetConnection(), specification.GetHash(), nullptr, queryClass->GetId(), ECInstanceId(), *LabelDefinition::Create());
-        });
-    auto childSpecs = GetDirectChildNodeSpecifications(fakeParentNodes, props.GetRulesPreprocessor());
-    for (auto const& childSpec : childSpecs)
-        childSpec->Accept(visitor);
+        auto fakeParentNode = CreateFakeInstanceNode(props, specification.GetHash(), queryClass->GetId(), parentNode);
+        onParentNodeOverride(fakeParentNode.get());
+        auto childSpecs = GetDirectChildNodeSpecifications({ fakeParentNode }, props.GetRulesPreprocessor());
+        for (auto const& childSpec : childSpecs)
+            childSpec->Accept(visitor);
+        }
+    onParentNodeOverride(nullptr);
     }
 
 #define REPORT_ISSUE(issue) \
@@ -380,6 +412,7 @@ struct HierarchySpecsToContentRulesetConverter : PresentationRuleSpecificationVi
 private:
     TraverseHierarchyRulesProps const& m_props;
     NavNodeCP m_parentNode;
+    NavNodeCP m_parentNodeOverride;
 
     PresentationRuleSetPtr m_ruleset;
     ContentRuleP m_contentRule;
@@ -413,6 +446,11 @@ private:
     * @bsimethod
     +---------------+---------------+---------------+---------------+---------------+------*/
     bool IsParentGroupingNode() const {return m_parentNode && m_parentNode->GetKey()->AsGroupingNodeKey();}
+
+    /*---------------------------------------------------------------------------------**//**
+    * @bsimethod
+    +---------------+---------------+---------------+---------------+---------------+------*/
+    NavNodeCP GetParentNode() const {return m_parentNodeOverride ? m_parentNodeOverride : m_parentNode;}
 
     /*---------------------------------------------------------------------------------**//**
     * @bsimethod
@@ -477,7 +515,7 @@ protected:
         if (specification.GetHideNodesInHierarchy())
             {
             ChainedSpecificationsContext chained(*this, specification);
-            TraverseChildNodeSpecifications(*this, specification, m_props);
+            TraverseChildNodeSpecifications(*this, specification, m_props, GetParentNode(), [&](NavNodeCP ovr){m_parentNodeOverride = ovr; });
             return;
             }
 
@@ -488,8 +526,8 @@ protected:
             }
 
         // acquire information for handling `parent` symbols in instance filter
-        NavNodeCPtr parentInstanceNode = m_parentNode
-            ? HierarchiesInstanceFilteringHelper::GetParentInstanceNode(m_props.GetNodesCache(), *m_parentNode)
+        NavNodeCPtr parentInstanceNode = GetParentNode()
+            ? HierarchiesInstanceFilteringHelper::GetParentInstanceNode(m_props.GetNodesCache(), *GetParentNode())
             : nullptr;
         auto parentInstanceFilteringInfo = HierarchiesInstanceFilteringHelper::CreateParentInstanceFilteringInfo(m_props.GetNodesCache(),
             parentInstanceNode.get(), specification.GetInstanceFilter());
@@ -541,7 +579,7 @@ protected:
             for (auto const& pathSpec : specification.GetRelationshipPaths())
                 {
                 ChainedSpecificationsContext chained(*this, specification, *pathSpec);
-                TraverseChildNodeSpecifications(*this, specification, *pathSpec, m_props);
+                TraverseChildNodeSpecifications(*this, specification, *pathSpec, m_props, GetParentNode(), [&](NavNodeCP ovr){m_parentNodeOverride = ovr;});
                 }
             return;
             }
@@ -604,8 +642,8 @@ protected:
             );
 
         // acquire information for handling `parent` symbols in instance filter
-        NavNodeCPtr parentInstanceNode = m_parentNode
-            ? HierarchiesInstanceFilteringHelper::GetParentInstanceNode(m_props.GetNodesCache(), *m_parentNode)
+        NavNodeCPtr parentInstanceNode = GetParentNode()
+            ? HierarchiesInstanceFilteringHelper::GetParentInstanceNode(m_props.GetNodesCache(), *GetParentNode())
             : nullptr;
         auto parentInstanceFilteringInfo = HierarchiesInstanceFilteringHelper::CreateParentInstanceFilteringInfo(m_props.GetNodesCache(),
             parentInstanceNode.get(), specification.GetInstanceFilter());
@@ -636,7 +674,7 @@ protected:
         if (specification.GetHideNodesInHierarchy())
             {
             ChainedSpecificationsContext chained(*this, specification);
-            TraverseChildNodeSpecifications(*this, specification, m_props);
+            TraverseChildNodeSpecifications(*this, specification, m_props, GetParentNode(), [&](NavNodeCP ovr){m_parentNodeOverride = ovr;});
             return;
             }
 
@@ -670,7 +708,8 @@ public:
     * @bsimethod
     +---------------+---------------+---------------+---------------+---------------+------*/
     HierarchySpecsToContentRulesetConverter(TraverseHierarchyRulesProps const& props, NavNodeCP parentNode)
-        : m_contentRule(nullptr), m_props(props), m_inputReset(false), m_parentNode(parentNode), m_didAddSelectedNodeInstancesSpec(false)
+        : m_contentRule(nullptr), m_props(props), m_inputReset(false), m_parentNode(parentNode), m_parentNodeOverride(nullptr),
+        m_didAddSelectedNodeInstancesSpec(false)
         {}
 
     /*---------------------------------------------------------------------------------**//**

--- a/iModelCore/ECPresentation/Source/Hierarchies/NavNodesHelper.cpp
+++ b/iModelCore/ECPresentation/Source/Hierarchies/NavNodesHelper.cpp
@@ -351,7 +351,7 @@ static bvector<ECInstanceId> GetInstanceIdsWithClass(bvector<ECClassInstanceKey>
     bvector<ECInstanceId> ids;
     for (ECClassInstanceKeyCR key : keys)
         {
-        if (key.GetClass() == &ecClass)
+        if (key.GetClass() == &ecClass && key.GetId().IsValid())
             ids.push_back(key.GetId());
         }
     return ids;

--- a/iModelCore/ECPresentation/Tests/NonPublished/Integration/Hierarchies/Hierarchies_InstanceFiltering.cpp
+++ b/iModelCore/ECPresentation/Tests/NonPublished/Integration/Hierarchies/Hierarchies_InstanceFiltering.cpp
@@ -634,6 +634,85 @@ TEST_F(RulesDrivenECPresentationManagerNavigationTests, InstanceFiltering_Filter
 /*---------------------------------------------------------------------------------**//**
 * @bsitest
 +---------------+---------------+---------------+---------------+---------------+------*/
+DEFINE_SCHEMA(InstanceFiltering_FiltersWithInstanceNodesOfSpecificClassesSpecification_WhenFilterUsesParentSymbolAndParentLevelIsHidden, R"*(
+    <ECEntityClass typeName="A">
+        <ECProperty propertyName="PropA" typeName="int" />
+    </ECEntityClass>
+    <ECEntityClass typeName="B">
+        <ECProperty propertyName="PropB" typeName="int" />
+    </ECEntityClass>
+    <ECEntityClass typeName="C">
+        <ECProperty propertyName="PropC" typeName="int" />
+    </ECEntityClass>
+)*");
+TEST_F(RulesDrivenECPresentationManagerNavigationTests, InstanceFiltering_FiltersWithInstanceNodesOfSpecificClassesSpecification_WhenFilterUsesParentSymbolAndParentLevelIsHidden)
+    {
+    // dataset
+    ECClassCP classA = GetClass("A");
+    ECClassCP classB = GetClass("B");
+    ECClassCP classC = GetClass("C");
+
+    IECInstancePtr a = RulesEngineTestHelpers::InsertInstance(s_project->GetECDb(), *classA, [](IECInstanceR instance){instance.SetValue("PropA", ECValue(1)); });
+    IECInstancePtr b = RulesEngineTestHelpers::InsertInstance(s_project->GetECDb(), *classB, [](IECInstanceR instance){instance.SetValue("PropB", ECValue(2)); });
+    IECInstancePtr c1 = RulesEngineTestHelpers::InsertInstance(s_project->GetECDb(), *classC, [](IECInstanceR instance){instance.SetValue("PropC", ECValue(3)); });
+    IECInstancePtr c2 = RulesEngineTestHelpers::InsertInstance(s_project->GetECDb(), *classC, [](IECInstanceR instance){instance.SetValue("PropC", ECValue(4)); });
+
+    // ruleset
+    PresentationRuleSetPtr rules = PresentationRuleSet::CreateInstance(BeTest::GetNameOfCurrentTest());
+    m_locater->AddRuleSet(*rules);
+
+    auto ruleA = new RootNodeRule();
+    ruleA->AddSpecification(*new InstanceNodesOfSpecificClassesSpecification(1, ChildrenHint::Unknown, false, false, false, false, "",
+        {
+        new MultiSchemaClass(classA->GetSchema().GetName(), true, bvector<Utf8String>{ classA->GetName() })
+        }, {}));
+    rules->AddPresentationRule(*ruleA);
+
+    auto ruleB = new ChildNodeRule(Utf8PrintfString("ParentNode.IsOfClass(\"%s\", \"%s\")", classA->GetName().c_str(), classA->GetSchema().GetName().c_str()), 1, false);
+    ruleB->AddSpecification(*new InstanceNodesOfSpecificClassesSpecification(1, ChildrenHint::Unknown, true, false, false, false, "",
+        {
+        new MultiSchemaClass(classB->GetSchema().GetName(), true, bvector<Utf8String>{ classB->GetName() })
+        }, {}));
+    rules->AddPresentationRule(*ruleB);
+
+    auto ruleC = new ChildNodeRule(Utf8PrintfString("ParentNode.IsOfClass(\"%s\", \"%s\")", classB->GetName().c_str(), classB->GetSchema().GetName().c_str()), 1, false);
+    ruleC->AddSpecification(*new InstanceNodesOfSpecificClassesSpecification(1, ChildrenHint::Unknown, false, false, false, false,
+        "parent.PropB = 2 AND parent.parent.PropA = 1",
+        {
+        new MultiSchemaClass(classC->GetSchema().GetName(), true, bvector<Utf8String>{ classC->GetName() })
+        }, {}));
+    rules->AddPresentationRule(*ruleC);
+
+    // verify without instance filter
+    auto params = AsyncHierarchyRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables());
+    auto hierarchy = ValidateHierarchy(params,
+        {
+        ExpectedHierarchyDef(CreateInstanceNodeValidator({ a }),
+            ExpectedHierarchyListDef(true,
+                {
+                CreateInstanceNodeValidator({ c1 }),
+                CreateInstanceNodeValidator({ c2 }),
+                })),
+        });
+
+    // validate hierarchy level filter descriptor
+    params.SetParentNode(hierarchy[0].node.get());
+    ValidateHierarchyLevelDescriptor(*m_manager, params, CreateDescriptorValidator(
+        {
+        CreatePropertiesFieldValidator(*classC->GetPropertyP("PropC")),
+        }));
+
+    // verify with instance filter
+    params.SetInstanceFilter(std::make_unique<InstanceFilterDefinition>("this.PropC = 4"));
+    ValidateHierarchy(params,
+        {
+        CreateInstanceNodeValidator({ c2 }),
+        });
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* @bsitest
++---------------+---------------+---------------+---------------+---------------+------*/
 DEFINE_SCHEMA(InstanceFiltering_FiltersWithRelatedInstanceNodesSpecification, R"*(
     <ECEntityClass typeName="A" />
     <ECEntityClass typeName="B">


### PR DESCRIPTION
Fixes https://github.com/iTwin/imodel-native/issues/669.

Found & fixed two problems:

1. We have 2 specifications that return child Subjects - one that returns hidden nodes and one that returns visible ones. When traversing through the hidden nodes spec, we find the same two specifications for children level. Those specs are visited and added to visited specs list, but don't contribute to the resulting descriptor. Then, when visiting the specification that contributes to the resulting descriptor, we find it in the visited specs list and don't process it. This was causing Subject class to not be included in the descriptor.

2. The specification that loads Model nodes uses a `parent` ECExpression symbol to join itself to the parent Subject. However, if the parent Subjects level is hidden, we were joining to the wrong instance. This was causing Model class to not be included in the descriptor.