### PR TITLE
Renamed BytesToVectorOfGeometry to BytesToVectorOfGeometrySafe

### DIFF
--- a/iModelCore/GeomLibs/PublicAPI/GeomSerialization/GeomLibsFlatBufferApi.h
+++ b/iModelCore/GeomLibs/PublicAPI/GeomSerialization/GeomLibsFlatBufferApi.h
@@ -59,7 +59,7 @@ static BGFBIMPEXP bool BytesToPolyfaceQueryCarrierSafe
 //!    </ul>
 //! </ul>
 //!
-static BGFBIMPEXP bool BytesToVectorOfGeometry
+static BGFBIMPEXP bool BytesToVectorOfGeometrySafe
 (
     bvector<Byte> &buffer,
     bvector<IGeometryPtr> &dest,

--- a/iModelCore/GeomLibs/geom/test/CurvePrimitiveTest/t_IGeometry.cpp
+++ b/iModelCore/GeomLibs/geom/test/CurvePrimitiveTest/t_IGeometry.cpp
@@ -347,8 +347,8 @@ TEST(Flatbuffer, GeometryGroup)
     array0.push_back (IGeometry::Create (cp0));
     array0.push_back (IGeometry::Create (cp1));
     bvector<Byte> buffer;
-    BentleyGeometryFlatBuffer::GeometryToBytes (array0, buffer);
-    BentleyGeometryFlatBuffer::BytesToVectorOfGeometry (buffer, array1);
+    BentleyGeometryFlatBuffer::GeometryToBytes(array0, buffer);
+    BentleyGeometryFlatBuffer::BytesToVectorOfGeometrySafe (buffer, array1);
     if (Check::Size (array0.size (), array1.size ()))
         {
         for (size_t i = 0; i < array0.size (); i++)
@@ -375,7 +375,7 @@ TEST(Flatbuffer, RoundTripHoleOrigin)
     array0.push_back(IGeometry::Create(bsurfB));
     bvector<Byte> buffer;
     BentleyGeometryFlatBuffer::GeometryToBytes(array0, buffer);
-    BentleyGeometryFlatBuffer::BytesToVectorOfGeometry(buffer, array1);
+    BentleyGeometryFlatBuffer::BytesToVectorOfGeometrySafe(buffer, array1);
     if (Check::Size(array0.size(), array1.size()))
         {
         for (size_t i = 0; i < array0.size(); i++)
@@ -906,7 +906,7 @@ TEST(FlatBuffer, IsNanValues)
             Check::True(g1.IsValid(), "Flat buffer access to bad geometry");
             Check::False (myValidator->IsValidGeometry (g1), "Validator should find errors");
             bvector<IGeometryPtr> g2;
-            BentleyGeometryFlatBuffer::BytesToVectorOfGeometry(buffer, g2);
+            BentleyGeometryFlatBuffer::BytesToVectorOfGeometrySafe(buffer, g2);
             Check::Size(0, g2.size (), "Flat buffer checked access");
             BentleyGeometryFlatBuffer__SetFBWriteValidation(oldWriteValidator);
             }
@@ -1020,10 +1020,10 @@ TEST(FlatBuffer, IsNanValues)
     bvector<IGeometryPtr> gVectorA {goodGCV, badGCV};
     bvector<IGeometryPtr> gVectorB, gVectorC, gVectorD;
     bvector<Byte> bufferAB;
-    BentleyGeometryFlatBuffer::GeometryToBytes (gVectorA, bufferAB, nullptr, &gVectorB);
-    Check::Size (1, gVectorB.size (), "should reject 1 of 2");
-    BentleyGeometryFlatBuffer::BytesToVectorOfGeometry(bufferAB, gVectorC, true, &gVectorD);
-    Check::Size (1, gVectorC.size (), "should round trip 1");
+    BentleyGeometryFlatBuffer::GeometryToBytes(gVectorA, bufferAB, nullptr, &gVectorB);
+    Check::Size (1, gVectorB.size(), "should reject 1 of 2");
+    BentleyGeometryFlatBuffer::BytesToVectorOfGeometrySafe(bufferAB, gVectorC, true, &gVectorD);
+    Check::Size (1, gVectorC.size(), "should round trip 1");
     }
 
 TEST(FlatBuffer, IsNanValuesPolyface)

--- a/iModelCore/GeomLibs/geom/test/SerializationTest/t_imodeljson.cpp
+++ b/iModelCore/GeomLibs/geom/test/SerializationTest/t_imodeljson.cpp
@@ -77,7 +77,7 @@ WCharCP flatbufferUInt8Extension = nullptr   // optionally write flatbuffer to s
             if (flatbufferUInt8Extension != nullptr)
                 {
                 bvector<Byte> bytes;
-                BentleyGeometryFlatBuffer::GeometryToBytes (geometry, bytes);
+                BentleyGeometryFlatBuffer::GeometryToBytes(geometry, bytes);
                 GTestFileOps::WriteByteArrayToTextFile(bytes, outputDirectory, nameB, nameC, flatbufferUInt8Extension);
                 }
             }
