### PR TITLE
Regression 4.9.2 where aliased ECClassId switch from returning classId to className

### DIFF
--- a/iModelCore/ECDb/ECDb/ConcurrentQueryManagerImpl.cpp
+++ b/iModelCore/ECDb/ECDb/ConcurrentQueryManagerImpl.cpp
@@ -1006,6 +1006,7 @@ void QueryHelper::Execute(CachedQueryAdaptor& cachedAdaptor, RunnableRequestBase
     const auto abbreviateBlobs = request.GetAbbreviateBlobs();
     const auto includeMetaData= request.GetIncludeMetaData();
     const auto classIdToClassNames = request.GetConvertClassIdsToClassNames();
+    const auto doNotConvertClassIdsToClassNamesWhenAliased = request.GetDoNotConvertClassIdsToClassNamesWhenAliased();
     auto& stmt = cachedAdaptor.GetStatement();
     auto& adaptor = cachedAdaptor.GetJsonAdaptor();
     ECSqlRowProperty::List props;
@@ -1015,6 +1016,7 @@ void QueryHelper::Execute(CachedQueryAdaptor& cachedAdaptor, RunnableRequestBase
     adaptor.GetOptions().SetAbbreviateBlobs(abbreviateBlobs);
     adaptor.GetOptions().SetConvertClassIdsToClassNames(classIdToClassNames);
     adaptor.GetOptions().UseJsNames(request.GetValueFormat() == ECSqlRequest::ECSqlValueFormat::JsNames);
+    adaptor.GetOptions().DoNotConvertClassIdsToClassNamesWhenAliased(doNotConvertClassIdsToClassNamesWhenAliased);
     uint32_t row_count = 0;
     std::string& result = cachedAdaptor.ClearAndGetCachedString();
     result.reserve(QUERY_WORKER_RESULT_RESERVE_BYTES);
@@ -1649,6 +1651,9 @@ void ECSqlRequest::FromJs(BeJsConst const& val) {
     }
     if (val.isNumericMember(JValueFormat)) {
         m_valueFmt = (ECSqlValueFormat)val[JValueFormat].asInt();
+    }
+    if (val.isBoolMember(ECSqlRowAdaptor::Options::JDoNotConvertClassIdsToClassNamesWhenAliased)) {
+        m_doNotConvertClassIdsToClassNamesWhenAliased = val[ECSqlRowAdaptor::Options::JDoNotConvertClassIdsToClassNamesWhenAliased].asBool();
     }
 }
 

--- a/iModelCore/ECDb/PublicAPI/ECDb/ConcurrentQueryManager.h
+++ b/iModelCore/ECDb/PublicAPI/ECDb/ConcurrentQueryManager.h
@@ -278,10 +278,11 @@ struct ECSqlRequest : public QueryRequest{
         bool m_suppressLogErrors;
         bool m_includeMetaData;
         bool m_convertClassIdsToClassNames;
+        bool m_doNotConvertClassIdsToClassNamesWhenAliased;
         ECSqlValueFormat m_valueFmt;
     public:
         ECSqlRequest(std::string const& query, ECSqlParams&& args)
-            :QueryRequest(Kind::ECSql), m_query(query), m_args(std::move(args)),m_abbreviateBlobs(false), m_suppressLogErrors(false),m_includeMetaData(true), m_convertClassIdsToClassNames(false),m_valueFmt(ECSqlValueFormat::ECSqlNames){}
+            :QueryRequest(Kind::ECSql), m_query(query), m_args(std::move(args)),m_abbreviateBlobs(false), m_suppressLogErrors(false),m_includeMetaData(true), m_convertClassIdsToClassNames(false), m_doNotConvertClassIdsToClassNamesWhenAliased(true), m_valueFmt(ECSqlValueFormat::ECSqlNames){}
         virtual ~ECSqlRequest(){}
         std::string const& GetQuery() const { return m_query; }
         ECSqlParams const& GetArgs() const { return  m_args; }
@@ -290,6 +291,7 @@ struct ECSqlRequest : public QueryRequest{
         bool GetSuppressLogErrors() const {return m_suppressLogErrors; }
         bool GetIncludeMetaData() const {return m_includeMetaData; }
         bool GetConvertClassIdsToClassNames() const {return m_convertClassIdsToClassNames; }
+        bool GetDoNotConvertClassIdsToClassNamesWhenAliased() const { return m_doNotConvertClassIdsToClassNamesWhenAliased; }
         QueryLimit const& GetLimit() const {return m_limit;}
         ECSqlValueFormat GetValueFormat() const { return m_valueFmt; }
         ECSqlRequest& SetValueFmt(ECSqlValueFormat fmt) noexcept { m_valueFmt = fmt; return *this;}

--- a/iModelCore/ECDb/PublicAPI/ECDb/ECSqlStatement.h
+++ b/iModelCore/ECDb/PublicAPI/ECDb/ECSqlStatement.h
@@ -757,10 +757,10 @@ enum class QueryRowFormat {
 //=======================================================================================
 struct ECSqlRowAdaptor {
     struct Options {
-        const char* JAbbreviateBlobs = "abbreviateBlobs";
-        const char* JClassIdsToClassNames = "classIdsToClassNames";
-        const char* JUseJsName = "useJsName";
-        const char* JDoNotConvertClassIdsToClassNamesWhenAliased = "doNotConvertClassIdsToClassNamesWhenAliased";
+        static constexpr auto JAbbreviateBlobs = "abbreviateBlobs";
+        static constexpr auto JClassIdsToClassNames = "classIdsToClassNames";
+        static constexpr auto JUseJsName = "useJsName";
+        static constexpr auto JDoNotConvertClassIdsToClassNamesWhenAliased = "doNotConvertClassIdsToClassNamesWhenAliased";
 
         bool m_abbreviateBlobs = true;
         bool m_classIdToClassNames = false;
@@ -770,6 +770,7 @@ struct ECSqlRowAdaptor {
         Options& SetAbbreviateBlobs(bool v) { m_abbreviateBlobs = v; return *this; }
         Options& SetConvertClassIdsToClassNames(bool v) { m_classIdToClassNames = v;  return *this; }
         Options& UseJsNames(bool v) { m_useJsName = v;  return *this; }
+        Options& DoNotConvertClassIdsToClassNamesWhenAliased(bool v) { m_doNotConvertClassIdsToClassNamesWhenAliased = v;  return *this; }
         ECDB_EXPORT void FromJson(BeJsValue opts);
         ECDB_EXPORT void ToJson(BeJsValue opts) const;
     };


### PR DESCRIPTION
1. CTE query returning classid switch from className to classId in `4.9.x`. This broke a user. 
2. [PR 7235](https://github.com/iTwin/itwinjs-core/pull/7238) Fix CTE, but this requires properly handling extendType information. This result in another break in behavior where aliased classid property was return as className. In 4.8.x/ 4.9.0 it used to return Id not class name. This break only happens for Concurrent Query for ECSqlStatement was fine as it set a flag called `DoNotConvertClassIdsToClassNamesWhenAliased` to reproduce previous behavior.
3. This PR also set `DoNotConvertClassIdsToClassNamesWhenAliased` for concurrent query to reproduce behavior of classId returning class name when aliased to be compilable with 4.8.x


First query that broke user is following 
```sql
SELECT t(aClassId) AS (SELECT ECClassId FROM Bis.Element) SELECT * FROM t
-- 4.8.x return className
-- 4.9.0 return classId
```
```sql
SELECT ECClassId AS aClassId FROM Bis.Element
--4.9.0 returned classId
--4.9.2 return className
```

After current fix

```sql
SELECT t(aClassId) AS (SELECT ECClassId FROM Bis.Element) SELECT * FROM t
-- return className as in 4.8.x
```
```sql
SELECT ECClassId AS aClassId FROM Bis.Element
-- returned classId  as in 4.8.x
```

itwinjs-core: https://github.com/iTwin/itwinjs-core/pull/7279