### PR TITLE
Presentation: Fix duplicated related property fields 

### DIFF
--- a/iModelCore/ECPresentation/Source/Shared/RelatedClass.cpp
+++ b/iModelCore/ECPresentation/Source/Shared/RelatedClass.cpp
@@ -319,7 +319,7 @@ bool RelatedClassPath::ClassesEqual(RelatedClassPathCR other) const
 +---------------+---------------+---------------+---------------+---------------+------*/
 BentleyStatus RelatedClass::Unify(RelatedClass& result, RelatedClassCR lhs, RelatedClassCR rhs)
     {
-    if (lhs.GetTargetIds() != rhs.GetTargetIds() || lhs.GetTargetInstanceFilter() != rhs.GetTargetInstanceFilter())
+    if (lhs.GetTargetIds() != rhs.GetTargetIds() || !AreTargetInstanceFiltersEqual(lhs, rhs))
         return ERROR;
 
     result = lhs;


### PR DESCRIPTION
Fix duplicated related property fields when input contains multiple classes and related property spec has an instance filter. This fixes https://github.com/iTwin/viewer-components-react/issues/936.