### PR TITLE
ignore deleted connections in connection cache (race)

### DIFF
--- a/iModelCore/ECDb/ECDb/ConcurrentQueryManagerImpl.cpp
+++ b/iModelCore/ECDb/ECDb/ConcurrentQueryManagerImpl.cpp
@@ -238,7 +238,8 @@ std::shared_ptr<CachedConnection> CachedConnection::Make(ConnectionCache& cache,
 void ConnectionCache::InterruptIf(std::function<bool(RunnableRequestBase const&)> predicate, bool cancel) {
     recursive_guard_t lock(m_mutex);
     for (auto& conn: m_conns) {
-        conn->InterruptIf(predicate, cancel);
+        if (conn != nullptr)
+            conn->InterruptIf(predicate, cancel);
     }
 }
 //---------------------------------------------------------------------------------------


### PR DESCRIPTION
not an ideal fix but putting here for @khanaffan to take over.

There is some kind of race while closing a db and the concurrent query manager can try to iterate and use an empty shared_ptr in the connection list that was deleted by another thread.

<details>
<summary>crashing thread (concurrent query manager)</summary>
<pre><code>
#0  ___pthread_mutex_lock (mutex=0xd8) at ./nptl/pthread_mutex_lock.c:80
#1  0x000077cb5bb13ed3 in __gthread_mutex_lock (__mutex=0xd8)
    at /usr/lib/gcc/x86_64-linux-gnu/11/../../../../include/x86_64-linux-gnu/c++/11/bits/gthr-default.h:749
#2  0x000077cb5bb13ea5 in __gthread_recursive_mutex_lock (__mutex=0xd8)
    at /usr/lib/gcc/x86_64-linux-gnu/11/../../../../include/x86_64-linux-gnu/c++/11/bits/gthr-default.h:811
#3  0x000077cb5bb13045 in std::recursive_mutex::lock (this=0xd8) at /usr/lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/mutex:108
#4  0x000077cb5c07e9f3 in std::lock_guard<std::recursive_mutex>::lock_guard (this=0x77cb71ffab50, __m=...)
    at /usr/lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_mutex.h:229
#5  0x000077cb5c07ed0c in BentleyM0200::BeSQLite::EC::CachedConnection::InterruptIf(std::function<bool (BentleyM0200::BeSQLite::EC::RunnableRequestBase const&)>, bool) (this=0x0, cb=..., cancel=false)
    at /home/michael/work/itwinjs-cospace/repos/imodel02/src/imodel-native/iModelCore/ECDb/ECDb/ConcurrentQueryManagerImpl.cpp:146
#6  0x000077cb5c080260 in BentleyM0200::BeSQLite::EC::ConnectionCache::InterruptIf(std::function<bool (BentleyM0200::BeSQLite::EC::RunnableRequestBase const&)>, bool) (this=0x77cb789d60d8, predicate=..., cancel=false)
    at /home/michael/work/itwinjs-cospace/repos/imodel02/src/imodel-native/iModelCore/ECDb/ECDb/ConcurrentQueryManagerImpl.cpp:241
#7  0x000077cb5c0b8267 in BentleyM0200::BeSQLite::EC::QueryMonitor::QueryMonitor(BentleyM0200::BeSQLite::EC::RunnableRequestQueue&, BentleyM0200::BeSQLite::EC::QueryExecutor&, std::chrono::duration<long, std::ratio<1l, 1000l> >)::$_6::operator()(std::promise<void>*) const (
    this=0x77cb8243e7a0, notifyWhenThreadStarted=0x77cb786d49b0)
    at /home/michael/work/itwinjs-cospace/repos/imodel02/src/imodel-native/iModelCore/ECDb/ECDb/ConcurrentQueryManagerImpl.cpp:1294
