### PR TITLE
Fix Comment regarding Workspace Priority Param

### DIFF
--- a/iModelCore/GeoCoord/PublicAPI/GeoCoord/BaseGeoCoord.h
+++ b/iModelCore/GeoCoord/PublicAPI/GeoCoord/BaseGeoCoord.h
@@ -470,7 +470,7 @@ public:
     // Add a list of WorkspaceDbs to find GCS resources.
     // @param dbName the workspace database name containing GCS resources.
     // @param container the CloudContainer holding the dbs (or nullptr)
-    // @param priority 0=highest (loaded first)
+    // @param priority 0=lowest
     BASEGEOCOORD_EXPORTED static bool AddWorkspaceDb(Utf8String dbName, BeSQLite::CloudContainerP container, int priority);
 
     BASEGEOCOORD_EXPORTED static BaseGCSPtr CreateGCS(CSParameters const& csParameters, int32_t coordSysId);


### PR DESCRIPTION
I believe this comment is incorrect unless I'm miss understanding it. When working with GCS workspaces using 0 does give it the lowest priority, as in workspaces with greater numbers are used first.