@@ -125,11 +125,11 @@ TEST(IModelJson,BytesToXXX)
                 }
             bool ret;
             bvector<IGeometryPtr> geometryVector;
-            ret = BentleyGeometryFlatBuffer::BytesToVectorOfGeometry(buffer, geometryVector);
+            ret = BentleyGeometryFlatBuffer::BytesToVectorOfGeometrySafe(buffer, geometryVector);
             if (ret)
                 {
                 writeGeometryToFile(geometryVector, L"IModelJson.BytesToXXX", L"geometryVector", nullptr, L"imjs");
-                Check::Fail("expect BytesToVectorOfGeometry to return false for invalid bytes");
+                Check::Fail("expect BytesToVectorOfGeometrySafe to return false for invalid bytes");
                 }
             PolyfaceQueryCarrier carrier(0, false, 0, 0, nullptr, nullptr);
             ret = BentleyGeometryFlatBuffer::BytesToPolyfaceQueryCarrierSafe(buffer.data(), buffer.size(), carrier);
@@ -184,7 +184,7 @@ TEST(IModelJson,GeometryToBytes)
     Check::True(arcSingle->IsSameStructureAndGeometry(*geometrySingle1, 0));
 
     bvector<IGeometryPtr> geometryArray1;
-    BentleyGeometryFlatBuffer::BytesToVectorOfGeometry(bytesSingle, geometryArray1);
+    BentleyGeometryFlatBuffer::BytesToVectorOfGeometrySafe(bytesSingle, geometryArray1);
     Check::Size(geometryArray1.size(), 1);
     Check::True(arcSingle->IsSameStructureAndGeometry((*geometryArray1[0]->GetAsICurvePrimitive()), 0));
 
@@ -196,7 +196,7 @@ TEST(IModelJson,GeometryToBytes)
     bvector<Byte> bytesArray;
     BentleyGeometryFlatBuffer::GeometryToBytes(arcArray, bytesArray, validGeometry, invalidGeometry);
     bvector<IGeometryPtr> geometryArray2;
-    BentleyGeometryFlatBuffer::BytesToVectorOfGeometry(bytesArray, geometryArray2);
+    BentleyGeometryFlatBuffer::BytesToVectorOfGeometrySafe(bytesArray, geometryArray2);
     Check::Size(geometryArray2.size(), 1);
     Check::True(arcSingle->IsSameStructureAndGeometry((*geometryArray2[0]->GetAsICurvePrimitive()), 0));
 
@@ -204,18 +204,20 @@ TEST(IModelJson,GeometryToBytes)
     Check::IsNull(geometrySingle2.get());
     }
 