#8  0x000077cb5c0b8182 in std::__invoke_impl<void, BentleyM0200::BeSQLite::EC::QueryMonitor::QueryMonitor(BentleyM0200::BeSQLite::EC::RunnableRequestQueue&, BentleyM0200::BeSQLite::EC::QueryExecutor&, std::chrono::duration<long, std::ratio<1l, 1000l> >)::$_6, std::promise<void>*>(std::__invoke_other, BentleyM0200::BeSQLite::EC::QueryMonitor::QueryMonitor(BentleyM0200::BeSQLite::EC::RunnableRequestQueue&, BentleyM0200::BeSQLite::EC::QueryExecutor&, std::chrono::duration<long, std::ratio<1l, 1000l> >)::$_6&&, std::promise<void>*&&) (__f=..., __args=@0x77cb8243e798: 0x77cb786d49b0) at /usr/lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
#9  0x000077cb5c0b80d2 in std::__invoke<BentleyM0200::BeSQLite::EC::QueryMonitor::QueryMonitor(BentleyM0200::BeSQLite::EC::RunnableRequestQueue&, BentleyM0200::BeSQLite::EC::QueryExecutor&, std::chrono::duration<long, std::ratio<1l, 1000l> >)::$_6, std::promise<void>*>(BentleyM0200::BeSQLite::EC::QueryMonitor::QueryMonitor(BentleyM0200::BeSQLite::EC::RunnableRequestQueue&, BentleyM0200::BeSQLite::EC::QueryExecutor&, std::chrono::duration<long, std::ratio<1l, 1000l> >)::$_6&&, std::promise<void>*&&) (__fn=..., __args=@0x77cb8243e798: 0x77cb786d49b0) at /usr/lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96
#10 0x000077cb5c0b8092 in std::thread::_Invoker<std::tuple<BentleyM0200::BeSQLite::EC::QueryMonitor::QueryMonitor(BentleyM0200::BeSQLite::EC::RunnableRequestQueue&, BentleyM0200::BeSQLite::EC::QueryExecutor&, std::chrono::duration<long, std::ratio<1l, 1000l> >)::$_6, std::promise<void>*> >::_M_invoke<0ul, 1ul>(std::_Index_tuple<0ul, 1ul>) (this=0x77cb8243e798) at /usr/lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_thread.h:259
#11 0x000077cb5c0b8045 in std::thread::_Invoker<std::tuple<BentleyM0200::BeSQLite::EC::QueryMonitor::QueryMonitor(BentleyM0200::BeSQLite::EC::RunnableRequestQueue&, BentleyM0200::BeSQLite::EC::QueryExecutor&, std::chrono::duration<long, std::ratio<1l, 1000l> >)::$_6, std::promise<void>*> >::operator()() (this=0x77cb8243e798) at /usr/lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_thread.h:266
#12 0x000077cb5c0b7ea9 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<BentleyM0200::BeSQLite::EC::QueryMonitor::QueryMonitor(BentleyM0200::BeSQLite::EC::RunnableRequestQueue&, BentleyM0200::BeSQLite::EC::QueryExecutor&, std::chrono::duration<long, std::ratio<1l, 1000l> >)::$_6, std::promise<void>*> > >::_M_run() (this=0x77cb8243e790) at /usr/lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_thread.h:211
#13 0x000077cb822dc253 in std::execute_native_thread_routine (__p=0x77cb8243e790) at ../../../../../src/libstdc++-v3/src/c++11/thread.cc:82
#14 0x000077cb81e94ac3 in start_thread (arg=<optimized out>) at ./nptl/pthread_create.c:442
#15 0x000077cb81f26850 in clone3 () at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:81
</code></pre>
</details>


<details>
<summary>main thread</summary>
<pre><code>
#0  pthreadMutexHeld (p=0x77cb63c399c0 <pthreadMutexAlloc.staticMutexes+64>)
    at /home/michael/work/itwinjs-cospace/repos/imodel02/src/imodel-native/iModelCore/BeSQLite/SQLite/sqlite3.c:29201
#1  0x000077cb5bea4546 in sqlite3_mutex_held (p=0x77cb63c399c0 <pthreadMutexAlloc.staticMutexes+64>)
    at /home/michael/work/itwinjs-cospace/repos/imodel02/src/imodel-native/iModelCore/BeSQLite/SQLite/sqlite3.c:28894
