### PR TITLE
Presentation: Fix a memory leak

### DIFF
--- a/iModelCore/ECPresentation/PublicAPI/ECPresentation/ECPresentationManager.h
+++ b/iModelCore/ECPresentation/PublicAPI/ECPresentation/ECPresentationManager.h
@@ -257,9 +257,9 @@ struct ECPresentationManager : public NonCopyableClass
         CachingParams m_cachingParams;
         MultiThreadingParams m_multiThreadingParams;
         ContentCachingParams m_contentCachingParams;
-        IJsonLocalState* m_localState;
-        IECPropertyFormatter const* m_propertyFormatter;
-        IPropertyCategorySupplier const* m_categorySupplier;
+        std::shared_ptr<IJsonLocalState> m_localState;
+        std::shared_ptr<IECPropertyFormatter const> m_propertyFormatter;
+        std::shared_ptr<IPropertyCategorySupplier const> m_categorySupplier;
         bvector<std::shared_ptr<ECInstanceChangeEventSource>> m_ecInstanceChangeEventSources;
         bvector<std::shared_ptr<IUpdateRecordsHandler>> m_updateRecordsHandlers;
     public:
@@ -284,12 +284,12 @@ struct ECPresentationManager : public NonCopyableClass
         void SetConnections(std::shared_ptr<IConnectionManager> connections) {m_connections = connections;}
         std::shared_ptr<IConnectionManager> GetConnections() const {return m_connections;}
 
-        IJsonLocalState* GetLocalState() const {return m_localState;}
-        void SetLocalState(IJsonLocalState* localState) {m_localState = localState;}
-        IECPropertyFormatter const* GetECPropertyFormatter() const {return m_propertyFormatter;}
-        void SetECPropertyFormatter(IECPropertyFormatter const* formatter) {m_propertyFormatter = formatter;}
-        IPropertyCategorySupplier const* GetCategorySupplier() const {return m_categorySupplier;}
-        void SetCategorySupplier(IPropertyCategorySupplier const* supplier) {m_categorySupplier = supplier;}
+        std::shared_ptr<IJsonLocalState> GetLocalState() const {return m_localState;}
+        void SetLocalState(std::shared_ptr<IJsonLocalState> localState) {m_localState = localState;}
+        std::shared_ptr<IECPropertyFormatter const> GetECPropertyFormatter() const {return m_propertyFormatter;}
+        void SetECPropertyFormatter(std::shared_ptr<IECPropertyFormatter const> formatter) {m_propertyFormatter = formatter;}
+        std::shared_ptr<IPropertyCategorySupplier const> GetCategorySupplier() const {return m_categorySupplier;}
+        void SetCategorySupplier(std::shared_ptr<IPropertyCategorySupplier const> supplier) {m_categorySupplier = supplier;}
         bvector<std::shared_ptr<ECInstanceChangeEventSource>> const& GetECInstanceChangeEventSources() const {return m_ecInstanceChangeEventSources;}
         void SetECInstanceChangeEventSources(bvector<std::shared_ptr<ECInstanceChangeEventSource>> sources) {m_ecInstanceChangeEventSources = sources;}
         bvector<std::shared_ptr<IUpdateRecordsHandler>> const& GetUpdateRecordsHandlers() const {return m_updateRecordsHandlers;}

--- a/iModelCore/ECPresentation/PublicAPI/ECPresentation/ECPresentationTypes.h
+++ b/iModelCore/ECPresentation/PublicAPI/ECPresentation/ECPresentationTypes.h
@@ -589,6 +589,7 @@ protected:
     virtual void _SaveValue(Utf8CP nameSpace, Utf8CP key, BeJsConst value) = 0;
     virtual BeJsDocument _GetValue(Utf8CP nameSpace, Utf8CP key) const { return BeJsDocument(); };
 public:
+    virtual ~IJsonLocalState() {}
     void SaveValue(Utf8CP nameSpace, Utf8CP key, BeJsConst value) { _SaveValue(nameSpace, key, value); }
     BeJsDocument GetValue(Utf8CP nameSpace, Utf8CP key) const { return _GetValue(nameSpace, key); }
 };
@@ -603,7 +604,7 @@ private:
 
 protected:
     virtual void _SaveValue(Utf8CP nameSpace, Utf8CP key, BeJsConst value) override { m_storage->SaveValue(nameSpace, key, value.Stringify()); };
