### PR TITLE
Fix RenderBRep crash

### DIFF
--- a/iModelCore/iModelPlatform/DgnCore/RenderBRep.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/RenderBRep.cpp
@@ -208,8 +208,8 @@ void BRepFacetRequestQueue::Process()
     outerMark = nullptr; // destroy the mark so that its tls is freed before we are terminated
     m_state.store(State::Terminated);
 
-    lock.unlock();
     m_cv.notify_all();
+    lock.unlock();
     }
 
 /*---------------------------------------------------------------------------------**//**


### PR DESCRIPTION
Problem:
`BRepFacetRequestQueue::Process()` sometimes may crash at the `m_cv.notify_all();` (the on at the end of the method). Was reproduced on iOS simulator and device while exiting model, `imobile-native` is used through https://github.com/iTwin/mobile-sdk-ios.

Solution:
Seems like this can happen, because `BRepFacetRequestQueue` destructor can finish executing while `BRepFacetRequestQueue::Process()` is still executing. This crash can be forced to happen by hitting a breakpoint on the last line of `BRepFacetRequestQueue::Process()` and then continuing program execution.
Fixed by putting `m_cv.notify_all();` before `m_cv.unlock()` to ensure that it is executed before destructor has finished (I think it's correct to use it that way, if not - I don't know how else to fix).