### PR TITLE
add repo resource to Profile Version Validation

### DIFF
--- a/build/profile-version-validation.yml
+++ b/build/profile-version-validation.yml
@@ -40,6 +40,10 @@ resources:
       endpoint: imodel-native
       name: iTwin/itwinjs-core
 
+    - repository: imodeljs-build-pipeline-scripts
+      type: git
+      name: iModelTechnologies/imodeljs-build-pipeline-scripts
+
 extends:
   template: /common/azure-pipelines/templates/pipeline.yml@profileversion-tests
   parameters:


### PR DESCRIPTION
add repo resource to use install-node-addon-from-artifact.yaml template so builds can consume native addon from pipelines build artifacts

Another PR is needed in profileversion-tests repo, but don't have write permissions to push branch and open PR at the moment