#2  0x000077cb5bedd12b in mallocWithAlarm (n=472, pp=0x7ffcb267dbc0)
    at /home/michael/work/itwinjs-cospace/repos/imodel02/src/imodel-native/iModelCore/BeSQLite/SQLite/sqlite3.c:30263
#3  0x000077cb5bea4a17 in sqlite3Malloc (n=472)
    at /home/michael/work/itwinjs-cospace/repos/imodel02/src/imodel-native/iModelCore/BeSQLite/SQLite/sqlite3.c:30337
#4  0x000077cb5beddfa8 in dbMallocRawFinish (db=0x77cb782cca78, n=472)
    at /home/michael/work/itwinjs-cospace/repos/imodel02/src/imodel-native/iModelCore/BeSQLite/SQLite/sqlite3.c:30643
#5  0x000077cb5bedde0f in sqlite3DbMallocRawNN (db=0x77cb782cca78, n=472)
    at /home/michael/work/itwinjs-cospace/repos/imodel02/src/imodel-native/iModelCore/BeSQLite/SQLite/sqlite3.c:30725
#6  0x000077cb5beb8868 in sqlite3DbMallocRaw (db=0x77cb782cca78, n=472)
    at /home/michael/work/itwinjs-cospace/repos/imodel02/src/imodel-native/iModelCore/BeSQLite/SQLite/sqlite3.c:30674
#7  0x000077cb5bf2d1f5 in allocateCursor (p=0x77cb78401c08, iCur=0, nField=6, eCurType=0 '\000')
    at /home/michael/work/itwinjs-cospace/repos/imodel02/src/imodel-native/iModelCore/BeSQLite/SQLite/sqlite3.c:93090
#8  0x000077cb5bf1ab23 in sqlite3VdbeExec (p=0x77cb78401c08)
    at /home/michael/work/itwinjs-cospace/repos/imodel02/src/imodel-native/iModelCore/BeSQLite/SQLite/sqlite3.c:97155
