### PR TITLE
Fix for Xcode 16 compilation

### DIFF
--- a/iModelCore/Bentley/PublicAPI/Bentley/BeEvent.h
+++ b/iModelCore/Bentley/PublicAPI/Bentley/BeEvent.h
@@ -79,24 +79,24 @@ public:
         m_listeners.push_back(std::make_unique<EventContext>(listener, false, ++m_listenerIds));
         uint32_t id = m_listeners.back()->Id();
         if (eventId) *eventId = id;
-        return [=]() { RemoveListener(id); };
+        return [=, this]() { RemoveListener(id); };
     }
     void AddListener(BeEventScope& scope, listener_type listener) {
         uint32_t id;
         auto cancel = AddListener(listener, &id);
-        scope.Add([=]() { RemoveListener(id); });
+        scope.Add([=, this]() { RemoveListener(id); });
     }
     cancel_callback_type AddOnce(listener_type listener, uint32_t* eventId = nullptr) {
         BeMutexHolder lock(m_mutex);
         m_listeners.push_back(std::make_unique<EventContext>(listener, true,  ++m_listenerIds));
         uint32_t id = m_listeners.back()->Id();
         if (eventId) *eventId = id;
-        return [=]() { RemoveListener(id); };
+        return [=, this]() { RemoveListener(id); };
     }
     void AddOnce(BeEventScope& scope, listener_type listener) {
         uint32_t id;
         auto cancel = AddOnce(listener, &id);
-        scope.Add([=]() { RemoveListener(id); });
+        scope.Add([=, this]() { RemoveListener(id); });
     }
     void RemoveListener(uint32_t eventId) {
         BeMutexHolder lock(m_mutex);

--- a/iModelCore/libsrc/facebook/VendorApi/folly/BeFolly.h
+++ b/iModelCore/libsrc/facebook/VendorApi/folly/BeFolly.h
@@ -106,7 +106,7 @@ struct LimitingTaskQueue
         folly::via(&m_executor, [=] {
             return task.first(); // execute task
         })
-            .then([=](Result_T result) {
+            .then([=, this](Result_T result) {
                 --m_runningTasks;
                 task.second->setValue(result); // fulfill the promise
                 CheckQueue();

--- a/iModelJsNodeAddon/JsCloudSqlite.cpp
+++ b/iModelJsNodeAddon/JsCloudSqlite.cpp
@@ -257,7 +257,7 @@ struct JsCloudContainer : CloudContainer, Napi::ObjectWrap<JsCloudContainer> {
 
     Napi::Value UploadChanges(NapiInfoCR info) {
         RequireWriteLock();
-        return QueueWorker(info, [=]() { return CloudContainer::UploadChanges(); });
+        return QueueWorker(info, [=, this]() { return CloudContainer::UploadChanges(); });
     }
 
     Napi::Value GetBlockSize(NapiInfoCR) {
@@ -448,13 +448,13 @@ struct JsCloudContainer : CloudContainer, Napi::ObjectWrap<JsCloudContainer> {
         RequireWriteLock();
         REQUIRE_ARGUMENT_STRING(0, fromName);
         REQUIRE_ARGUMENT_STRING(1, toName);
-        return QueueWorker(info, [=]() { return CloudContainer::CopyDatabase(fromName, toName); });
+        return QueueWorker(info, [=, this]() { return CloudContainer::CopyDatabase(fromName, toName); });
     }
 
     Napi::Value DeleteDatabase(NapiInfoCR info) {
         RequireWriteLock();
         REQUIRE_ARGUMENT_STRING(0, dbName);
-        return QueueWorker(info, [=]() { return CloudContainer::DeleteDatabase(dbName); });
+        return QueueWorker(info, [=, this]() { return CloudContainer::DeleteDatabase(dbName); });
     }
 
     void InitializeContainer(NapiInfoCR info) {


### PR DESCRIPTION
New warning treated as error: implicit this in lambda capture. Update `[=]` to `[=, this]` where `this` is captured.

Note: I believe that these changes require C++20, but as far as I can tell, all of the code that I modified is set to C++20 mode.