### PR TITLE
NativeLogger.categoryFilter is a read-only object

### DIFF
--- a/iModelJsNodeAddon/api_package/ts/src/NativeLibrary.ts
+++ b/iModelJsNodeAddon/api_package/ts/src/NativeLibrary.ts
@@ -53,7 +53,7 @@ export const NativeLoggerCategory = {
 /** @internal */
 export interface NativeLogger {
   readonly minLevel: LogLevel | undefined;
-  readonly categoryFilter: { [categoryName: string]: LogLevel };
+  readonly categoryFilter: Readonly<{[categoryName: string]: LogLevel | undefined}>;
   logTrace: (category: string, message: string) => void;
   logInfo: (category: string, message: string) => void;
   logWarning: (category: string, message: string) => void;


### PR DESCRIPTION
itwinjs-core: https://github.com/iTwin/itwinjs-core/pull/6828

NativeLibrary.ts should really just import `Logger` from core-bentley and export `type NativeLogger = Pick<Logger, "categoryFilter" | "etc...">`.
But it can't do that until the updated core-bentley package in linked PR is merged.

I don't know why only the docs build complained about the type discrepancy in the linked PR.