### PR TITLE
Add openGroup() and writeToFile() to SqliteChangesetReader

### DIFF
--- a/iModelCore/BeSQLite/PublicAPI/BeSQLite/ChangesetFile.h
+++ b/iModelCore/BeSQLite/PublicAPI/BeSQLite/ChangesetFile.h
@@ -16,7 +16,7 @@ BEGIN_BENTLEY_SQLITE_NAMESPACE
 //=======================================================================================
 struct EXPORT_VTABLE_ATTRIBUTE ChangesetFileReaderBase : ChangeStream {
 private:
-    Db const& m_db; // Used only for debugging
+    Db const* m_db; // Used only for debugging
     bvector<BeFileName> m_files;
 
     struct Reader : Changes::Reader {
@@ -46,8 +46,8 @@ public:
     bool _IsEmpty() const override { return m_files.size() == 0; }
     RefCountedPtr<Reader> MakeReader() const { return new Reader(*this); }
     RefCountedPtr<Changes::Reader> _GetReader() const override { return MakeReader(); }
-    ChangesetFileReaderBase(bvector<BeFileName> const& files, Db const& db) : m_files(files), m_db(db) {}
-    Db const& GetDb() const { return m_db; }
+    ChangesetFileReaderBase(bvector<BeFileName> const& files, Db const* db = nullptr) : m_files(files), m_db(db) {}
+    Db const* GetDb() const { return m_db; }
 };
 
 //=======================================================================================
@@ -60,7 +60,7 @@ private:
     BeFileName m_pathname;
     BeFileLzmaOutStream* m_outLzmaFileStream;
     Utf8String m_prefix;
-    Db const& m_db; // Only for debugging
+    Db const* m_db; // Only for debugging
 
     DbResult StartOutput();
     BE_SQLITE_EXPORT void FinishOutput();
@@ -72,7 +72,7 @@ private:
     BE_SQLITE_EXPORT ChangeSet::ConflictResolution _OnConflict(ChangeSet::ConflictCause cause, Changes::Change iter) override;
 
 public:
-    BE_SQLITE_EXPORT ChangesetFileWriter(BeFileNameCR pathname, bool containsEcSchemaChanges, DdlChangesCR ddlChanges, Db const&,
+    BE_SQLITE_EXPORT ChangesetFileWriter(BeFileNameCR pathname, bool containsEcSchemaChanges, DdlChangesCR ddlChanges, Db const*,
                                          BeSQLite::LzmaEncoder::LzmaParams const& lzmaParams = BeSQLite::LzmaEncoder::LzmaParams());
     BE_SQLITE_EXPORT DbResult Initialize();
     ~ChangesetFileWriter() { FinishOutput(); }

--- a/iModelCore/iModelPlatform/DgnCore/EntityIdsChangeGroup.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/EntityIdsChangeGroup.cpp
@@ -75,7 +75,7 @@ DgnDbStatus EntityIdsChangeGroup::ExtractChangedInstanceIdsFromChangeSets(DgnDbR
 
     for (const auto& changeSetFile : changeSetFiles)
         {
-        ChangesetFileReader changeSetReader(changeSetFile, db);
+        ChangesetFileReader changeSetReader(changeSetFile, &db);
         // changeSetReader.Dump("ExtractChangedInstanceIdsFromChangeSet", db);
         ChangedIdsIterator changeIter(db, changeSetReader);
         for (const auto& changeEntry : changeIter)

--- a/iModelCore/iModelPlatform/DgnHandlers/DgnChangeSummary.cpp
+++ b/iModelCore/iModelPlatform/DgnHandlers/DgnChangeSummary.cpp
@@ -492,7 +492,7 @@ StatusInt    DgnChangeSummary::GetChangedElements(DgnDbR currentDb, DgnDbPtr tar
         for (auto changeset : changesetList)
             {
             BeFileNameCR changesetChangesFile = changeset->GetFileName();
-            ChangesetFileReader changeStream(changesetChangesFile, currentDb);
+            ChangesetFileReader changeStream(changesetChangesFile, &currentDb);
             changeStream.AddToChangeGroup(group);
             }
 

--- a/iModelCore/iModelPlatform/DgnHandlers/VersionCompareChangeSummary.cpp
+++ b/iModelCore/iModelPlatform/DgnHandlers/VersionCompareChangeSummary.cpp
@@ -1775,7 +1775,7 @@ StatusInt    VersionCompareChangeSummary::ProcessChangesets()
         // Create a summary with the current target db
         DgnChangeSummary changeSummary(*m_targetDb);
         // Put together the changeset
-        ChangesetFileReader fr (changeset->GetFileName(), m_targetDb);
+        ChangesetFileReader fr (changeset->GetFileName(), m_targetDb.get());
         changeSummary.FromChangeSet(fr);
 
 // #define DUMP_CHANGE_SUMMARIES

--- a/iModelCore/iModelPlatform/DgnHandlers/VersionCompareChangeSummary.cpp
+++ b/iModelCore/iModelPlatform/DgnHandlers/VersionCompareChangeSummary.cpp
@@ -1601,7 +1601,7 @@ StatusInt ChangedElementFinder::GetChangedElementsFromSummary(
     VCLOG.infov("GetChangedElementsFromSummary: start processing all instances");
     for (auto const& entry : changeSummary.MakeInstanceIterator())
         ProcessInstance(db, changeSummary, entry.GetInstance(), relatedInstanceFinder);
-    
+
     // Query any missing model ids
     QueryMissingInstancesModelIds(db);
 
@@ -1775,7 +1775,7 @@ StatusInt    VersionCompareChangeSummary::ProcessChangesets()
         // Create a summary with the current target db
         DgnChangeSummary changeSummary(*m_targetDb);
         // Put together the changeset
-        ChangesetFileReader fr (changeset->GetFileName(), *m_targetDb);
+        ChangesetFileReader fr (changeset->GetFileName(), m_targetDb);
         changeSummary.FromChangeSet(fr);
 
 // #define DUMP_CHANGE_SUMMARIES

--- a/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/TxnManager.h
+++ b/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/TxnManager.h
@@ -1025,11 +1025,11 @@ struct ChangesetProps : RefCountedBase {
 struct EXPORT_VTABLE_ATTRIBUTE ChangesetFileReader : BeSQLite::ChangesetFileReaderBase {
 private:
     DGNPLATFORM_EXPORT BeSQLite::ChangeSet::ConflictResolution _OnConflict(BeSQLite::ChangeSet::ConflictCause, BeSQLite::Changes::Change iter) override;
-    DgnDbR m_dgndb;
+    DgnDb* m_dgndb;
     Utf8String m_lastErrorMessage;
 
 public:
-    ChangesetFileReader(BeFileNameCR pathname, DgnDbR dgndb) : BeSQLite::ChangesetFileReaderBase({pathname}, dgndb), m_dgndb(dgndb) {}
+    ChangesetFileReader(BeFileNameCR pathname, DgnDb* dgndb = nullptr) : BeSQLite::ChangesetFileReaderBase({pathname}, dgndb), m_dgndb(dgndb) {}
     Utf8StringCR GetLastErrorMessage() const { return m_lastErrorMessage; }
     void ClearLastErrorMessage() { m_lastErrorMessage.clear(); }
 };

--- a/iModelCore/iModelPlatform/Tests/DgnProject/NonPublished/Revision_Test.cpp
+++ b/iModelCore/iModelPlatform/Tests/DgnProject/NonPublished/Revision_Test.cpp
@@ -1552,10 +1552,10 @@ TEST_F(RevisionTestFixture, IterateOverRedundantSchemaChange)
 
     // ignore the initial revision since it will have a bunch of inserted stuff for setup purposes that we're not trying to iterate over
     //RevisionChangesFileReader reader1(revisionPtrs[0]->GetRevisionChangesFile(), *m_db);
-    ChangesetFileReader reader2(revisionPtrs[1]->GetFileName(), *m_db);
-    ChangesetFileReader reader3(revisionPtrs[2]->GetFileName(), *m_db);
-    ChangesetFileReader reader4(revisionPtrs[3]->GetFileName(), *m_db);
-    ChangesetFileReader reader5(revisionPtrs[4]->GetFileName(), *m_db);
+    ChangesetFileReader reader2(revisionPtrs[1]->GetFileName(), m_db.get());
+    ChangesetFileReader reader3(revisionPtrs[2]->GetFileName(), m_db.get());
+    ChangesetFileReader reader4(revisionPtrs[3]->GetFileName(), m_db.get());
+    ChangesetFileReader reader5(revisionPtrs[4]->GetFileName(), m_db.get());
     // this pointer array compensates for a lack of copy or move constructors which make this type difficult to put in STL containers
     std::array<ChangesetFileReader*, revisionPtrs.size() - 1> revisionReaders { &reader2, &reader3, &reader4, &reader5  };
 

--- a/iModelCore/iModelPlatform/iModelConsole/Command.cpp
+++ b/iModelCore/iModelPlatform/iModelConsole/Command.cpp
@@ -919,7 +919,7 @@ void ChangeCommand::_Run(Session& session, Utf8StringCR argsUnparsed) const
                 return;
                 }
 
-            Dgn::ChangesetFileReader changeStream(changesetFilePath, session.GetFile().GetAs<IModelFile>().GetDgnDbHandleR());
+            Dgn::ChangesetFileReader changeStream(changesetFilePath, &session.GetFile().GetAs<IModelFile>().GetDgnDbHandleR());
             PERFLOG_START("iModelConsole", "ExtractChangeSummary>ECDb::ExtractChangeSummary");
             ECInstanceKey changeSummaryKey;
             if (session.GetFileR().GetECDbHandle()->ExtractChangeSummary(changeSummaryKey, ChangeSetArg(changeStream)) != SUCCESS)
@@ -991,7 +991,7 @@ void ChangeCommand::_Run(Session& session, Utf8StringCR argsUnparsed) const
             return;
             }
 
-        Dgn::ChangesetFileReader changeStream(changesetFilePath, session.GetFile().GetAs<IModelFile>().GetDgnDbHandleR());
+        Dgn::ChangesetFileReader changeStream(changesetFilePath, &session.GetFile().GetAs<IModelFile>().GetDgnDbHandleR());
         changeStream.Dump(Utf8String(changesetFilePath.GetFileNameWithoutExtension().c_str()).c_str(), session.GetFile().GetAs<IModelFile>().GetHandle());
         IModelConsole::WriteLine("Successfully logged the content of the changeset file. See logging category 'Changeset' in the iModelConsole logs.");
         return;

--- a/iModelJsNodeAddon/IModelJsNative.cpp
+++ b/iModelJsNodeAddon/IModelJsNative.cpp
@@ -2246,7 +2246,7 @@ struct NativeDgnDb : BeObjectWrap<NativeDgnDb>, SQLiteOps<DgnDb>
         REQUIRE_ARGUMENT_OBJ(0, NativeECDb, changeCacheECDb);
         REQUIRE_ARGUMENT_STRING(1, changesetFilePathStr);
         BeFileName changesetFilePath(changesetFilePathStr.c_str(), true);
-        ChangesetFileReader changeStream(changesetFilePath, db);
+        ChangesetFileReader changeStream(changesetFilePath, &db);
         PERFLOG_START("iModelJsNative", "ExtractChangeSummary>ECDb::ExtractChangeSummary");
         ECInstanceKey changeSummaryKey;
         if (SUCCESS != ECDb::ExtractChangeSummary(changeSummaryKey, changeCacheECDb->GetECDb(), GetOpenedDb(info), ChangeSetArg(changeStream)))
@@ -4352,6 +4352,8 @@ public:
           InstanceMethod("isIndirectChange", &NativeChangesetReader::IsIndirectChange),
           InstanceMethod("getPrimaryKeyColumnIndexes", &NativeChangesetReader::GetPrimaryKeyColumnIndexes),
           InstanceMethod("openFile", &NativeChangesetReader::OpenFile),
+          InstanceMethod("openGroup", &NativeChangesetReader::OpenGroup),
+          InstanceMethod("writeToFile", &NativeChangesetReader::WriteToFile),
           InstanceMethod("openLocalChanges", &NativeChangesetReader::OpenLocalChanges),
           InstanceMethod("reset", &NativeChangesetReader::Reset),
           InstanceMethod("step", &NativeChangesetReader::Step),
@@ -4442,6 +4444,19 @@ public:
         REQUIRE_ARGUMENT_STRING(0, fileName);
         REQUIRE_ARGUMENT_BOOL(1, invert);
         m_changeset.OpenFile(Env(), fileName.c_str(), invert);
+        }
+    void OpenGroup(NapiInfoCR info)
+        {
+        REQUIRE_ARGUMENT_STRING_ARRAY(0, fileNames);
+        REQUIRE_ARGUMENT_BOOL(1, invert);
+        m_changeset.OpenGroup(Env(), fileNames, invert);
+        }
+    void WriteToFile(NapiInfoCR info)
+        {
+        REQUIRE_ARGUMENT_STRING(0, fileName);
+        REQUIRE_ARGUMENT_BOOL(1, containsSchemaChanges);
+        REQUIRE_ARGUMENT_BOOL(2, overrideFile);
+        m_changeset.WriteToFile(Env(), fileName, containsSchemaChanges, overrideFile);
         }
     void OpenLocalChanges(NapiInfoCR info)
         {

--- a/iModelJsNodeAddon/IModelJsNative.h
+++ b/iModelJsNodeAddon/IModelJsNative.h
@@ -634,7 +634,6 @@ struct NativeChangeset {
         bool m_invert;
         Byte* m_primaryKeyColumns;
         Changes::Change m_currentChange;
-        Db m_unusedDb;
         DbOpcode m_opcode;
         int m_columnCount;
         int m_indirect;
@@ -642,6 +641,7 @@ struct NativeChangeset {
         int m_primaryKeyCount;
         std::unique_ptr<Changes> m_changes;
         std::unique_ptr<ChangeStream> m_changeStream;
+        std::unique_ptr<ChangeGroup> m_changeGroup;
         Utf8CP m_tableName;
         Utf8String m_ddl;
 
@@ -656,8 +656,10 @@ struct NativeChangeset {
         NativeChangeset():m_primaryKeyColumns(nullptr), m_tableName(nullptr), m_currentChange(nullptr, false), m_invert(false){}
         void OpenFile(Napi::Env env, Utf8StringCR changesetFile, bool invert);
         void OpenChangeStream(Napi::Env env, std::unique_ptr<ChangeStream>, bool invert);
+        void OpenGroup(Napi::Env env, T_Utf8StringVector const& changesetFiles, bool invert);
         void Close(Napi::Env env);
         void Reset(Napi::Env env);
+        void WriteToFile(Napi::Env env, Utf8String const& fileName, bool containChanges, bool override);
         Napi::Value GetHasRow(Napi::Env env);
         Napi::Value GetColumnCount(Napi::Env env);
         Napi::Value GetColumnValue(Napi::Env env, int col, int target);

--- a/iModelJsNodeAddon/JsInterop.cpp
+++ b/iModelJsNodeAddon/JsInterop.cpp
@@ -388,6 +388,7 @@ private:
 
 public:
     JsDgnHost() { BeAssertFunctions::SetBeAssertHandler(&JsInterop::HandleAssertion);}
+
 };
 
 
@@ -1274,7 +1275,7 @@ void NativeChangeset::OpenFile(Napi::Env env, Utf8StringCR changesetFile, bool i
         BeNapi::ThrowJsException(env, "open(): changeset file specified does not exists", (int)BE_SQLITE_CANTOPEN);
     }
 
-    auto reader = std::make_unique<ChangesetFileReaderBase>(bvector<BeFileName>{input}, m_unusedDb);
+    auto reader = std::make_unique<ChangesetFileReaderBase>(bvector<BeFileName>{input});
     DdlChanges ddlChanges;
     bool hasSchemaChanges;
     reader->MakeReader()->GetSchemaChanges(hasSchemaChanges, ddlChanges);
@@ -1298,6 +1299,82 @@ void NativeChangeset::OpenChangeStream(Napi::Env env, std::unique_ptr<ChangeStre
     m_invert = invert;
     m_changeStream = std::move(changeStream);
 }
+
+//---------------------------------------------------------------------------------------
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+------
+void NativeChangeset::OpenGroup(Napi::Env env, T_Utf8StringVector const& changesetFiles, bool invert) {
+    m_changeGroup = std::make_unique<ChangeGroup>();
+    DdlChanges ddlGroup;
+    for(auto& changesetFile : changesetFiles) {
+        BeFileName inputFile(changesetFile);
+        if (!inputFile.DoesPathExist()) {
+            BeNapi::ThrowJsException(env, SqlPrintfString("openGroup(): changeset file specified does not exists (%s)", inputFile.GetNameUtf8().c_str()), (int)BE_SQLITE_CANTOPEN);
+        }
+
+        ChangesetFileReader reader(inputFile);
+        bool containsSchemaChanges;
+        DdlChanges ddlChanges;
+        if (BE_SQLITE_OK != reader.MakeReader()->GetSchemaChanges(containsSchemaChanges, ddlChanges)){
+            BeNapi::ThrowJsException(env, "openGroup(): unable to read schema changes", (int)BE_SQLITE_ERROR);
+        }
+        for(auto& ddl : ddlChanges.GetDDLs()) {
+            ddlGroup.AddDDL(ddl.c_str());
+        }
+        if (BE_SQLITE_OK != reader.AddToChangeGroup(*m_changeGroup)){
+            BeNapi::ThrowJsException(env, "openGroup(): unable to add changeset to group", (int)BE_SQLITE_ERROR);
+        }
+    }
+
+    m_changeStream = std::make_unique<ChangeSet>();
+    if (BE_SQLITE_OK != m_changeStream->FromChangeGroup(*m_changeGroup)){
+        BeNapi::ThrowJsException(env, "openGroup(): unable to create change stream", (int)BE_SQLITE_ERROR);
+    }
+    m_ddl = ddlGroup.ToString();
+    m_invert = invert;
+}
+//---------------------------------------------------------------------------------------
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+------
+void NativeChangeset::WriteToFile(Napi::Env env, Utf8String const& fileName, bool containChanges, bool override) {
+    const auto kStmtDelimiter = ";";
+    BeFileName outputFile(fileName);
+    DdlChanges ddlChanges;
+    bvector<Utf8String> individualDDLs;
+    BeStringUtilities::Split(m_ddl.c_str(), kStmtDelimiter, individualDDLs);
+
+    for(auto const& ddl : individualDDLs) {
+        ddlChanges.AddDDL(ddl.c_str());
+    }
+
+    if (outputFile.DoesPathExist() && !override) {
+        BeNapi::ThrowJsException(env, "writeToFile(): changeset file already exists", (int)BE_SQLITE_ERROR);
+    }
+
+    if(outputFile.DoesPathExist() && override) {
+        if (outputFile.BeDeleteFile() != BeFileNameStatus::Success) {
+            BeNapi::ThrowJsException(env, "writeToFile(): unable to delete existing changeset file", (int)BE_SQLITE_ERROR);
+        }
+    }
+
+    ChangesetFileWriter writer(outputFile, containChanges, ddlChanges, nullptr);
+    if (BE_SQLITE_OK !=  writer.Initialize()){
+        BeNapi::ThrowJsException(env, "writeToFile(): unable to initialize changeset writer", (int)BE_SQLITE_ERROR);
+    }
+
+    if(m_changeGroup){
+        writer.FromChangeGroup(*m_changeGroup);
+    } else if (m_changeStream) {
+        ChangeGroup changeGroup;
+        m_changeStream->AddToChangeGroup(changeGroup);
+        writer.FromChangeGroup(changeGroup);
+    } else {
+        BeNapi::ThrowJsException(env, "writeToFile(): no changeset to write", (int)BE_SQLITE_ERROR);
+    }
+    if (!outputFile.DoesPathExist()) {
+        BeNapi::ThrowJsException(env, "writeToFile(): unable to write changeset file", (int)BE_SQLITE_ERROR);
+    }
+}
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //+---------------+---------------+---------------+---------------+---------------+------
@@ -1305,6 +1382,8 @@ void NativeChangeset::Close(Napi::Env env) {
     m_currentChange = Changes::Change(nullptr, false);
     m_changes = nullptr;
     m_changeStream = nullptr;
+    m_changeGroup = nullptr;
+    m_invert = false;
     m_ddl.clear();
 }
 

--- a/iModelJsNodeAddon/api_package/ts/src/NativeLibrary.ts
+++ b/iModelJsNodeAddon/api_package/ts/src/NativeLibrary.ts
@@ -1397,9 +1397,11 @@ export declare namespace IModelJsNative {
     public isIndirectChange(): boolean;
     public getPrimaryKeyColumnIndexes(): number[];
     public openFile(fileName: string, invert: boolean): void;
+    public openGroup(fileName: string[], invert: boolean): void;
     public openLocalChanges(db: DgnDb, includeInMemoryChanges: boolean, invert: boolean): void;
     public reset(): void;
     public step(): boolean;
+    public writeToFile(fileName: string, containsSchemaChanges: boolean, overrideFile: boolean): void;
   }
 
   class DisableNativeAssertions implements IDisposable {


### PR DESCRIPTION
This change supports the use case for version comparison, where it is necessary to group or combine changesets before enumerating the changes.

Another minor modification involves allowing the Db& to be provided to the constructor or changeset reader/writer, which is solely utilized for the `Dump()` function in the changeset as Db*. This would make it optional, and if it's not supplied, the Dump() would perform no action.

itwinjs-core:https://github.com/iTwin/itwinjs-core/pull/7080