### PR TITLE
Enable FTS4

### DIFF
--- a/iModelCore/BeSQLite/SQLite/bentley-sqlite.c
+++ b/iModelCore/BeSQLite/SQLite/bentley-sqlite.c
@@ -21,8 +21,9 @@
 //Allocate around ~ 32 Mb
 #define SQLITE_DEFAULT_CACHE_SIZE 8000
 #define SQLITE_ENABLE_FTS5 1    // include support for full text search
+#define SQLITE_ENABLE_FTS4 1    // include support for full text search
 #define SESSIONS_STRM_CHUNK_SIZE 64*1024
-// https://sqlite.org/lang_mathfunc.html
+// https://sqlite.org/lang_mathfunc.htmlbb
 #define SQLITE_ENABLE_MATH_FUNCTIONS 1
 #define SQLITE_ENABLE_DBSTAT_VTAB 1
 #define SQLITE_ENABLE_NORMALIZE 1


### PR DESCRIPTION
For experiment with full db free text search.

https://github.com/iTwin/itwin-cli/pull/64

```sql
select * from ftsElements where ftsElements MATCH 'Cast Iron AND PaletteName: Metals'
```

**Why FTS4 and not FTS5?**

FTS4 can have very large number of columns. Since it does not store them as column rather just document. FTS5 has arbitrary limit as it store each column as row in table.

