### PR TITLE
Fix rotated TextString bounding box

### DIFF
--- a/iModelCore/iModelPlatform/DgnCore/ElementGeometry.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/ElementGeometry.cpp
@@ -319,7 +319,7 @@ template<> bool getRange(TextStringCR text, DRange3dR range, TransformCP transfo
     range.high.y += yPad;
 
     Transform textTransform = text.ComputeTransform();
-    textTransform.Multiply(&range.low, 2);
+    textTransform.Multiply(range, range);
 
     if (nullptr != transform)
         transform->Multiply(range, range);


### PR DESCRIPTION
Fixes clipping at the extremes of rotated text as noted [here](https://github.com/iTwin/itwinjs-core/pull/6693).
It needs to expand the box to fully encompass the rotated box.