### PR TITLE
Update BeGTest to compile with Android SDK 31

### DIFF
--- a/iModelCore/BeGTest/Android/project/app/build.gradle
+++ b/iModelCore/BeGTest/Android/project/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
 
-    compileSdkVersion 28
+    compileSdkVersion 31
     
     defaultConfig {
         applicationId "com.bentley.test"


### PR DESCRIPTION
This is hopefully a fix for https://github.com/iTwin/itwinjs-backlog/issues/1090