### PR TITLE
Improve logging when multiple schemas with the same name are being referenced

### DIFF
--- a/iModelCore/ecobjects/PublicApi/ECObjects/SchemaComparer.h
+++ b/iModelCore/ecobjects/PublicApi/ECObjects/SchemaComparer.h
@@ -926,7 +926,7 @@ private :
     Options m_options;
 
     BentleyStatus CompareSchema(SchemaChange&, ECN::ECSchemaCP, ECN::ECSchemaCP);
-    BentleyStatus CompareReferences(SchemaReferenceChanges&, ECN::ECSchemaReferenceList const*, ECN::ECSchemaReferenceList const*);
+    BentleyStatus CompareReferences(SchemaReferenceChanges&, ECN::ECSchemaReferenceList const*, ECN::ECSchemaReferenceList const*, ECN::ECSchemaCP oldVal, ECN::ECSchemaCP newVal);
     BentleyStatus CompareClasses(ClassChanges&, ECN::ECClassContainerCP, ECN::ECClassContainerCP);
     BentleyStatus CompareClass(ClassChange&, ECN::ECClassCP, ECN::ECClassCP);
     BentleyStatus CompareBaseClasses(BaseClassChanges&, ECN::ECBaseClassesList const*, ECN::ECBaseClassesList const*);

--- a/iModelCore/ecobjects/src/ECSchema.cpp
+++ b/iModelCore/ecobjects/src/ECSchema.cpp
@@ -2470,6 +2470,18 @@ ECObjectsStatus ECSchema::AddReferencedSchema(ECSchemaR refSchema, Utf8StringCR 
             }
         }
 
+    Utf8CP schemaName = refSchemaKey.GetName().c_str();
+    auto iter = std::find_if(m_refSchemaList.begin(), m_refSchemaList.end(), [&schemaName](const bpair<SchemaKey, ECSchemaPtr>& schemaPair) 
+        {
+        return BeStringUtilities::Stricmp(schemaName, schemaPair.first.GetName().c_str()) == 0;
+        });
+
+    if (iter != m_refSchemaList.end())
+        {
+        LOG.warningv("Schema %s is adding a reference to %s while it already references %s. For compatibility this is currently permitted but probably indicates a problem.",
+            this->GetFullSchemaName().c_str(), refSchema.GetFullSchemaName().c_str(), iter->second->GetFullSchemaName().c_str());
+        }
+
     m_refSchemaList[refSchemaKey] = &refSchema;
     // Check for recursion
     if (AddingSchemaCausedCycles ())


### PR DESCRIPTION
AddReferencedSchema now writes warnings like:
`WARNING  ECObjectsNative      Schema TestSchema.01.00.00 is adding a reference to RefSchema.01.01.00 while it already references RefSchema.01.00.00. For compatibility this is currently permitted but probably indicates a problem.`

Also, SchemaComparer will now provide more details when it fails due to this.
`ERROR    ECObjectsNative      Schema Reference comparison failed (Comparing old schema TestSchema.01.00.00 against new schema TestSchema.01.00.00). Multiple schema references with the same name were found in the old schema (RefSchema.01.00.00 and RefSchema.01.01.00).`