### PR TITLE
Improve performance of drop schema

### DIFF
--- a/iModelCore/ECDb/Tests/NonPublished/SchemaUpgradeTests.cpp
+++ b/iModelCore/ECDb/Tests/NonPublished/SchemaUpgradeTests.cpp
@@ -587,6 +587,40 @@ TEST_F(SchemaUpgradeTestFixture, DeleteSchema) {
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //+---------------+---------------+---------------+---------------+---------------+------
+// TEST_F(SchemaUpgradeTestFixture, DropSchemaPerformance) {
+//     ECDb db;
+//     db.OpenBeSQLiteDb("D:/temp/TRU.bim", Db::OpenParams(Db::OpenMode::ReadWrite));
+//     auto getDynamicSchemas = [&]() {
+//         std::vector<std::string> list;
+//         Statement stmt;
+//         stmt.Prepare(db, R"(
+//         SELECT
+//             [ss].[Name]
+//         FROM   [ec_Schema] [ss]
+//             JOIN [ec_CustomAttribute] [ca] ON [ca].[ContainerId] = [ss].[Id]
+//             JOIN [ec_Class] [cc] ON [cc].[Id] = [ca].[ClassId]
+//             JOIN [ec_Schema] [sa] ON [sa].[Id] = [cc].[SchemaId]
+//         WHERE  [cc].[Name] = 'DynamicSchema'
+//                 AND [sa].[Name] = 'CoreCustomAttributes'
+//                 AND [ca].[ContainerType] = 1
+//         ORDER  BY [ss].Id DESC)");
+//         while (stmt.Step() == BE_SQLITE_ROW)
+//             list.push_back(stmt.GetValueText(0));
+//         return list;
+//     };
+//     auto schemas = getDynamicSchemas();
+//     StopWatch w1(true);
+//     for (int i = 0; i< schemas.size(); ++i) {
+//         StopWatch w2(true);
+//         printf("[%d/%d] Dropping schemas: %s ", i, (int)schemas.size(), schemas[i].c_str());
+//         db.Schemas().DropSchema(schemas[i]);
+//         printf("(%0.2f sec) total: %0.2f sec\n", w2.GetCurrentSeconds(), w1.GetCurrentSeconds());
+//     }
+//     db.AbandonChanges();
+// }
+//---------------------------------------------------------------------------------------
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+------
 TEST_F(SchemaUpgradeTestFixture, DeleteSchema_InstanceFinder) {
     Utf8CP schemaXml =
         "<?xml version='1.0' encoding='utf-8'?>"


### PR DESCRIPTION
Dropping a very large number of schemas takes a very long time. With a specific iModel dropping `922` schemas takes 1 hour and 25 minutes. 

Most of the time is spent trying to figure out if the schema has an instance or has FK references.

To improve performance the check now limits the instance search to specific schema classes previously it used root relationships and classes to search for instances. This causes unrelated relationships to be searched for schema classes that are going to be dropped. 

This improvement for the given data set brings overall time to 15 min from over an hour. 


