### PR TITLE
Add db to OpenGroup to resolve schema changes

### DIFF
--- a/iModelJsNodeAddon/IModelJsNative.cpp
+++ b/iModelJsNodeAddon/IModelJsNative.cpp
@@ -4474,7 +4474,6 @@ public:
         ECDb* ecdb = nullptr;
         if (NativeDgnDb::InstanceOf(dbObj)) {
             NativeDgnDb* addonDgndb = NativeDgnDb::Unwrap(dbObj);
-
             ecdb = &addonDgndb->GetDgnDb();
 
         } else if (NativeECDb::InstanceOf(dbObj)) {
@@ -4482,11 +4481,11 @@ public:
             ecdb = &addonECDb->GetECDb();
 
         } else {
-            THROW_JS_TYPE_EXCEPTION("ECSqlStatement::Prepare requires first argument to be a NativeDgnDb or NativeECDb object.");
+            THROW_JS_TYPE_EXCEPTION("Provided db must be a NativeDgnDb or NativeECDb object");
         }
 
         if (!ecdb || !ecdb->IsDbOpen())
-            BeNapi::ThrowJsException(Env(), "provided db is not open");
+            BeNapi::ThrowJsException(Env(), "Provided db is not open");
 
         m_changeset.OpenGroup(Env(), fileNames, *ecdb, invert);
         }

--- a/iModelJsNodeAddon/IModelJsNative.cpp
+++ b/iModelJsNodeAddon/IModelJsNative.cpp
@@ -4468,8 +4468,27 @@ public:
     void OpenGroup(NapiInfoCR info)
         {
         REQUIRE_ARGUMENT_STRING_ARRAY(0, fileNames);
-        REQUIRE_ARGUMENT_BOOL(1, invert);
-        m_changeset.OpenGroup(Env(), fileNames, invert);
+        REQUIRE_ARGUMENT_ANY_OBJ(1, dbObj);
+        REQUIRE_ARGUMENT_BOOL(2, invert);
+
+        ECDb* ecdb = nullptr;
+        if (NativeDgnDb::InstanceOf(dbObj)) {
+            NativeDgnDb* addonDgndb = NativeDgnDb::Unwrap(dbObj);
+
+            ecdb = &addonDgndb->GetDgnDb();
+
+        } else if (NativeECDb::InstanceOf(dbObj)) {
+            NativeECDb* addonECDb = NativeECDb::Unwrap(dbObj);
+            ecdb = &addonECDb->GetECDb();
+
+        } else {
+            THROW_JS_TYPE_EXCEPTION("ECSqlStatement::Prepare requires first argument to be a NativeDgnDb or NativeECDb object.");
+        }
+
+        if (!ecdb || !ecdb->IsDbOpen())
+            BeNapi::ThrowJsException(Env(), "provided db is not open");
+
+        m_changeset.OpenGroup(Env(), fileNames, *ecdb, invert);
         }
     void WriteToFile(NapiInfoCR info)
         {

--- a/iModelJsNodeAddon/IModelJsNative.h
+++ b/iModelJsNodeAddon/IModelJsNative.h
@@ -656,7 +656,7 @@ struct NativeChangeset {
         NativeChangeset():m_primaryKeyColumns(nullptr), m_tableName(nullptr), m_currentChange(nullptr, false), m_invert(false){}
         void OpenFile(Napi::Env env, Utf8StringCR changesetFile, bool invert);
         void OpenChangeStream(Napi::Env env, std::unique_ptr<ChangeStream>, bool invert);
-        void OpenGroup(Napi::Env env, T_Utf8StringVector const& changesetFiles, bool invert);
+        void OpenGroup(Napi::Env env, T_Utf8StringVector const& changesetFiles, Db const& db, bool invert);
         void Close(Napi::Env env);
         void Reset(Napi::Env env);
         void WriteToFile(Napi::Env env, Utf8String const& fileName, bool containChanges, bool override);

--- a/iModelJsNodeAddon/JsInterop.cpp
+++ b/iModelJsNodeAddon/JsInterop.cpp
@@ -1303,8 +1303,8 @@ void NativeChangeset::OpenChangeStream(Napi::Env env, std::unique_ptr<ChangeStre
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //+---------------+---------------+---------------+---------------+---------------+------
-void NativeChangeset::OpenGroup(Napi::Env env, T_Utf8StringVector const& changesetFiles, bool invert) {
-    m_changeGroup = std::make_unique<ChangeGroup>();
+void NativeChangeset::OpenGroup(Napi::Env env, T_Utf8StringVector const& changesetFiles, Db const& db, bool invert) {
+    m_changeGroup = std::make_unique<ChangeGroup>(db);
     DdlChanges ddlGroup;
     for(auto& changesetFile : changesetFiles) {
         BeFileName inputFile(changesetFile);

--- a/iModelJsNodeAddon/api_package/ts/src/NativeLibrary.ts
+++ b/iModelJsNodeAddon/api_package/ts/src/NativeLibrary.ts
@@ -1400,7 +1400,7 @@ export declare namespace IModelJsNative {
     public isIndirectChange(): boolean;
     public getPrimaryKeyColumnIndexes(): number[];
     public openFile(fileName: string, invert: boolean): void;
-    public openGroup(fileName: string[], invert: boolean): void;
+    public openGroup(fileName: string[], db: AnyECDb, invert: boolean): void;
     public openLocalChanges(db: DgnDb, includeInMemoryChanges: boolean, invert: boolean): void;
     public reset(): void;
     public step(): boolean;


### PR DESCRIPTION
Opening changesets as a group requires the context of an iModel db to resolve any schema changes that may have happened in those changesets.

Fixes a bug where OpenGroup failed when the changesets included schema changes.

itwinjs-core: 