-    virtual BeJsDocument _GetValue(Utf8CP nameSpace, Utf8CP key) const override 
+    virtual BeJsDocument _GetValue(Utf8CP nameSpace, Utf8CP key) const override
         {
         BeJsDocument json(m_storage->GetValue(nameSpace, key));
         return json;

--- a/iModelCore/ECPresentation/Source/PresentationManagerImpl.cpp
+++ b/iModelCore/ECPresentation/Source/PresentationManagerImpl.cpp
@@ -707,7 +707,7 @@ protected:
         NavNodesProviderContextPtr context = NavNodesProviderContext::Create(*ruleset, TargetTree_MainTree, parentNode,
             std::move(rulesetVariables), ecexpressionsCache, relatedPathsCache, *m_manager.m_nodesFactory, cache,
             *m_manager.m_nodesProviderFactory, m_manager.GetLocalState());
-        context->SetQueryContext(*m_manager.m_connections, connection, m_manager.m_usedClassesListener);
+        context->SetQueryContext(*m_manager.m_connections, connection, m_manager.m_usedClassesListener.get());
 
         if (parentNode)
             context->SetChildNodeContext(nullptr, *parentNode);
@@ -742,25 +742,25 @@ RulesDrivenECPresentationManagerImpl::RulesDrivenECPresentationManagerImpl(Param
 
     m_userSettings = params.GetUserSettings() ? params.GetUserSettings() : std::make_shared<UserSettingsManager>(params.GetPaths().GetTemporaryDirectory());
     GetUserSettingsManager().SetChangesListener(this);
-    GetUserSettingsManager().SetLocalState(m_localState);
+    GetUserSettingsManager().SetLocalState(m_localState.get());
 
     m_ecInstanceChangeEventSources = params.GetECInstanceChangeEventSources(); // need to copy this list to keep the ref counts
     for (auto const& ecInstanceChangeEventSource : m_ecInstanceChangeEventSources)
         ecInstanceChangeEventSource->RegisterEventHandler(*this);
 
-    m_customFunctions = new CustomFunctionsInjector(*m_connections);
-    m_rulesetECExpressionsCache = new RulesetECExpressionsCache();
-    m_ecdbCaches = new ECDbCaches();
-    m_nodesProviderContextFactory = new NodesProviderContextFactory(*this);
-    m_nodesProviderFactory = new NodesProviderFactory();
-    m_usedClassesListener = new UsedClassesListener(*this);
-    m_nodesFactory = new NavNodesFactory();
+    m_customFunctions = std::make_unique<CustomFunctionsInjector>(*m_connections);
+    m_rulesetECExpressionsCache = std::make_unique<RulesetECExpressionsCache>();
+    m_ecdbCaches = std::make_unique<ECDbCaches>();
+    m_nodesProviderContextFactory = std::make_unique<NodesProviderContextFactory>(*this);
+    m_nodesProviderFactory = std::make_unique<NodesProviderFactory>();
+    m_usedClassesListener = std::make_unique<UsedClassesListener>(*this);
+    m_nodesFactory = std::make_unique<NavNodesFactory>();
 
     m_nodesCachesManager = CreateCacheManager(params.GetCachingParams().GetCacheDirectoryPath(), *m_nodesFactory, *m_nodesProviderContextFactory, *m_nodesProviderFactory,
         *m_connections, params.GetCachingParams().GetCacheMode(), params.GetCachingParams().GetDiskCacheFileSizeLimit(), params.GetCachingParams().GetDiskCacheMemoryCacheSize());
-    m_contentCache = new ContentCache(params.GetContentCachingParams().GetPrivateCacheSize());
+    m_contentCache = std::make_unique<ContentCache>(params.GetContentCachingParams().GetPrivateCacheSize());
 
-    m_updateHandler = new UpdateHandler(*m_nodesCachesManager, m_contentCache, *m_connections, *m_nodesProviderContextFactory,
+    m_updateHandler = std::make_unique<UpdateHandler>(*m_nodesCachesManager, m_contentCache.get(), *m_connections, *m_nodesProviderContextFactory,
         *m_nodesProviderFactory, *m_rulesetECExpressionsCache);
     m_updateHandler->SetRecordsHandler(std::make_unique<CompositeUpdateRecordsHandler>(params.GetUpdateRecordsHandlers()));
 
@@ -799,15 +799,6 @@ RulesDrivenECPresentationManagerImpl::~RulesDrivenECPresentationManagerImpl()
     auto scope = Diagnostics::Scope::Create("Destroy manager impl");
     m_connections->DropListener(*this);
     m_connections->CloseConnections();
-    DELETE_AND_CLEAR(m_updateHandler);
-    DELETE_AND_CLEAR(m_contentCache);
-    DELETE_AND_CLEAR(m_nodesFactory);
-    DELETE_AND_CLEAR(m_usedClassesListener);
-    DELETE_AND_CLEAR(m_nodesProviderFactory);
-    DELETE_AND_CLEAR(m_nodesProviderContextFactory);
-    DELETE_AND_CLEAR(m_ecdbCaches);
-    DELETE_AND_CLEAR(m_rulesetECExpressionsCache);
-    DELETE_AND_CLEAR(m_customFunctions);
     }
 
 /*---------------------------------------------------------------------------------**//**

--- a/iModelCore/ECPresentation/Source/PresentationManagerImpl.h
+++ b/iModelCore/ECPresentation/Source/PresentationManagerImpl.h
@@ -228,22 +228,22 @@ struct RulesDrivenECPresentationManagerImpl : ECPresentationManager::Impl, ECIns
 
 private:
     std::shared_ptr<IConnectionManager> m_connections;
-    NavNodesFactory const* m_nodesFactory;
-    NodesProviderContextFactory const* m_nodesProviderContextFactory;
-    NodesProviderFactory const* m_nodesProviderFactory;
-    CustomFunctionsInjector* m_customFunctions;
+    std::unique_ptr<NavNodesFactory const> m_nodesFactory;
+    std::unique_ptr<NodesProviderContextFactory const> m_nodesProviderContextFactory;
+    std::unique_ptr<NodesProviderFactory const> m_nodesProviderFactory;
+    std::unique_ptr<CustomFunctionsInjector> m_customFunctions;
     std::unique_ptr<INodesCacheManager> m_nodesCachesManager;
-    ContentCache* m_contentCache;
-    ECDbCaches* m_ecdbCaches;
-    RulesetECExpressionsCache* m_rulesetECExpressionsCache;
-    UpdateHandler* m_updateHandler;
-    UsedClassesListener* m_usedClassesListener;
+    std::unique_ptr<ContentCache> m_contentCache;
+    std::unique_ptr<ECDbCaches> m_ecdbCaches;
+    std::unique_ptr<RulesetECExpressionsCache> m_rulesetECExpressionsCache;
+    std::unique_ptr<UpdateHandler> m_updateHandler;
+    std::unique_ptr<UsedClassesListener> m_usedClassesListener;
     bmap<Utf8String, bvector<RuleSetLocaterPtr>> m_embeddedRuleSetLocaters;
     std::shared_ptr<IRulesetLocaterManager> m_locaters;
     std::shared_ptr<IUserSettingsManager> m_userSettings;
-    IJsonLocalState* m_localState;
-    IECPropertyFormatter const* m_ecPropertyFormatter;
-    IPropertyCategorySupplier const* m_categorySupplier;
+    std::shared_ptr<IJsonLocalState> m_localState;
+    std::shared_ptr<IECPropertyFormatter const> m_ecPropertyFormatter;
+    std::shared_ptr<IPropertyCategorySupplier const> m_categorySupplier;
     bvector<std::shared_ptr<ECInstanceChangeEventSource>> m_ecInstanceChangeEventSources;
     mutable BeMutex m_mutex;
 
@@ -263,7 +263,7 @@ protected:
     IECPropertyFormatter const& _GetECPropertyFormatter() const override;
     IUserSettingsManager& _GetUserSettingsManager() const override {return *m_userSettings;}
     bvector<std::shared_ptr<ECInstanceChangeEventSource>> const& _GetECInstanceChangeEventSources() const override {return m_ecInstanceChangeEventSources;}
-    IJsonLocalState* _GetLocalState() const override {return m_localState;}
+    IJsonLocalState* _GetLocalState() const override {return m_localState.get();}
     IRulesetLocaterManager& _GetLocaters() const override {return *m_locaters;}
     IConnectionManagerR _GetConnections() override {return *m_connections;}
     ECPRESENTATION_EXPORT std::shared_ptr<INavNodesCache> _GetHierarchyCache(Utf8StringCR connectionId) const override;

--- a/iModelCore/ECPresentation/Tests/NonPublished/Helpers/RulesDrivenECPresentationManagerImplBase.h
+++ b/iModelCore/ECPresentation/Tests/NonPublished/Helpers/RulesDrivenECPresentationManagerImplBase.h
@@ -23,9 +23,9 @@ private:
     std::shared_ptr<IConnectionManager> m_connections;
     std::shared_ptr<IRulesetLocaterManager> m_locaters;
     std::shared_ptr<IUserSettingsManager> m_userSettings;
-    IJsonLocalState* m_localState;
-    IECPropertyFormatter const* m_ecPropertyFormatter;
-    IPropertyCategorySupplier const* m_categorySupplier;
+    std::shared_ptr<IJsonLocalState> m_localState;
+    std::shared_ptr<IECPropertyFormatter const> m_ecPropertyFormatter;
+    std::shared_ptr<IPropertyCategorySupplier const> m_categorySupplier;
     bvector<std::shared_ptr<ECInstanceChangeEventSource>> m_ecInstanceChangeEventSources;
     std::shared_ptr<TestNodesCache> m_nodesCache;
 protected:
@@ -33,7 +33,7 @@ protected:
     IECPropertyFormatter const& _GetECPropertyFormatter() const override { return *m_ecPropertyFormatter; }
     IUserSettingsManager& _GetUserSettingsManager() const override { return *m_userSettings; }
     bvector<std::shared_ptr<ECInstanceChangeEventSource>> const& _GetECInstanceChangeEventSources() const override { return m_ecInstanceChangeEventSources; }
-    IJsonLocalState* _GetLocalState() const override { return m_localState; }
+    IJsonLocalState* _GetLocalState() const override { return m_localState.get(); }
     IRulesetLocaterManager& _GetLocaters() const override { return *m_locaters; }
     IConnectionManagerR _GetConnections() override { return *m_connections; }
     void _OnRulesetCreated(RuleSetLocaterCR, PresentationRuleSetR) override {}
@@ -44,14 +44,14 @@ public:
     RulesDrivenECPresentationManagerImplBase(ECPresentationManager::Impl::Params const& params)
         : m_connections(params.GetConnections())
         {
-        static const TestPropertyFormatter s_defaultPropertyFormatter;
-        static const TestCategorySupplier s_defaultCategorySupplier;
+        static std::shared_ptr<TestPropertyFormatter const> const s_defaultPropertyFormatter = std::make_shared<TestPropertyFormatter>();
+        static std::shared_ptr<TestCategorySupplier const> const s_defaultCategorySupplier = std::make_shared<TestCategorySupplier>();
 
         m_locaters = params.GetRulesetLocaters();
         m_userSettings = params.GetUserSettings();
         m_localState = params.GetLocalState();
-        m_ecPropertyFormatter = params.GetECPropertyFormatter() ? params.GetECPropertyFormatter() : &s_defaultPropertyFormatter;
-        m_categorySupplier = params.GetCategorySupplier() ? params.GetCategorySupplier() : &s_defaultCategorySupplier;
+        m_ecPropertyFormatter = params.GetECPropertyFormatter() ? params.GetECPropertyFormatter() : s_defaultPropertyFormatter;
+        m_categorySupplier = params.GetCategorySupplier() ? params.GetCategorySupplier() : s_defaultCategorySupplier;
         m_ecInstanceChangeEventSources = params.GetECInstanceChangeEventSources();
 
         m_locaters->SetRulesetCallbacksHandler(this);

--- a/iModelCore/ECPresentation/Tests/NonPublished/Integration/Content/ContentIntegrationTests.cpp
+++ b/iModelCore/ECPresentation/Tests/NonPublished/Integration/Content/ContentIntegrationTests.cpp
@@ -9977,7 +9977,7 @@ TEST_F(RulesDrivenECPresentationManagerContentTests, LoadsPrimitiveArrayProperty
     ASSERT_EQ(1, descriptor->GetVisibleFields().size());
     auto arrayField = descriptor->GetVisibleFields()[0]->AsPropertiesField()->AsArrayPropertiesField();
     ASSERT_TRUE(arrayField != nullptr);
-    
+
     rapidjson::Document expectedArrayFieldType;
     expectedArrayFieldType.Parse(Utf8PrintfString(R"({
         "ValueFormat": "Array",
@@ -12124,7 +12124,7 @@ TEST_F(RulesDrivenECPresentationManagerContentTests, LoadsStructArrayPropertyVal
         << "Expected: \r\n" << BeRapidJsonUtilities::ToPrettyString(expectedValues2) << "\r\n"
         << "Actual: \r\n" << BeRapidJsonUtilities::ToPrettyString(recordJson2["Values"]);
     }
-    
+
 /*---------------------------------------------------------------------------------**//**
 * @bsitest
 +---------------+---------------+---------------+---------------+---------------+------*/
@@ -16033,14 +16033,14 @@ TEST_F(RulesDrivenECPresentationManagerContentTests, ReturnsCorrectContentWhenUs
 //=======================================================================================
 struct RulesDrivenECPresentationManagerContentWithCustomPropertyFormatterTests : RulesDrivenECPresentationManagerContentTests
     {
-    StubPropertyFormatter m_propertyFormatter;
+    std::shared_ptr<StubPropertyFormatter> m_propertyFormatter;
     RulesDrivenECPresentationManagerContentWithCustomPropertyFormatterTests()
-        : RulesDrivenECPresentationManagerContentTests(), m_propertyFormatter(true)
+        : RulesDrivenECPresentationManagerContentTests(), m_propertyFormatter(std::make_shared<StubPropertyFormatter>(true))
         {}
     virtual void _ConfigureManagerParams(ECPresentationManager::Params& params) override
         {
         RulesDrivenECPresentationManagerContentTests::_ConfigureManagerParams(params);
-        params.SetECPropertyFormatter(&m_propertyFormatter);
+        params.SetECPropertyFormatter(m_propertyFormatter);
         }
     };
 

--- a/iModelCore/ECPresentation/Tests/NonPublished/Integration/Content/Content_DistinctValuesTests.cpp
+++ b/iModelCore/ECPresentation/Tests/NonPublished/Integration/Content/Content_DistinctValuesTests.cpp
@@ -1352,14 +1352,14 @@ DEFINE_SCHEMA(GetDistinctPrimitiveValuesFromMergedFieldWhenFormatterFormatsThemD
 TEST_F(RulesDrivenECPresentationManagerContentTests, GetDistinctPrimitiveValuesFromMergedFieldWhenFormatterFormatsThemDifferently)
     {
     // set up manager with a custom formatter
-    TestPropertyFormatter formatter;
-    formatter.SetValueFormatter([](Utf8StringR result, ECPropertyCR prop, ECValueCR value, ECPresentation::UnitSystem)
+    auto formatter = std::make_shared<TestPropertyFormatter>();
+    formatter->SetValueFormatter([](Utf8StringR result, ECPropertyCR prop, ECValueCR value, ECPresentation::UnitSystem)
         {
         result = Utf8PrintfString("%s-%s", prop.GetClass().GetName().c_str(), value.ToString().c_str());
         return SUCCESS;
         });
     ECPresentationManager::Params managerParams = CreateManagerParams();
-    managerParams.SetECPropertyFormatter(&formatter);
+    managerParams.SetECPropertyFormatter(formatter);
     ReCreatePresentationManager(managerParams);
 
     // set up dataset

--- a/iModelCore/ECPresentation/Tests/NonPublished/Integration/Content/Content_PropertyCategorizationTests.cpp
+++ b/iModelCore/ECPresentation/Tests/NonPublished/Integration/Content/Content_PropertyCategorizationTests.cpp
@@ -637,7 +637,7 @@ TEST_F(RulesDrivenECPresentationManagerContentTests, PropertyCategorization_Calc
     ContentRuleP contentRule = new ContentRule("", 1, false);
     ContentInstancesOfSpecificClassesSpecificationP spec = new ContentInstancesOfSpecificClassesSpecification(1, "", classA->GetFullName(), false, false);
     spec->AddPropertyCategory(*new PropertyCategorySpecification("custom", "Custom", "", 1000, false, nullptr, PropertyCategoryIdentifier::CreateForRoot()));
-    spec->AddCalculatedProperty(*new CalculatedPropertiesSpecification("CalculatedProp", 1000, "", nullptr, nullptr, PropertyCategoryIdentifier::CreateForId("custom"))); 
+    spec->AddCalculatedProperty(*new CalculatedPropertiesSpecification("CalculatedProp", 1000, "", nullptr, nullptr, PropertyCategoryIdentifier::CreateForId("custom")));
     contentRule->AddSpecification(*spec);
     rules->AddPresentationRule(*contentRule);
 
@@ -5244,7 +5244,7 @@ TEST_F(RulesDrivenECPresentationManagerContentTests, PropertyCategoryOverride_Re
     ContentModifierP categoriesModifier = new ContentModifier(GetSchema()->GetName(), classB->GetName());
     categoriesModifier->AddPropertyCategory(*new PropertyCategorySpecification("custom", "Custom"));
     rules->AddPresentationRule(*categoriesModifier);
-    
+
     // validate descriptor
     ContentDescriptorCPtr descriptor = GetValidatedResponse(m_manager->GetContentDescriptor(AsyncContentDescriptorRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables(), nullptr, 0, *KeySet::Create())));
     ASSERT_TRUE(descriptor.IsValid());
@@ -5301,7 +5301,7 @@ TEST_F(RulesDrivenECPresentationManagerContentTests, PropertyCategoryOverride_Re
         new RelationshipStepSpecification(relAB->GetFullName(), RequiredRelationDirection_Forward)
         }), {new PropertySpecification("*", 1000, "", PropertyCategoryIdentifier::CreateForId("custom"))}, RelationshipMeaning::SameInstance));
     rules->AddPresentationRule(*modifier);
-    
+
     // validate descriptor
     ContentDescriptorCPtr descriptor = GetValidatedResponse(m_manager->GetContentDescriptor(AsyncContentDescriptorRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables(), nullptr, 0, *KeySet::Create())));
     ASSERT_TRUE(descriptor.IsValid());
@@ -5979,12 +5979,12 @@ TEST_F(RulesDrivenECPresentationManagerContentTests, CategorizesCalculatedProper
 //=======================================================================================
 struct RulesDrivenECPresentationManagerContentWithCustomCategorySupplierTests : RulesDrivenECPresentationManagerContentTests
     {
-    TestCategorySupplier m_categorySupplier = TestCategorySupplier(ContentDescriptor::Category("CustomName", "Custom label", "Custom description", 0));
+    std::shared_ptr<TestCategorySupplier> m_categorySupplier = std::make_shared<TestCategorySupplier>(ContentDescriptor::Category("CustomName", "Custom label", "Custom description", 0));
 
     virtual void _ConfigureManagerParams(ECPresentationManager::Params& params) override
         {
         RulesDrivenECPresentationManagerContentTests::_ConfigureManagerParams(params);
-        params.SetCategorySupplier(&m_categorySupplier);
+        params.SetCategorySupplier(m_categorySupplier);
         }
     };
 

--- a/iModelCore/ECPresentation/Tests/NonPublished/Integration/PresentationManagerIntegrationTests.cpp
+++ b/iModelCore/ECPresentation/Tests/NonPublished/Integration/PresentationManagerIntegrationTests.cpp
@@ -52,7 +52,7 @@ void PresentationManagerIntegrationTests::_ConfigureManagerParams(ECPresentation
 #endif
     params.SetCachingParams(cachingParams);
     params.SetConnections(m_connectionManager);
-    params.SetLocalState(&m_localState);
+    params.SetLocalState(m_localState);
     }
 
 /*---------------------------------------------------------------------------------**//**

--- a/iModelCore/ECPresentation/Tests/NonPublished/Integration/PresentationManagerIntegrationTests.h
+++ b/iModelCore/ECPresentation/Tests/NonPublished/Integration/PresentationManagerIntegrationTests.h
@@ -61,12 +61,12 @@ struct PresentationManagerIntegrationTests : ECPresentationTest
     ECPresentationManager* m_manager;
     std::shared_ptr<IConnectionManager> m_connectionManager;
     DelayLoadingRuleSetLocaterPtr m_locater;
-    JsonLocalState m_localState;
+    std::shared_ptr<JsonLocalState> m_localState;
 
     static void SetUpTestCase();
     static void TearDownTestCase();
 
-    PresentationManagerIntegrationTests() : m_manager(nullptr), m_localState(std::make_shared<RuntimeLocalState>()) {}
+    PresentationManagerIntegrationTests() : m_manager(nullptr), m_localState(std::make_shared<JsonLocalState>(std::make_shared<RuntimeLocalState>())) {}
     virtual std::unique_ptr<IConnectionManager> _CreateConnectionManager();
     virtual void _ConfigureManagerParams(ECPresentationManager::Params&);
     virtual ECDbR _GetProject();

--- a/iModelCore/ECPresentation/Tests/NonPublished/Unit/PresentationManagerImplCancelationTests.cpp
+++ b/iModelCore/ECPresentation/Tests/NonPublished/Unit/PresentationManagerImplCancelationTests.cpp
@@ -45,7 +45,7 @@ struct RulesDrivenECPresentationManagerImplCancelationTests : ECPresentationTest
     std::shared_ptr<TestConnectionManager> m_connections;
     IConnectionPtr m_connection;
     RulesDrivenECPresentationManagerImpl* m_impl;
-    TestCategorySupplier m_categorySupplier;
+    std::shared_ptr<TestCategorySupplier> m_categorySupplier;
     TestRuleSetLocaterPtr m_locater;
 
     static void SetUpTestCase();
@@ -68,7 +68,7 @@ struct RulesDrivenECPresentationManagerImplCancelationTests : ECPresentationTest
 
 
     RulesDrivenECPresentationManagerImplCancelationTests()
-        : m_categorySupplier(ContentDescriptor::Category("cat", "cat", "descr", 1)), m_impl(nullptr)
+        : m_categorySupplier(std::make_shared<TestCategorySupplier>(ContentDescriptor::Category("cat", "cat", "descr", 1))), m_impl(nullptr)
         {}
     };
 ECDbTestProject* RulesDrivenECPresentationManagerImplCancelationTests::s_project = nullptr;
@@ -140,7 +140,7 @@ void RulesDrivenECPresentationManagerImplCancelationTests::Reset()
     RulesDrivenECPresentationManagerImpl::Params params(RulesEngineTestHelpers::GetPaths(BeTest::GetHost()));
     params.SetConnections(m_connections);
     params.SetCachingParams(cachingParams);
-    params.SetCategorySupplier(&m_categorySupplier);
+    params.SetCategorySupplier(m_categorySupplier);
 
     m_impl = new RulesDrivenECPresentationManagerImpl(params);
     m_impl->GetLocaters().RegisterLocater(*m_locater);

--- a/iModelCore/ECPresentation/Tests/NonPublished/Unit/PresentationManagerImplTests.cpp
+++ b/iModelCore/ECPresentation/Tests/NonPublished/Unit/PresentationManagerImplTests.cpp
@@ -21,7 +21,7 @@ struct RulesDrivenECPresentationManagerImplTests : ECPresentationTest
     std::shared_ptr<TestConnectionManager> m_connections;
     IConnectionPtr m_connection;
     RulesDrivenECPresentationManagerImpl* m_impl;
-    TestCategorySupplier m_categorySupplier;
+    std::shared_ptr<TestCategorySupplier> m_categorySupplier;
     TestRuleSetLocaterPtr m_locater;
 
     static void SetUpTestCase();
@@ -30,7 +30,7 @@ struct RulesDrivenECPresentationManagerImplTests : ECPresentationTest
     virtual void TearDown() override;
 
     RulesDrivenECPresentationManagerImplTests()
-        : m_categorySupplier(ContentDescriptor::Category("cat", "cat", "descr", 1))
+        : m_categorySupplier(std::make_shared<TestCategorySupplier>(ContentDescriptor::Category("cat", "cat", "descr", 1)))
         {}
     };
 ECDbTestProject* RulesDrivenECPresentationManagerImplTests::s_project = nullptr;
@@ -71,7 +71,7 @@ void RulesDrivenECPresentationManagerImplTests::SetUp()
     RulesDrivenECPresentationManagerImpl::Params params(RulesEngineTestHelpers::GetPaths(BeTest::GetHost()));
     params.SetConnections(m_connections);
     params.SetCachingParams(cachingParams);
-    params.SetCategorySupplier(&m_categorySupplier);
+    params.SetCategorySupplier(m_categorySupplier);
     m_impl = new RulesDrivenECPresentationManagerImpl(params);
 
     m_impl->GetLocaters().RegisterLocater(*m_locater);

--- a/iModelCore/ECPresentation/Tests/TestHelpers/PresentationRulesetTest.cpp
+++ b/iModelCore/ECPresentation/Tests/TestHelpers/PresentationRulesetTest.cpp
@@ -145,8 +145,7 @@ int PresentationRulesetTester::CheckNode(NavNodeCR node, BeJsConst tree, int ind
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //---------------------------------------------------------------------------------------
-PresentationRulesetTester::PresentationRulesetTester(BeTest::Host& host, BeFileNameCR rulesetsDir) 
-    : m_localState(std::make_shared<RuntimeLocalState>())
+PresentationRulesetTester::PresentationRulesetTester(BeTest::Host& host, BeFileNameCR rulesetsDir)
     {
     BeFileName assetsDirectory, temporaryDirectory;
     host.GetDgnPlatformAssetsDirectory(assetsDirectory);
@@ -154,7 +153,7 @@ PresentationRulesetTester::PresentationRulesetTester(BeTest::Host& host, BeFileN
     ECPresentationManager::Paths paths(assetsDirectory, temporaryDirectory);
 
     ECPresentationManager::Params params(paths);
-    params.SetLocalState(&m_localState);
+    params.SetLocalState(std::make_shared<JsonLocalState>(std::make_shared<RuntimeLocalState>()));
     m_presentationManager = new ECPresentationManager(params);
     m_presentationManager->GetLocaters().RegisterLocater(*DirectoryRuleSetLocater::Create(rulesetsDir.GetNameUtf8().c_str()));
     }

--- a/iModelCore/ECPresentation/Tests/TestHelpers/PresentationRulesetTest.h
+++ b/iModelCore/ECPresentation/Tests/TestHelpers/PresentationRulesetTest.h
@@ -21,7 +21,6 @@ private:
     ECPresentationManager* m_presentationManager;
     ECDb* m_db;
     ECPresentation::Tests::IssueReporter m_issueReporter;
-    JsonLocalState m_localState;
 
     //! Compare a node we read from the BIM file with the corresponding node in the JSON expected output file
     //! The last 3 arguments are used to recursively call the function on the node's children

--- a/iModelJsNodeAddon/IModelJsNative.cpp
+++ b/iModelJsNodeAddon/IModelJsNative.cpp
@@ -5267,7 +5267,6 @@ struct NativeECPresentationManager : BeObjectWrap<NativeECPresentationManager>
     std::unique_ptr<ECPresentationManager> m_presentationManager;
     RefCountedPtr<SimpleRuleSetLocater> m_supplementalRulesets;
     RefCountedPtr<SimpleRuleSetLocater> m_primaryRulesets;
-    ECPresentation::JsonLocalState m_localState;
     std::shared_ptr<IModelJsECPresentationUpdateRecordsHandler> m_updatesHandler;
     Napi::ThreadSafeFunction m_threadSafeFunc;
     Napi::ThreadSafeFunction m_updateCallback;
@@ -5352,7 +5351,7 @@ struct NativeECPresentationManager : BeObjectWrap<NativeECPresentationManager>
         }
 
     NativeECPresentationManager(NapiInfoCR info)
-        : BeObjectWrap<NativeECPresentationManager>(info), m_localState(std::make_shared<RuntimeLocalState>())
+        : BeObjectWrap<NativeECPresentationManager>(info)
         {
         REQUIRE_ARGUMENT_ANY_OBJ(0, props);
         if (!props.Get("id").IsString())
@@ -5380,8 +5379,7 @@ struct NativeECPresentationManager : BeObjectWrap<NativeECPresentationManager>
                     delete updateInfoPtr;
                     });
                 });
-            m_presentationManager = std::unique_ptr<ECPresentationManager>(ECPresentationUtils::CreatePresentationManager(T_HOST.GetIKnownLocationsAdmin(),
-                m_localState, m_updatesHandler, props));
+            m_presentationManager = ECPresentationUtils::CreatePresentationManager(T_HOST.GetIKnownLocationsAdmin(), m_updatesHandler, props);
             m_supplementalRulesets = SimpleRuleSetLocater::Create();
             m_presentationManager->GetLocaters().RegisterLocater(*SupplementalRuleSetLocater::Create(*m_supplementalRulesets));
             m_primaryRulesets = SimpleRuleSetLocater::Create();

--- a/iModelJsNodeAddon/presentation/ECPresentationUtils.cpp
+++ b/iModelJsNodeAddon/presentation/ECPresentationUtils.cpp
@@ -302,7 +302,7 @@ NativeLogging::CategoryLogger ECPresentationUtils::GetLogger() {return NativeLog
 /*---------------------------------------------------------------------------------**//**
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/
-ECPresentationManager* ECPresentationUtils::CreatePresentationManager(Dgn::PlatformLib::Host::IKnownLocationsAdmin& locations, IJsonLocalState& localState,
+std::unique_ptr<ECPresentationManager> ECPresentationUtils::CreatePresentationManager(Dgn::PlatformLib::Host::IKnownLocationsAdmin& locations,
     std::shared_ptr<IUpdateRecordsHandler> updateRecordsHandler, BeJsConst props)
     {
     BeFileName assetsDir = locations.GetDgnPlatformAssetsDirectory();
@@ -330,12 +330,12 @@ ECPresentationManager* ECPresentationUtils::CreatePresentationManager(Dgn::Platf
     params.SetConnections(CreateConfiguredConnectionManager(props));
     params.SetContentCachingParams(contentCacheParams);
     params.SetMultiThreadingParams(threadingParams);
-    params.SetECPropertyFormatter(new DefaultPropertyFormatter(CreateDefaultFormatsMap(props["defaultFormats"])));
+    params.SetECPropertyFormatter(std::make_shared<DefaultPropertyFormatter>(CreateDefaultFormatsMap(props["defaultFormats"])));
     params.SetCachingParams(CreateCachingParams(props["cacheConfig"]));
-    params.SetLocalState(&localState);
+    params.SetLocalState(std::make_shared<JsonLocalState>(std::make_unique<RuntimeLocalState>()));
     params.SetECInstanceChangeEventSources({std::make_shared<DgnDbECInstanceChangeEventSource>()});
     params.SetUpdateRecordsHandlers({ updateRecordsHandler });
-    return new ECPresentationManager(params);
+    return std::make_unique<ECPresentationManager>(params);
     }
 
 /*---------------------------------------------------------------------------------**//**

--- a/iModelJsNodeAddon/presentation/ECPresentationUtils.h
+++ b/iModelJsNodeAddon/presentation/ECPresentationUtils.h
@@ -115,7 +115,7 @@ struct ECPresentationUtils
     static ECPresentation::Diagnostics::Options CreateDiagnosticsOptions(RapidJsonValueCR);
     static ECPresentationResult CreateResultFromException(folly::exception_wrapper const&, std::unique_ptr<rapidjson::Document> diagnostics = nullptr);
 
-    static ECPresentationManager* CreatePresentationManager(Dgn::PlatformLib::Host::IKnownLocationsAdmin&, IJsonLocalState&,
+    static std::unique_ptr<ECPresentationManager> CreatePresentationManager(Dgn::PlatformLib::Host::IKnownLocationsAdmin&,
         std::shared_ptr<IUpdateRecordsHandler>, BeJsConst props);
 
     static ECPresentationResult SetupRulesetDirectories(ECPresentationManager&, bvector<Utf8String> const&);


### PR DESCRIPTION
`NativeECPresentationManager` was leaking `DefaultPropertyFormatter` instance - `ECPresentationManager` was taking a raw pointer with the intention that its creator would own the property formatter, however `NativeECPresentationManager` never deleted the object. 

While this was the only leak I found, I went ahead and changed a number of other raw pointers to smart ones, making such mistakes harder to do in the future.