### PR TITLE
add release/4.x

### DIFF
--- a/build/begin_addon_release.yml
+++ b/build/begin_addon_release.yml
@@ -4,6 +4,7 @@ trigger:
   branches:
     include:
     - main
+    - release/4.x
 
   paths:
     exclude:


### PR DESCRIPTION
add new trigger for release branches, so patch addons are automatically kicked off after a new merge
