### PR TITLE
Fix default ECDb schema version numbers for profile 4005

### DIFF
--- a/iModelCore/ECDb/ECDb/ProfileUpgrader.cpp
+++ b/iModelCore/ECDb/ECDb/ProfileUpgrader.cpp
@@ -541,11 +541,11 @@ DbResult ProfileSchemaUpgrader::ImportProfileSchemas(ECDbCR ecdb, SchemaManager:
     if (SUCCESS != ReadSchemaFromDisk(*context, schemaKey, ecdb.GetDbFileName()))
         return BE_SQLITE_ERROR;
 
-    schemaKey = SchemaKey("ECDbMap", 2, 0, 3);
+    schemaKey = SchemaKey("ECDbMap", 2, 0, 4);
     if (SUCCESS != ReadSchemaFromDisk(*context, schemaKey, ecdb.GetDbFileName()))
         return BE_SQLITE_ERROR;
 
-    schemaKey = SchemaKey("ECDbMeta", 4, 0, 2);
+    schemaKey = SchemaKey("ECDbMeta", 4, 0, 3);
     if (SUCCESS != ReadSchemaFromDisk(*context, schemaKey, ecdb.GetDbFileName()))
         return BE_SQLITE_ERROR;
 


### PR DESCRIPTION
Was an oversight during the recent version increment.