-static  bvector<Byte>  jsSegmentBytes {
-98,103,48,48,48,49,102,98,4,0,0,0,144,255,255,255,12,0,0,0,0,15,
-6,0,8,0,4,0,6,0,0,0,4,0,0,0,2,0,0,0,92,0,0,0,12,0,0,0,8,0,12,0,
-11,0,4,0,8,0,0,0,8,0,0,0,0,0,0,1,182,255,255,255,0,0,0,0,0,0,0,
-0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,8,64,0,0,0,0,0,0,
-8,64,0,0,0,0,0,0,0,0,0,0,0,0,8,0,10,0,9,0,4,0,8,0,0,0,12,0,0,0,0,
-1,6,0,4,0,4,0,6,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-0,0,0,0,0,0,0,0,8,64,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0 };
+static  bvector<Byte>  jsSegmentBytes
+    {
+    98,103,48,48,48,49,102,98,4,0,0,0,144,255,255,255,12,0,0,0,0,15,
+    6,0,8,0,4,0,6,0,0,0,4,0,0,0,2,0,0,0,92,0,0,0,12,0,0,0,8,0,12,0,
+    11,0,4,0,8,0,0,0,8,0,0,0,0,0,0,1,182,255,255,255,0,0,0,0,0,0,0,
+    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,8,64,0,0,0,0,0,0,
+    8,64,0,0,0,0,0,0,0,0,0,0,0,0,8,0,10,0,9,0,4,0,8,0,0,0,12,0,0,0,0,
+    1,6,0,4,0,4,0,6,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+    0,0,0,0,0,0,0,0,8,64,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+    };
 TEST(IModelJson, JsonFlatBuffer)
     {
     bvector<IGeometryPtr> geometry;
-    BentleyGeometryFlatBuffer::BytesToVectorOfGeometry(jsSegmentBytes, geometry);
+    BentleyGeometryFlatBuffer::BytesToVectorOfGeometrySafe(jsSegmentBytes, geometry);
     }
 /*---------------------------------------------------------------------------------**//**
 * @bsimethod
@@ -338,7 +340,7 @@ TEST(Serialization, ExpectedClosure)
         bvector<Byte> bytes;
         BentleyGeometryFlatBuffer::GeometryToBytes(*IGeometry::Create(meshA), bytes);
         bvector<IGeometryPtr> geometryC;
-        BentleyGeometryFlatBuffer::BytesToVectorOfGeometry(bytes, geometryC);
+        BentleyGeometryFlatBuffer::BytesToVectorOfGeometrySafe(bytes, geometryC);
         if (Check::Size(1, geometryC.size()), "singleton from flatbuffer")
             {
             auto meshC = geometryC[0]->GetAsPolyfaceHeader();
@@ -388,7 +390,7 @@ void CheckArrayActivity(
     bvector<Byte> bytes;
     BentleyGeometryFlatBuffer::GeometryToBytes(*g, bytes);
     bvector<IGeometryPtr> geometryC;
-    BentleyGeometryFlatBuffer::BytesToVectorOfGeometry(bytes, geometryC);
+    BentleyGeometryFlatBuffer::BytesToVectorOfGeometrySafe(bytes, geometryC);
     if (Check::Size(1, geometryC.size(), "singleton fb round trip"))
         {
         auto meshC = geometryC.front()->GetAsPolyfaceHeader();
@@ -440,7 +442,7 @@ PolyfaceHeaderPtr RoundTripMeshFB(PolyfaceHeaderPtr & meshA)
     bvector<Byte> bytes;
     BentleyGeometryFlatBuffer::GeometryToBytes(*IGeometry::Create(meshA), bytes);
     bvector<IGeometryPtr> geometryC;
-    BentleyGeometryFlatBuffer::BytesToVectorOfGeometry(bytes, geometryC);
+    BentleyGeometryFlatBuffer::BytesToVectorOfGeometrySafe(bytes, geometryC);
     if (Check::Size(1, geometryC.size(), "singleton from flatbuffer"))
         {
         auto meshC = geometryC[0]->GetAsPolyfaceHeader();

--- a/iModelCore/GeomLibs/serialization/src/FlatBuffer/FixedStructs.cpp
+++ b/iModelCore/GeomLibs/serialization/src/FlatBuffer/FixedStructs.cpp
@@ -1020,7 +1020,8 @@ void BentleyGeometryFlatBuffer::GeometryToBytes (CurveVectorCR source, bvector<B
     writer.FinishAndGetBuffer (g, buffer);
     }
 
-void BentleyGeometryFlatBuffer::GeometryToBytes (bvector<IGeometryPtr> &source,
+void BentleyGeometryFlatBuffer::GeometryToBytes(
+    bvector<IGeometryPtr> &source,
     bvector<Byte>& buffer,
     bvector<IGeometryPtr> *validGeometry,
     bvector<IGeometryPtr> *invalidGeometry)
@@ -2005,8 +2006,8 @@ static void ReadVariantGeometry(const BGFB::VariantGeometry * fbGeometry, bvecto
     if (fbGeometry == nullptr)
         return;
     if (fbGeometry->geometry_type() == BGFB::VariantGeometryUnion_VectorOfVariantGeometry)
-    FBReader::ReadVectorOfVariantGeometryDirect(
-        reinterpret_cast <const BGFB::VectorOfVariantGeometry *> (fbGeometry->geometry()), dest);
+        FBReader::ReadVectorOfVariantGeometryDirect(
+            reinterpret_cast <const BGFB::VectorOfVariantGeometry *> (fbGeometry->geometry()), dest);
     else
         {
         IGeometryPtr g = FBReader::ReadGeometry(fbGeometry);
@@ -2097,7 +2098,7 @@ MSBsplineSurfacePtr BentleyGeometryFlatBuffer::BytesToMSBsplineSurfaceSafe(Byte 
     return BytesToXXXSafe<MSBsplineSurfacePtr>(buffer, bufferSize, applyValidation, FBReader::ReadMSBsplineSurface);
     }
 
-bool BentleyGeometryFlatBuffer::BytesToVectorOfGeometry
+bool BentleyGeometryFlatBuffer::BytesToVectorOfGeometrySafe
 (
     bvector<Byte> &buffer,
     bvector<IGeometryPtr> &dest,

--- a/iModelCore/GeomLibs/serialization/src/FlatBuffer/FixedStructs.cpp
+++ b/iModelCore/GeomLibs/serialization/src/FlatBuffer/FixedStructs.cpp
@@ -2006,8 +2006,10 @@ static void ReadVariantGeometry(const BGFB::VariantGeometry * fbGeometry, bvecto
     if (fbGeometry == nullptr)
         return;
     if (fbGeometry->geometry_type() == BGFB::VariantGeometryUnion_VectorOfVariantGeometry)
+        {
         FBReader::ReadVectorOfVariantGeometryDirect(
-            reinterpret_cast <const BGFB::VectorOfVariantGeometry *> (fbGeometry->geometry()), dest);
+            reinterpret_cast <const BGFB::VectorOfVariantGeometry*>(fbGeometry->geometry()), dest);
+        }
     else
         {
         IGeometryPtr g = FBReader::ReadGeometry(fbGeometry);


### PR DESCRIPTION
This is done to make names consistent over all repos (imodel-native, imodel02, and PPBase)