### PR TITLE
Revert a previous change that cause two of itwin.js test to fail

### DIFF
--- a/iModelCore/iModelPlatform/DgnCore/TxnManager.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/TxnManager.cpp
@@ -1373,8 +1373,8 @@ DbResult TxnManager::ApplyChanges(ChangeStreamCR changeset, TxnAction action, bo
     auto dataApplyArgs = ApplyChangesArgs::Default()
         .SetRebase(rebase)
         .SetInvert(invert)
-        .SetIgnoreNoop(false)
-        .SetFkNoAction(false);
+        .SetIgnoreNoop(true)
+        .SetFkNoAction(true);
 
     // If schema changes are present, we need to apply only data changes after schema changes are applied.
     if (containsSchemaChanges){


### PR DESCRIPTION
After investigation, it turns out, the behavior documented by the test was incorrect. 

### `DbConflictCause.NotFound - deleted row` 

The test check if we force an orphan row in change set, then anyone pulling it should see FK violation.

1. `b1`, `b2` start off with an element `el1`
2. `b1` delete `el1`.
3. `b2` insert aspect for el1
4. `b1` push OK
5. `b2` pull/merge (test force to ignore conflict of type `CONSTRAINT`)
6. `b2` push just the aspect with no parent element.
7. `b3` pull all changes and it should see two conflict
 * `NOTFOUND` bis_Element (as el1 does not exist
 * `FKVOILATION` as bis_MultiElementAspect has orphan row with no parent.

Before SQLite update, we did not see `FKVOILATION` and only saw `NOTFOUND`.

### `aspect insert, update & delete requires exclusive lock`

This test check if appropriate lock is needed to insert/update/delete aspect.

After the operations on b1 & b2, we should never have pushed any change that resulted in a conflict handler being called. Since we acquire locks and all insert/update/delete were serialized when pushed.