#9  0x000077cb5beb4b95 in sqlite3Step (p=0x77cb78401c08) at /home/michael/work/itwinjs-cospace/repos/imodel02/src/imodel-native/iModelCore/BeSQLite/SQLite/sqlite3.c:90907
#10 0x000077cb5beac8b7 in sqlite3_step (pStmt=0x77cb78401c08) at /home/michael/work/itwinjs-cospace/repos/imodel02/src/imodel-native/iModelCore/BeSQLite/SQLite/sqlite3.c:90968
#11 0x000077cb5be399ea in BentleyM0200::BeSQLite::Statement::Step (this=0x77cb78179760) at /home/michael/work/itwinjs-cospace/repos/imodel02/src/imodel-native/iModelCore/BeSQLite/BeSQLite.cpp:555
#12 0x000077cb5c28dcb5 in BentleyM0200::BeSQLite::EC::SchemaWriter::InsertCAEntry (ctx=..., customAttribute=..., ecClassId=..., containerId=..., containerType=BentleyM0200::BeSQLite::EC::SchemaPersistenceHelper::GeneralizedCustomAttributeContainerType::Class, ordinal=0) at /home/michael/work/itwinjs-cospace/repos/imodel02/src/imodel-native/iModelCore/ECDb/ECDb/SchemaWriter.cpp:1955
#13 0x000077cb5c286c61 in BentleyM0200::BeSQLite::EC::SchemaWriter::ImportCustomAttributes (ctx=..., sourceContainer=..., sourceContainerId=..., containerType=BentleyM0200::BeSQLite::EC::SchemaPersistenceHelper::GeneralizedCustomAttributeContainerType::Class) at /home/michael/work/itwinjs-cospace/repos/imodel02/src/imodel-native/iModelCore/ECDb/ECDb/SchemaWriter.cpp:1598
#14 0x000077cb5c2869d6 in BentleyM0200::BeSQLite::EC::SchemaWriter::ImportClass (ctx=..., ecClass=...) at /home/michael/work/itwinjs-cospace/repos/imodel02/src/imodel-native/iModelCore/ECDb/ECDb/SchemaWriter.cpp:539
#15 0x000077cb5c28b7e5 in BentleyM0200::BeSQLite::EC::SchemaWriter::ImportRelationshipConstraint (ctx=..., relClassId=..., relationshipConstraint=..., end=BentleyM0200::ECN::ECRelationshipEnd_Source) at /home/michael/work/itwinjs-cospace/repos/imodel02/src/imodel-native/iModelCore/ECDb/ECDb/SchemaWriter.cpp:1266
#16 0x000077cb5c28972a in BentleyM0200::BeSQLite::EC::SchemaWriter::ImportRelationshipClass (ctx=..., relationship=0x77cb7818edc0) at /home/michael/work/itwinjs-cospace/repos/imodel02/src/imodel-native/iModelCore/ECDb/ECDb/SchemaWriter.cpp:1242
#17 0x000077cb5c28694a in BentleyM0200::BeSQLite::EC::SchemaWriter::ImportClass (ctx=..., ecClass=...) at /home/michael/work/itwinjs-cospace/repos/imodel02/src/imodel-native/iModelCore/ECDb/ECDb/SchemaWriter.cpp:535
#18 0x000077cb5c287bdf in BentleyM0200::BeSQLite::EC::SchemaWriter::ImportProperty (ctx=..., ecProperty=..., ordinal=4) at /home/michael/work/itwinjs-cospace/repos/imodel02/src/imodel-native/iModelCore/ECDb/ECDb/SchemaWriter.cpp:1378
#19 0x000077cb5c28679d in BentleyM0200::BeSQLite::EC::SchemaWriter::ImportClass (ctx=..., ecClass=...) at /home/michael/work/itwinjs-cospace/repos/imodel02/src/imodel-native/iModelCore/ECDb/ECDb/SchemaWriter.cpp:525
#20 0x000077cb5c28b7e5 in BentleyM0200::BeSQLite::EC::SchemaWriter::ImportRelationshipConstraint (ctx=..., relClassId=..., relationshipConstraint=..., end=BentleyM0200::ECN::ECRelationshipEnd_Target) at /home/michael/work/itwinjs-cospace/repos/imodel02/src/imodel-native/iModelCore/ECDb/ECDb/SchemaWriter.cpp:1266
#21 0x000077cb5c289775 in BentleyM0200::BeSQLite::EC::SchemaWriter::ImportRelationshipClass (ctx=..., relationship=0x77cb7818e590) at /home/michael/work/itwinjs-cospace/repos/imodel02/src/imodel-native/iModelCore/ECDb/ECDb/SchemaWriter.cpp:1245
#22 0x000077cb5c28694a in BentleyM0200::BeSQLite::EC::SchemaWriter::ImportClass (ctx=..., ecClass=...) at /home/michael/work/itwinjs-cospace/repos/imodel02/src/imodel-native/iModelCore/ECDb/ECDb/SchemaWriter.cpp:535
#23 0x000077cb5c27c41c in BentleyM0200::BeSQLite::EC::SchemaWriter::ImportSchema (ctx=..., ecSchema=...) at /home/michael/work/itwinjs-cospace/repos/imodel02/src/imodel-native/iModelCore/ECDb/ECDb/SchemaWriter.cpp:344
#24 0x000077cb5c278d6a in BentleyM0200::BeSQLite::EC::SchemaWriter::ImportSchemas (schemasToMap=std::vector of length 0, capacity 0, schemaImportCtx=..., schemasRaw=std::vector of length 5, capacity 8 = {...}) at /home/michael/work/itwinjs-cospace/repos/imodel02/src/imodel-native/iModelCore/ECDb/ECDb/SchemaWriter.cpp:172
#25 0x000077cb5c1e6bb9 in BentleyM0200::BeSQLite::EC::MainSchemaManager::ImportSchemas (this=0x77cb7829dbd0, ctx=..., schemas=std::vector of length 5, capacity 8 = {...}, schemaImportToken=0x77cb78212140, syncDbUri=...) at /home/michael/work/itwinjs-cospace/repos/imodel02/src/imodel-native/iModelCore/ECDb/ECDb/SchemaManagerDispatcher.cpp:1264
#26 0x000077cb5c1e5bd0 in BentleyM0200::BeSQLite::EC::MainSchemaManager::ImportSchemas (this=0x77cb7829dbd0, schemas=std::vector of length 5, capacity 8 = {...}, options=BentleyM0200::BeSQLite::EC::SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade, token=0x77cb78212140, schemaSync=...) at /home/michael/work/itwinjs-cospace/repos/imodel02/src/imodel-native/iModelCore/ECDb/ECDb/SchemaManagerDispatcher.cpp:1087
#27 0x000077cb5c1c49b3 in BentleyM0200::BeSQLite::EC::SchemaManager::ImportSchemas (this=0x77cb7839c970, schemas=std::vector of length 5, capacity 8 = {...}, options=BentleyM0200::BeSQLite::EC::SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade, token=0x77cb78212140, syncDbUri=...) at /home/michael/work/itwinjs-cospace/repos/imodel02/src/imodel-native/iModelCore/ECDb/ECDb/SchemaManager.cpp:42
#28 0x000077cb5c1704d7 in BentleyM0200::BeSQLite::EC::ProfileSchemaUpgrader::ImportProfileSchemas (ecdb=..., opts=BentleyM0200::BeSQLite::EC::SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade) at /home/michael/work/itwinjs-cospace/repos/imodel02/src/imodel-native/iModelCore/ECDb/ECDb/ProfileUpgrader.cpp:555
#29 0x000077cb5c166db4 in BentleyM0200::BeSQLite::EC::ProfileManager::CreateProfile (this=0x77cb782511b0) at /home/michael/work/itwinjs-cospace/repos/imodel02/src/imodel-native/iModelCore/ECDb/ECDb/ProfileManager.cpp:44
#30 0x000077cb5c0c886c in BentleyM0200::BeSQLite::EC::ECDb::Impl::OnDbCreated (this=0x77cb78251170) at /home/michael/work/itwinjs-cospace/repos/imodel02/src/imodel-native/iModelCore/ECDb/ECDb/ECDbImpl.cpp:213
#31 0x000077cb5c0be467 in BentleyM0200::BeSQLite::EC::ECDb::_OnDbCreated (this=0x77cb78294ec0, params=...) at /home/michael/work/itwinjs-cospace/repos/imodel02/src/imodel-native/iModelCore/ECDb/ECDb/ECDb.cpp:86
#32 0x000077cb5be44a13 in BentleyM0200::BeSQLite::Db::CreateNewDb (this=0x77cb78294ec0, inName=0x77cb78357640 "generated-imodels/1565087547085875237.bim.target.bim", params=..., dbGuid=...) at /home/michael/work/itwinjs-cospace/repos/imodel02/src/imodel-native/iModelCore/BeSQLite/BeSQLite.cpp:2104
#33 0x000077cb5b7f0814 in BentleyM0200::BeSQLite::Db::CreateNewDb (this=0x77cb78294ec0, dbName=..., params=..., dbGuid=...) at /home/michael/work/itwinjs-cospace/repos/imodel02/out/LinuxX64/static/BuildContexts/iModelPlatform/PublicAPI/BeSQLite/BeSQLite.h:2914
#34 0x000077cb5c3a5a99 in BentleyM0200::Dgn::DgnDb::CreateNewIModel (this=0x77cb78294ec0, inFileName=..., params=...) at /home/michael/work/itwinjs-cospace/repos/imodel02/src/imodel-native/iModelCore/iModelPlatform/DgnCore/DgnDb.cpp:684
#35 0x000077cb5c3a5d97 in BentleyM0200::Dgn::DgnDb::CreateIModel (result=0x7ffcb2682354, fileName=..., params=...) at /home/michael/work/itwinjs-cospace/repos/imodel02/src/imodel-native/iModelCore/iModelPlatform/DgnCore/DgnDb.cpp:714
#36 0x000077cb5b7ec097 in IModelJsNative::JsInterop::CreateIModel (filenameIn=Python Exception <class 'IndexError'>: list index out of range
, props=...) at /home/michael/work/itwinjs-cospace/repos/imodel02/src/imodel-native/iModelJsNodeAddon/JsInterop.cpp:591
#37 0x000077cb5b6d9719 in IModelJsNative::NativeDgnDb::CreateIModel (this=0x77cb781f6830, info=...) at /home/michael/work/itwinjs-cospace/repos/imodel02/src/imodel-native/iModelJsNodeAddon/IModelJsNative.cpp:1151
#38 0x000077cb5b6f75e2 in Napi::InstanceWrap<IModelJsNative::NativeDgnDb>::InstanceVoidMethodCallbackWrapper(napi_env__*, napi_callback_info__*)::{lambda()#1}::operator()() const (this=0x7ffcb2682968) at /home/michael/work/itwinjs-cospace/repos/imodel02/out/LinuxX64/static/BuildContexts/iModelJsNodeAddon/VendorAPI/Napi/node-src/napi-inl.h:4354
#39 0x000077cb5b6f7356 in Napi::details::WrapCallback<Napi::InstanceWrap<IModelJsNative::NativeDgnDb>::InstanceVoidMethodCallbackWrapper(napi_env__*, napi_callback_info__*)::{lambda()#1}>(Napi::InstanceWrap<IModelJsNative::NativeDgnDb>::InstanceVoidMethodCallbackWrapper(napi_env__*, napi_callback_info__*)::{lambda()#1}) (callback=...) at /home/michael/work/itwinjs-cospace/repos/imodel02/out/LinuxX64/static/BuildContexts/iModelJsNodeAddon/VendorAPI/Napi/node-src/napi-inl.h:79
#40 0x000077cb5b6f6ffa in Napi::InstanceWrap<IModelJsNative::NativeDgnDb>::InstanceVoidMethodCallbackWrapper (env=0x77cb82103d00, info=0x7ffcb26829d0) at /home/michael/work/itwinjs-cospace/repos/imodel02/out/LinuxX64/static/BuildContexts/iModelJsNodeAddon/VendorAPI/Napi/node-src/napi-inl.h:4347
#41 0x0000000000b28b69 in v8impl::(anonymous namespace)::FunctionCallbackWrapper::Invoke(v8::FunctionCallbackInfo<v8::Value> const&) ()
#42 0x0000000000dc4e00 in v8::internal::MaybeHandle<v8::internal::Object> v8::internal::(anonymous namespace)::HandleApiCallHelper<false>(v8::internal::Isolate*, v8::internal::Handle<v8::internal::HeapObject>, v8::internal::Handle<v8::internal::HeapObject>, v8::internal::Handle<v8::internal::FunctionTemplateInfo>, v8::internal::Handle<v8::internal::Object>, v8::internal::BuiltinArguments) ()
#43 0x0000000000dc633f in v8::internal::Builtin_HandleApiCall(int, unsigned long*, v8::internal::Isolate*) ()
#44 0x0000000001705c39 in Builtins_CEntry_Return1_DontSaveFPRegs_ArgvOnStack_BuiltinExit ()
#45 0x0000000001689b90 in Builtins_InterpreterEntryTrampoline ()
#46 0x0000253414d815b9 in ?? ()
...
#65 0x0000000001689b90 in Builtins_InterpreterEntryTrampoline ()
#66 0x0000373303a011e9 in ?? ()
...
#87 0x00000000016bd87f in Builtins_AsyncFunctionAwaitResolveClosure ()
Backtrace stopped: previous frame inner to this frame (corrupt stack?)
</code></pre>
</details>
