### PR TITLE
Address unused-but-set-variable warnings

### DIFF
--- a/iModelCore/ECDb/ECDb/ECSql/Parser/SqlBison.cpp
+++ b/iModelCore/ECDb/ECDb/ECSql/Parser/SqlBison.cpp
@@ -2442,6 +2442,7 @@ YYSTYPE yylval YY_INITIAL_VALUE (= yyval_default);
 
     /* Number of syntax errors so far.  */
     int yynerrs = 0;
+    UNUSED_VARIABLE(yynerrs);
 
     yy_state_fast_t yystate = 0;
     /* Number of tokens to shift before error messages enabled.  */

--- a/iModelCore/ECDb/ECDb/ECSql/Parser/SqlFlex.cpp
+++ b/iModelCore/ECDb/ECDb/ECSql/Parser/SqlFlex.cpp
@@ -5176,12 +5176,10 @@ sal_Int32 parseString (yyscan_t yyscanner)
     Utf8String sBuffer;
     sBuffer.reserve(256);
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
-    int s = 1;
     while (!checkeof (ch = yyinput (yyscanner)))
     {
     if (ch == delim)
         {
-        s++;
         ch = yyinput (yyscanner);
         if (checkeof (ch))
         {

--- a/iModelCore/ECDb/ECDb/ECSql/SelectStatementExp.cpp
+++ b/iModelCore/ECDb/ECDb/ECSql/SelectStatementExp.cpp
@@ -866,6 +866,7 @@ SingleSelectStatementExp::SingleSelectStatementExp(std::vector<std::unique_ptr<V
     {
     std::unique_ptr<SelectClauseExp> selectClauseExp = std::make_unique<SelectClauseExp>();
     int expIx = 0;
+    UNUSED_VARIABLE(expIx);
     for (std::unique_ptr<ValueExp>& valueExp : valueExpList)
         {
         expIx++;

--- a/iModelCore/GeoCoord/BaseGeoCoord/basegeocoord.cpp
+++ b/iModelCore/GeoCoord/BaseGeoCoord/basegeocoord.cpp
@@ -13122,8 +13122,7 @@ Utf8CP unitName
         return GEOCOORDERR_InvalidCoordSys;
 
     const struct cs_Unittab_   *pUnit;
-    int                         index;
-    for (index = 0, pUnit = cs_Unittab; cs_UTYP_END != pUnit->type; pUnit++)
+    for (pUnit = cs_Unittab; cs_UTYP_END != pUnit->type; pUnit++)
         {
         if (pUnit->type == cs_UTYP_LEN)
             {
@@ -13133,7 +13132,6 @@ Utf8CP unitName
                 SetModified(true);
                 return SUCCESS;
                 }
-            index++;
             }
         /* If the unit type is not length then it must be angular and can only be used to set lat/long geographic coordinate systems */
         else if (cs_PRJCOD_UNITY == m_csParameters->prj_code)
@@ -13144,7 +13142,6 @@ Utf8CP unitName
                 SetModified(true);
                 return SUCCESS;
                 }
-            index++;
             }
         }
     return GEOCOORDERR_InvalidUnitCode;

--- a/iModelCore/GeomLibs/geom/src/CurvePrimitive/cv_areaBooleans.cpp
+++ b/iModelCore/GeomLibs/geom/src/CurvePrimitive/cv_areaBooleans.cpp
@@ -519,6 +519,8 @@ CurveVectorPtr &result
     result = CurveVectorPtr ();
     MTGNodeId nodeId, nextNodeId;   // or coded sequence token.
     int numLoop = 0;
+    UNUSED_VARIABLE(numLoop);
+    
     for (;TryGetInt (sequenceArray, nodeId, sequencerReadIndex);)
         {
         sequencerReadIndex++;

--- a/iModelCore/GeomLibs/geom/src/DeprecatedFunctions.cpp
+++ b/iModelCore/GeomLibs/geom/src/DeprecatedFunctions.cpp
@@ -1980,6 +1980,7 @@ int         depth
     {
     int parent;
     static int errors = 0;
+    UNUSED_VARIABLE(errors);
     if (SUCCESS == IntArrayWrapper::get (pInstance, &parent, cluster))
         {
         if (parent != cluster)

--- a/iModelCore/GeomLibs/geom/src/bezier/bezeval.cpp
+++ b/iModelCore/GeomLibs/geom/src/bezier/bezeval.cpp
@@ -1877,10 +1877,15 @@ int         numComponentB
     if (orderAB > MAX_BEZIER_ORDER)
         return false;
 
-    static int sNum1 = 0;
-    static int sNum2 = 0;
-    static int sNum3 = 0;
-    static int sNumX = 0;
+    int sNum1 = 0;
+    int sNum2 = 0;
+    int sNum3 = 0;
+    int sNumX = 0;
+    UNUSED_VARIABLE(sNum1);
+    UNUSED_VARIABLE(sNum2);
+    UNUSED_VARIABLE(sNum3);
+    UNUSED_VARIABLE(sNumX);
+
     if (degreeAB == 1)
         sNum1++;
     else if (degreeAB == 2)

--- a/iModelCore/GeomLibs/geom/src/bezier/bezierDPoint4d.cpp
+++ b/iModelCore/GeomLibs/geom/src/bezier/bezierDPoint4d.cpp
@@ -2780,8 +2780,11 @@ DPoint3d    *pPoleArray,
 static void GetSampleFractions (double *fraction, int &numOut, int order, int numInteriorEdge, int numExtrapolate, int maxOut)
     {
     double u0, du;
-    static size_t sNumLines = 0;
-    static size_t sNumCurves = 0;
+    size_t sNumLines = 0;
+    size_t sNumCurves = 0;
+    UNUSED_VARIABLE(sNumLines);
+    UNUSED_VARIABLE(sNumCurves);
+
     if (order < 3)
         {
         numOut = 2;
@@ -2865,9 +2868,12 @@ const DPoint4d  *pB,
     int numExtraIntersection    = 0;
 
 
-    static int sNum22 = 0;
-    static int sNum2N = 0;
-    static int sNumNN = 0;
+    int sNum22 = 0;
+    int sNum2N = 0;
+    int sNumNN = 0;
+    UNUSED_VARIABLE(sNum22);
+    UNUSED_VARIABLE(sNum2N);
+    UNUSED_VARIABLE(sNumNN);
 
     if (orderA == 2 && orderB == 2)
         sNum22++;
@@ -2899,6 +2905,8 @@ const DPoint4d  *pB,
                 xyzA, numSampleA, false,
                 xyzB, numSampleB, false);
     int numExternal = 0;
+    UNUSED_VARIABLE(numExternal);
+    
     if (numSegmentIntersection > 0)
         {
         Function_Bezier_FractionToXY bezierA(pA, orderA);

--- a/iModelCore/GeomLibs/geom/src/bspline/bspSmoothPolyface.cpp
+++ b/iModelCore/GeomLibs/geom/src/bspline/bspSmoothPolyface.cpp
@@ -197,6 +197,9 @@ void vu_deletePairedEdges (VuSetP graph, VuMask mask)
     vu_clearMaskInSet (graph, deleteMask);
     int numVu = 0;
     int numA = 0;
+    UNUSED_VARIABLE(numVu);
+    UNUSED_VARIABLE(numA);
+    
     VU_SET_LOOP (sectorSeed, graph)
         {
         numVu++;
@@ -557,7 +560,7 @@ void AddEvaluatedVuToPolyface (VuSetP graph, IPolyfaceConstructionR builder, MSB
     vu_collectInteriorFaceLoops (faceArrayP, graph);
     vu_arrayOpen (faceArrayP);
     static int s_skipStrangeFaces = 0;
-    for (int i = 0; vu_arrayRead (faceArrayP, &faceP); i++)
+    while (vu_arrayRead (faceArrayP, &faceP))
         {
         // We triangulated.  So of course there are 3 nodes per face.
         // Really?  If the input polygon retraces itself, there will be

--- a/iModelCore/GeomLibs/geom/src/bspline/bsppolyface.cpp
+++ b/iModelCore/GeomLibs/geom/src/bspline/bsppolyface.cpp
@@ -1136,6 +1136,8 @@ BuilderParams          *mpP                /* => mesh parameters */
     //   But whey didn't this show up in SS3 hline?  Dunno.
     static int s_diagonalFactorForLoHi = 0;   // 0 suppresses transfer of diagonal to edges.
     int numPositive, numNegative;
+    UNUSED_VARIABLE(numPositive);
+
     double polygonLength, polygonLength0, polygonLength1, polygonLength2;
     double          angleTolerance = mpP->options.GetAngleTolerance ();
     static double s_minAngleTolerance = 0.1;

--- a/iModelCore/GeomLibs/geom/src/bspline/bspsurfacetrim.cpp
+++ b/iModelCore/GeomLibs/geom/src/bspline/bspsurfacetrim.cpp
@@ -633,6 +633,7 @@ SurfaceBreakContext&    breakContext
     bvector<DPoint3d> surfacePoints;
 
     int numCurve = 0;
+    UNUSED_VARIABLE(numCurve);
 
     for (TrimCurveCP pCurrTrim = sourceBoundary.pFirst; NULL != pCurrTrim; pCurrTrim = pCurrTrim->pNext)
         {

--- a/iModelCore/GeomLibs/geom/src/funcs/PolygonOps.cpp
+++ b/iModelCore/GeomLibs/geom/src/funcs/PolygonOps.cpp
@@ -336,7 +336,6 @@ bool             addVerticesAtCrossings
     VuMask      numberedNodeMask = vu_grabMask (graphP);
     VuP         faceP, originalNodeP;
     bool status = false;
-    int       i;
     int       originalIndex;
     int       outputIndex;
     int     separator = signedOneBasedIndices ? 0 : -1;
@@ -368,7 +367,7 @@ bool             addVerticesAtCrossings
 
     vu_arrayOpen (faceArrayP);
     status = true;
-    for (i = 0; status && vu_arrayRead (faceArrayP, &faceP); i++)
+    while (status && vu_arrayRead (faceArrayP, &faceP))
         {
         // ignore faces that did not triangulate, such as a part of the polygon that retraces itself
         int numEdges = vu_faceLoopSize(faceP);
@@ -445,7 +444,7 @@ bool             addVerticesAtCrossings
         vu_collectExteriorFaceLoops (faceArrayP, graphP);
         vu_arrayOpen (faceArrayP);
         status = true;
-        for (i = 0; status && vu_arrayRead (faceArrayP, &faceP); i++)
+        while (status && vu_arrayRead (faceArrayP, &faceP))
             {
             VuP lowIndexP = faceP;
             int lowIndex = vu_getUserDataPAsInt (faceP);
@@ -1334,6 +1333,7 @@ bool PolygonOps::PickTriangleFromStart
     double fi;
     DPoint3d xyzi;
     size_t numHit = 0;
+    UNUSED_VARIABLE(numHit);
     for (size_t i0 = 1, i1 = 2; i1 < numXYZ; i0 = i1++)
         {
         DPoint3d uvwLocal;
@@ -1536,6 +1536,7 @@ double      tol             /* tolerance for ON case detection */
     double crossing;
     double s;
     int numLeft = 0, numRight = 0;
+    UNUSED_VARIABLE(numRight);
 
     int i, i0;
     if (fabs (h0) <= tol)
@@ -1596,6 +1597,7 @@ double      tol             /* tolerance for ON case detection */
     double crossing;
     double s;
     int numLeft = 0, numRight = 0;
+    UNUSED_VARIABLE(numRight);
 
     int i, i0;
     if (fabs (h0) <= tol)
@@ -1665,6 +1667,7 @@ double      tol             /* tolerance for ON case detection */
     double u;
     double s;
     int numLeft = 0, numRight = 0;
+    UNUSED_VARIABLE(numRight);
 
     int i, i0;
 

--- a/iModelCore/GeomLibs/geom/src/funcs/linalg.cpp
+++ b/iModelCore/GeomLibs/geom/src/funcs/linalg.cpp
@@ -2297,6 +2297,7 @@ int     n
     double  tresh, theta, tau, t, sum, s, c, g, h;
     //int nn = n * n;
     int numRotations = 0;
+    UNUSED_VARIABLE(numRotations);
     //int diagonalStep = n + 1;
 
     /* Initialize Eigenvectors as identity matrix */

--- a/iModelCore/GeomLibs/geom/src/funcs/polygon3d.cpp
+++ b/iModelCore/GeomLibs/geom/src/funcs/polygon3d.cpp
@@ -306,6 +306,7 @@ double      tol               /* tolerance for ON case detection */
     double crossing;
     double s;
     int numLeft = 0, numRight = 0;
+    UNUSED_VARIABLE(numRight);
 
     int i, i0;
     if (fabs (h0) <= tol)
@@ -366,6 +367,7 @@ double      tol               /* tolerance for ON case detection */
     double crossing;
     double s;
     int numLeft = 0, numRight = 0;
+    UNUSED_VARIABLE(numRight);
 
     int i, i0;
     if (fabs (h0) <= tol)
@@ -436,6 +438,7 @@ double      tol               /* tolerance for ON case detection */
     double u;
     double s;
     int numLeft = 0, numRight = 0;
+    UNUSED_VARIABLE(numRight);
 
     int i, i0;
 
@@ -704,6 +707,8 @@ double      tol
     int i0 = 0;
     int numIn = 0;
     int numOut = 0;
+    UNUSED_VARIABLE(numOut);
+    
     for (int i1 = 0; i1 <= numPoint;)
         {
         if (i1 >= numPoint || pPointArray[i1].IsDisconnect ())

--- a/iModelCore/GeomLibs/geom/src/mtg/MtgFacetPlanarMerge.cpp
+++ b/iModelCore/GeomLibs/geom/src/mtg/MtgFacetPlanarMerge.cpp
@@ -17,6 +17,9 @@ bool MarkPlanarBoundaries (MTGFacets &facets, MTGMask boundaryMask, MTGMask igno
     size_t errors = 0;
     size_t numSmooth = 0;
     size_t numAngle = 0;
+    UNUSED_VARIABLE(numSmooth);
+    UNUSED_VARIABLE(numAngle);
+
     MTGARRAY_SET_LOOP (nodeIdA, graph)
         {
         if (!graph->HasMaskAt (nodeIdA, visitMask))
@@ -116,6 +119,9 @@ void MarkColinearEdges (MTGFacets &facets, MTGMask boundaryMask, MTGMask exterio
     MTGMask visitMask = visitMaskA.Get ();
     size_t numSmooth = 0;
     size_t numTested = 0;
+    UNUSED_VARIABLE(numSmooth);
+    UNUSED_VARIABLE(numTested);
+
     MTGARRAY_SET_LOOP (nodeIdA, &graph)
         {
         if (!graph.HasMaskAt (nodeIdA, visitMask)

--- a/iModelCore/GeomLibs/geom/src/mtg/jmdl_mtgstitch.cpp
+++ b/iModelCore/GeomLibs/geom/src/mtg/jmdl_mtgstitch.cpp
@@ -659,6 +659,7 @@ bool     SortAroundEdges (bool deleteDuplicateFaces = true)
     const DPoint3d *pCoordinateArray;
     DVec3d normal;
     int errorCount = 0;
+    UNUSED_VARIABLE(errorCount);
 
     for (MTGNodeId startId : faceStartArray)
         {

--- a/iModelCore/GeomLibs/geom/src/polyface/ClipPlane.cpp
+++ b/iModelCore/GeomLibs/geom/src/polyface/ClipPlane.cpp
@@ -427,6 +427,8 @@ DRange1d &altitudeRange                 //!< [out] min and max altitude values.
     xyzOut.clear ();
     xyzIn.clear ();
     size_t numSplit = 0;
+    UNUSED_VARIABLE(numSplit);
+    
     static double s_fractionTol = 1.0e-8;
     if (xyz.size () > 2)
         {

--- a/iModelCore/GeomLibs/geom/src/polyface/ClipPlaneSet.cpp
+++ b/iModelCore/GeomLibs/geom/src/polyface/ClipPlaneSet.cpp
@@ -934,6 +934,9 @@ ClipPlaneSet  ClipPlaneSet::FromSweptPolygon (DPoint3dCP points, size_t n, DVec3
     ClipPlaneSet      clipSet;
     size_t numNegative = 0;
     size_t numPositive = 0;
+    UNUSED_VARIABLE(numNegative);
+    UNUSED_VARIABLE(numPositive);
+
     VU_SET_LOOP (faceSeed, graphP)
         {
         if (   !vu_getMask (faceSeed, visitMask)

--- a/iModelCore/GeomLibs/geom/src/polyface/IPolyfaceConstruction_Add.cpp
+++ b/iModelCore/GeomLibs/geom/src/polyface/IPolyfaceConstruction_Add.cpp
@@ -925,7 +925,7 @@ static bool AddRuledBetweenCorrespondingBsplineCurves
     if (numOK != numContour)
         return false;
 
-    for (size_t bezierIndex = 0; true; bezierIndex++)
+    while (true)
         {
         // Advance all the beziers ...
         size_t numAdvanced = 0;
@@ -2222,6 +2222,7 @@ static CurveVector::BoundaryType CommonBoundaryType (bvector<CurveVectorPtr> con
     size_t numClosed = 0;
     size_t numParity = 0;
     size_t numUnion = 0;
+    UNUSED_VARIABLE(numOpen);
 
     for (size_t i = 0; i < curves.size (); i++)
         {

--- a/iModelCore/GeomLibs/geom/src/polyface/Polyface.cpp
+++ b/iModelCore/GeomLibs/geom/src/polyface/Polyface.cpp
@@ -1402,6 +1402,7 @@ bvector<T> &newData
     for (size_t i = 0; i < numData; i++)
         oldDataToNewData.push_back (SIZE_MAX);
     size_t errors = 0;
+    UNUSED_VARIABLE(errors);
     for (int &index1 : indices)  // ONE BASED
         {
         if (index1 != 0)

--- a/iModelCore/GeomLibs/geom/src/polyface/PolyfaceAddTriangulation.cpp
+++ b/iModelCore/GeomLibs/geom/src/polyface/PolyfaceAddTriangulation.cpp
@@ -813,6 +813,8 @@ VuMask exteriorMask = VU_EXTERIOR_EDGE
     static bool s_interior = false;
     static double s_sign = -1.0;
     size_t errors = 0;
+    UNUSED_VARIABLE(errors);
+    
     if (nullptr != cellData)
         cellData->clear ();
     int useEdgeNeighborClip = voronoiMetric != 1.0;

--- a/iModelCore/GeomLibs/geom/src/polyface/PolyfaceClip1.cpp
+++ b/iModelCore/GeomLibs/geom/src/polyface/PolyfaceClip1.cpp
@@ -754,6 +754,7 @@ void AnalyzeCutPlaneLoops(size_t numComplexFaces)
             // Anything left is a complete loop.
             // Holes?
             size_t numLoop = 0;
+            UNUSED_VARIABLE(numLoop);
             for (size_t startIndex = beginIndex; startIndex < endIndex; startIndex++)
                 {
                 // This is wrong for holeInFace !!!

--- a/iModelCore/GeomLibs/geom/src/polyface/PolyfaceEdgeChain.cpp
+++ b/iModelCore/GeomLibs/geom/src/polyface/PolyfaceEdgeChain.cpp
@@ -53,6 +53,8 @@ bool PolyfaceEdgeChain::GetXYZ (bvector<DPoint3d> &dest, bvector<DPoint3d> const
     size_t n = source.size ();
     size_t oldIndex = SIZE_MAX;
     size_t dups = 0;
+    UNUSED_VARIABLE(dups);
+    
     for (auto index1 : m_vertexIndices)
         {
         if (index1 == oldIndex)

--- a/iModelCore/GeomLibs/geom/src/polyface/PolyfacePartition.cpp
+++ b/iModelCore/GeomLibs/geom/src/polyface/PolyfacePartition.cpp
@@ -299,6 +299,8 @@ bool Load ()
     */
     bool ignore = false;
     size_t numNull = 0;
+    UNUSED_VARIABLE(numNull);
+    
     bvector<DPoint3d>const& points = visitor->Point ();
     for (visitor->Reset (); visitor->AdvanceToNextFace ();)
         {

--- a/iModelCore/GeomLibs/geom/src/polyface/PolyfaceVisitorSearch.cpp
+++ b/iModelCore/GeomLibs/geom/src/polyface/PolyfaceVisitorSearch.cpp
@@ -58,7 +58,7 @@ bool PolyfaceVisitor::AdvanceToFacetBySearchPoint (DPoint3dCR xyz, double tolera
 #else
     edgeIndex = -1;
     edgeFraction = 0.0;
-    for (int faceIndex = 0; AdvanceToNextFace (); faceIndex++)
+    while (AdvanceToNextFace ())
         {
         int code = bsiPolygon_closestPointExt (facetXYZ, edgeIndex, edgeFraction, &m_point[0], (int)m_point.size (), xyz);
         double distance = xyz.Distance (facetXYZ);
@@ -75,7 +75,7 @@ bool PolyfaceVisitor::AdvanceToFacetBySearchPoint (DPoint3dCR xyz, double tolera
 +--------------------------------------------------------------------------------------*/
 bool PolyfaceVisitor::AdvanceToFacetBySearchPoint (DPoint3dCR xyz, double tolerance, DPoint3dR facetXYZ)
     {
-    for (int faceIndex = 0; AdvanceToNextFace (); faceIndex++)
+    while (AdvanceToNextFace ())
         {
         if (TryFindCloseFacetPoint (xyz, tolerance, facetXYZ))
             return true;

--- a/iModelCore/GeomLibs/geom/src/polyface/pf_cutFill.cpp
+++ b/iModelCore/GeomLibs/geom/src/polyface/pf_cutFill.cpp
@@ -246,6 +246,7 @@ void vu_deleteNullFaceParityPairs (VuSetP graph, VuMask exteriorMask, bool delet
 void vu_checkConsistentFaceMask (VuSetP graph, VuMask mask)
     {
     int numError = 0;
+    UNUSED_VARIABLE(numError);
     VuMask visitMask = vu_grabMask (graph);
     vu_clearMaskInSet (graph, visitMask);
     assert (visitMask != 0);
@@ -355,6 +356,7 @@ public:
 void PushGraph ()
     {
     static int numNonNull = 0;
+    UNUSED_VARIABLE(numNonNull);
     if (NULL != vu_firstNodeInGraph (m_pGraph))
         numNonNull++;
     vu_stackPush (m_pGraph);
@@ -363,6 +365,7 @@ void PushGraph ()
 void PopGraph ()
     {
     static int numNonNull = 0;
+    UNUSED_VARIABLE(numNonNull);
     if (NULL != vu_firstNodeInGraph (m_pGraph))
         numNonNull++;
     vu_stackPop (m_pGraph);
@@ -1159,6 +1162,8 @@ void CollectClip (TaggedPolygonVectorR outputPolygons, bool subtractB, bool inte
     m_clipper.ActivateCollection (s_indexFinal);
     m_clipper.SetupForLoopOverInteriorFaces ();
     size_t numPolygon = 0;
+    UNUSED_VARIABLE(numPolygon);
+    
     for (;m_clipper.GetFace (xyz, false);)
         {
         double area = bsiGeom_getXYPolygonArea (&xyz[0], (int)xyz.size ());

--- a/iModelCore/GeomLibs/geom/src/polyface/pf_halfEdgeArray.h
+++ b/iModelCore/GeomLibs/geom/src/polyface/pf_halfEdgeArray.h
@@ -380,6 +380,10 @@ DVec3dCP silhouetteVector
     size_t numBoundary = 0;
     size_t numPositiveIndex = 0;
     size_t numNegativeIndex = 0;
+    UNUSED_VARIABLE(numBoundary);
+    UNUSED_VARIABLE(numPositiveIndex);
+    UNUSED_VARIABLE(numNegativeIndex);
+
     for (size_t i0 = 0, numMatch = 0; i0 < numHalfEdge; i0 += numMatch)
         {
         numMatch = 1;
@@ -528,6 +532,7 @@ bool returnSingleEdgeReadIndex
         {
         numMatch = 1;
         size_t numVisible = 0;
+        UNUSED_VARIABLE(numVisible);
         if (at(i0).IsVisible ())
             numVisible = 1;
         for (size_t i1 = i0 + 1; i1 < numHalfEdge && !cb_LessThan_LowVertexHighVertex (at(i0), at(i1)); i1++)

--- a/iModelCore/GeomLibs/geom/src/polyface/pf_heal.cpp
+++ b/iModelCore/GeomLibs/geom/src/polyface/pf_heal.cpp
@@ -672,6 +672,7 @@ static size_t FillHolesBySpaceTriangulation (MTGFacets* facets)
     MTGMask visitMask = jmdlMTGGraph_grabMask (graph);
     jmdlMTGGraph_clearMaskInSet (graph, visitMask);
     int numFailures = 0;
+    UNUSED_VARIABLE(numFailures);
 
     MTGARRAY_SET_LOOP (seedNodeId, graph)
         {
@@ -696,6 +697,8 @@ static size_t FillHolesBySpaceTriangulation (MTGFacets* facets)
             int nA = 0;
             int nB = 0;
             int nOther = 0;
+            UNUSED_VARIABLE(nOther);
+            
             int fringeSize = jmdlEmbeddedDPoint3dArray_getCount (pFringeXYZArray);
             DPoint3dP pFringeXYZBuffer = jmdlEmbeddedDPoint3dArray_getPtr (pFringeXYZArray, 0);
             // TRUE ==> signed, one based indices that distinguish direction clearly.

--- a/iModelCore/GeomLibs/geom/src/polyface/pf_sweepMeshToSolid.cpp
+++ b/iModelCore/GeomLibs/geom/src/polyface/pf_sweepMeshToSolid.cpp
@@ -253,6 +253,10 @@ bool triangulateSides
     size_t numSimpleBoundary = 0;
     size_t numMatedPair = 0;
     size_t numUnMatedCoedge = 0;
+    UNUSED_VARIABLE(numSimpleBoundary);
+    UNUSED_VARIABLE(numMatedPair);
+    UNUSED_VARIABLE(numUnMatedCoedge);
+
     for (size_t i0 = 0, i1 = 0; i0 < numEdges; i0 = i1)
         {
         size_t numUndirectedMatch = 1;

--- a/iModelCore/GeomLibs/geom/src/polyface/polyfaceAddNormals.cpp
+++ b/iModelCore/GeomLibs/geom/src/polyface/polyfaceAddNormals.cpp
@@ -568,6 +568,7 @@ bvector<SectorData> &offsetVectors
 
             // verify that updates happend in all sectors around this vertex
             size_t numUntouched = 0;
+            UNUSED_VARIABLE(numUntouched);
             for (auto &sector : sectors)
                 {
                 size_t node = sector.m_node;

--- a/iModelCore/GeomLibs/geom/src/polyface/polyfaceToMTG.cpp
+++ b/iModelCore/GeomLibs/geom/src/polyface/polyfaceToMTG.cpp
@@ -80,7 +80,8 @@ int                    stitchSelect
 
     size_t numPrimary = 0;
     size_t numEdge = 0;
-
+    UNUSED_VARIABLE(numPrimary);
+    UNUSED_VARIABLE(numEdge);
 
     if (pNodeIdFromMeshVertex)
         {
@@ -222,6 +223,9 @@ MTGMask                     visibleEdgeMask
     MTGMask skipMask = visitMask | exclusionMask;
     size_t numPointIndex = 0;
     size_t numVisible = 0;
+    UNUSED_VARIABLE(numPointIndex);
+    UNUSED_VARIABLE(numVisible);
+
     MTGARRAY_SET_LOOP (seedNodeId, pGraph)
         {
         if (!jmdlMTGGraph_getMask (pGraph, seedNodeId, skipMask))
@@ -301,6 +305,8 @@ bvector<MTGNodeId> const &  nodes
     int maxMTGVertexIndex = -1;
     MTGMask skipMask = visitMask | exclusionMask;
     size_t numVisible = 0;
+    UNUSED_VARIABLE(facetCount);
+    UNUSED_VARIABLE(numVisible);
 
     for (size_t i = 0; i < pFacets->vertexArrayHdr.size (); i++)
         oldPointIndexToNewPointIndex.push_back (SIZE_MAX);

--- a/iModelCore/GeomLibs/geom/src/regions/rg_header.cpp
+++ b/iModelCore/GeomLibs/geom/src/regions/rg_header.cpp
@@ -3992,7 +3992,7 @@ MTGNodeId                       faceNodeId
     double deltaArea, deltaTheta, absArea;
     DPoint3d point;
     int numEdge = 0;
-
+    UNUSED_VARIABLE(numEdge);
 
     if (pPoint)
         {

--- a/iModelCore/GeomLibs/geom/src/regions/rg_intersections.cpp
+++ b/iModelCore/GeomLibs/geom/src/regions/rg_intersections.cpp
@@ -47,6 +47,8 @@ int                 index
     {
     static int s_flagLabel = -1;
     static int s_dummy;
+    UNUSED_VARIABLE(s_dummy);
+
     bool    myStat = pIL->GetIntersection ((size_t)index, *pIntersection);
     if (myStat && s_flagLabel == pIntersection->label)
         {

--- a/iModelCore/GeomLibs/geom/src/regions/rg_merge.cpp
+++ b/iModelCore/GeomLibs/geom/src/regions/rg_merge.cpp
@@ -927,6 +927,8 @@ bool                            *pParityChanged
     const RG_Intersection *pA;
     int     changeCount = 0;
     int     vertexCount = 0;
+    UNUSED_VARIABLE(vertexCount);
+
     *pParityChanged = false;
 
     for (size_t i = 0;

--- a/iModelCore/GeomLibs/geom/src/regions/rg_merge2.cpp
+++ b/iModelCore/GeomLibs/geom/src/regions/rg_merge2.cpp
@@ -118,6 +118,7 @@ int             noisy
     DPoint3d xyNodeId;
     int numThisCluster, clusterIndex, blockIndex;
     int xyNodeIdIndex;
+    UNUSED_VARIABLE(numThisCluster);
 
     jmdlVArrayDPoint3d_identifyMatchedVerticesXY
                             (pXYNodeIdArray, NULL, pBlockedIndexArray, tolerance, 0.0);
@@ -546,12 +547,13 @@ bvector<double>   *pParamArray
     DPoint3d xyzCenter, xyzCurr;
     DVec3d vector;
     int numIntersect;
-    int numFail;
+    int numFail = 0;
+    UNUSED_VARIABLE(numFail);
+    
     int i;
     jmdlEmbeddedDPoint3dArray_empty (pXYZArray);
     pParamArray->clear();
     jmdlRG_getVertexData (pRG, &xyzCenter, 0, NULL, pSortData[0].nodeId, 0.0);
-    numFail = 0;
     for (i = 0; i < numSort; i++)
         {
         jmdlRG_edgeCircleXYIntersection (pRG, pParamArray, pXYZArray,

--- a/iModelCore/GeomLibs/geom/src/rimsbs/rimsbs_context.cpp
+++ b/iModelCore/GeomLibs/geom/src/rimsbs/rimsbs_context.cpp
@@ -1064,6 +1064,8 @@ double tolerance
     int xyrIndex0, xyrIndex1, elementIndex0, elementIndex1;
     int numMatch = 0;
     int numTotalMatch = 0;
+    UNUSED_VARIABLE(numTotalMatch);
+
     EmbeddedIntArray *pXYRToElementIndexArray = jmdlEmbeddedIntArray_grab ();
     EmbeddedDPoint3dArray *pXYRArray = jmdlEmbeddedDPoint3dArray_grab ();
     EmbeddedIntArray *pBlockedXYRIndexArray = jmdlEmbeddedIntArray_grab ();

--- a/iModelCore/GeomLibs/geom/src/structs/cpp/refmethods/reffrange3d.cpp
+++ b/iModelCore/GeomLibs/geom/src/structs/cpp/refmethods/reffrange3d.cpp
@@ -501,16 +501,14 @@ void FRange3d::Get8Corners (bvector<FPoint3d> &corners) const
     {
     corners.clear ();
     FPoint3d minmax[2];
-    int ix,iy,iz,i;
+    int ix,iy,iz;
     minmax[0] = low;
     minmax[1] = high;
-    i = 0;
     for( iz = 0; iz < 2; iz++ )
         for ( iy = 0; iy < 2; iy++ )
             for ( ix = 0; ix < 2; ix++ )
                 {
                 corners.push_back (FPoint3d::From (minmax[ix].x, minmax[iy].y, minmax[iz].z ));
-                i++;
                 }
     }
 

--- a/iModelCore/GeomLibs/serialization/src/IModelJsonReader.cpp
+++ b/iModelCore/GeomLibs/serialization/src/IModelJsonReader.cpp
@@ -1135,6 +1135,7 @@ CurveVector::BoundaryType boundaryType
             int numOuter = 0;
             int numInner = 0;
             int numOther = 0;
+            UNUSED_VARIABLE(numInner);
             for (auto & cp : *result)
                 {
                 auto loop = cp->GetChildCurveVectorP ();

--- a/iModelCore/GeomLibs/vu/src/XYVisibilitySplitter.cpp
+++ b/iModelCore/GeomLibs/vu/src/XYVisibilitySplitter.cpp
@@ -307,6 +307,8 @@ void CollectClip (TaggedPolygonVectorR outputPolygons, bool primarySelect = true
 
     m_clipper->SetupForLoopOverFaces (primarySelect, secondarySelect);
     size_t numPolygon = 0;
+    UNUSED_VARIABLE(numPolygon);
+
     for (;m_clipper->GetFace (xyz, NULL, numThisFace, MAXOUT, false);)
         {
         PolygonVectorOps::AddPolygon (outputPolygons, xyz, numThisFace);

--- a/iModelCore/GeomLibs/vu/src/vuRefineSurface.cpp
+++ b/iModelCore/GeomLibs/vu/src/vuRefineSurface.cpp
@@ -306,6 +306,11 @@ size_t SplitEdges13 ()
     int numA1 = 0;
     int numA2 = 0;
     int numA3 = 0;
+    UNUSED_VARIABLE(numA0);
+    UNUSED_VARIABLE(numA1);
+    UNUSED_VARIABLE(numA2);
+    UNUSED_VARIABLE(numA3);
+
     VU_SET_LOOP (nodeA, m_graph)
         {
         if (!vu_getMask (nodeA, visitMask))
@@ -405,6 +410,11 @@ size_t SplitEdges13 ()
     int num1 = 0;
     int num2 = 0;
     int num3 = 0;
+    UNUSED_VARIABLE(num0);
+    UNUSED_VARIABLE(num1);
+    UNUSED_VARIABLE(num2);
+    UNUSED_VARIABLE(num3);
+    
     VU_SET_LOOP (nodeA, m_graph)
         {
         if (!vu_getMask (nodeA, visitMask))

--- a/iModelCore/GeomLibs/vu/src/vumaskops.cpp
+++ b/iModelCore/GeomLibs/vu/src/vumaskops.cpp
@@ -586,6 +586,9 @@ void vu_exchangeNullFacesToBringMaskInside (VuSetP pGraph, VuMask mask)
     {
     size_t numNull = 0;
     size_t numReversed = 0;
+    UNUSED_VARIABLE(numNull);
+    UNUSED_VARIABLE(numReversed);
+    
     // When two input faces "butt against each other along an edge,
     // the angular sort logic (in vu_merge) has no way of knowing which
     // of the geometrically identical edges is logicaly "first" in the sort order.

--- a/iModelCore/GeomLibs/vu/src/vupoly.cpp
+++ b/iModelCore/GeomLibs/vu/src/vupoly.cpp
@@ -202,7 +202,6 @@ bool                addVerticesAtCrossings
     VuMask      numberedNodeMask = graphP ? vu_grabMask (graphP) : 0;
     VuP         faceP, originalNodeP;
     StatusInt status = ERROR;
-    int       i;
     int       originalIndex;
     int       outputIndex;
     int     separator = signedOneBasedIndices ? 0 : -1;
@@ -268,7 +267,7 @@ bool                addVerticesAtCrossings
 
         vu_arrayOpen (faceArrayP);
         status = SUCCESS;
-        for (i = 0; SUCCESS == status && vu_arrayRead (faceArrayP, &faceP); i++)
+        while (SUCCESS == status && vu_arrayRead (faceArrayP, &faceP))
             {
             // We triangulated.  So of course there are 3 nodes per face.
             // Really?  If the input polygon retraces itself, there will be
@@ -341,7 +340,7 @@ bool                addVerticesAtCrossings
             vu_collectExteriorFaceLoops (faceArrayP, graphP);
             vu_arrayOpen (faceArrayP);
             status = SUCCESS;
-            for (i = 0; SUCCESS == status && vu_arrayRead (faceArrayP, &faceP); i++)
+            while (SUCCESS == status && vu_arrayRead (faceArrayP, &faceP))
                 {
                 VuP lowIndexP = faceP;
                 int lowIndex = vu_getUserDataPAsInt (faceP);
@@ -1097,7 +1096,6 @@ DPoint3d            *meshOrigin
     VuArrayP    faceArrayP = vu_grabArray (graphP);
     VuP         faceP;
     StatusInt status = SUCCESS;
-    int       i;
     int     separator = 0;
     int    maxPerFace = 3;
     static double s_shortEdgeToleranceFactor = 1.0e-8;
@@ -1272,7 +1270,7 @@ DPoint3d            *meshOrigin
     vu_collectInteriorFaceLoops (faceArrayP, graphP);
     VuMask visibleMask = (NULL == pVisible ? VU_BOUNDARY_EDGE : secondaryMask);
     vu_arrayOpen (faceArrayP);
-    for (i = 0; vu_arrayRead (faceArrayP, &faceP); i++)
+    while (vu_arrayRead (faceArrayP, &faceP))
         {
         // We triangulated.  So of course there are 3 nodes per face.
         // Really?  If the input polygon retraces itself, there will be

--- a/iModelCore/Units/src/SymbolicExpression.cpp
+++ b/iModelCore/Units/src/SymbolicExpression.cpp
@@ -277,6 +277,8 @@ BentleyStatus Expression::ParseDefinition(UnitsSymbolCR owner, int& depth, Utf8C
     Exponent currentExponent;
     bool inExponent = false;
     int numTokens = 0;
+    UNUSED_VARIABLE(numTokens);
+
     for (auto const& character : definitionString)
         {
         if (Utf8String::IsAsciiWhiteSpace(character))

--- a/iModelCore/libsrc/crashpad/vendor/third_party/mini_chromium/mini_chromium/base/logging.h
+++ b/iModelCore/libsrc/crashpad/vendor/third_party/mini_chromium/mini_chromium/base/logging.h
@@ -12,6 +12,8 @@
 #include <sstream>
 #include <string>
 
+#include <cstdint>
+
 #include "base/check.h"
 #include "base/check_op.h"
 #include "base/notreached.h"
@@ -20,7 +22,7 @@
 namespace logging {
 
 // A bitmask of potential logging destinations.
-using LoggingDestination = uint32_t;
+using LoggingDestination = std::uint32_t;
 
 // Specifies where logs will be written. Multiple destinations can be specified
 // with bitwise OR.

--- a/iModelCore/libsrc/crashpad/vendor/third_party/mini_chromium/mini_chromium/base/strings/utf_string_conversion_utils.h
+++ b/iModelCore/libsrc/crashpad/vendor/third_party/mini_chromium/mini_chromium/base/strings/utf_string_conversion_utils.h
@@ -6,10 +6,11 @@
 #define MINI_CHROMIUM_BASE_STRINGS_UTF_STRING_CONVERSION_UTILS_H_
 
 #include <string>
+#include <cstdint>
 
 namespace base {
 
-inline bool IsValidCodepoint(uint32_t code_point) {
+inline bool IsValidCodepoint(std::uint32_t code_point) {
   return code_point < 0xD800u ||
          (code_point >= 0xE000u && code_point <= 0x10FFFFu);
 }
@@ -17,16 +18,16 @@ inline bool IsValidCodepoint(uint32_t code_point) {
 bool ReadUnicodeCharacter(const char* src,
                           int32_t src_len,
                           int32_t* char_index,
-                          uint32_t* code_point_out);
+                          std::uint32_t* code_point_out);
 
 bool ReadUnicodeCharacter(const char16_t* src,
                           int32_t src_len,
                           int32_t* char_index,
-                          uint32_t* code_point);
+                          std::uint32_t* code_point);
 
-size_t WriteUnicodeCharacter(uint32_t code_point, std::string* output);
+size_t WriteUnicodeCharacter(std::uint32_t code_point, std::string* output);
 
-size_t WriteUnicodeCharacter(uint32_t code_point, std::u16string* output);
+size_t WriteUnicodeCharacter(std::uint32_t code_point, std::u16string* output);
 
 template<typename CHAR>
 void PrepareForUTF8Output(const CHAR* src, size_t src_len, std::string* output);


### PR DESCRIPTION
imodel-native-internal: https://github.com/iTwin/imodel-native-internal/pull/637

CI machines use clang 13 on linux. Installing 13 on Ubuntu 24.04 turned out to be quite tricky.
14 has some issues with consteval in std::chrono.
15 produces a slew of warnings re: variables that are assigned to but never used.
16 and 17 produce additional warnings about implicit functions.

15 seemed like the easiest one to get compiling.
Most of the unused variables are in GeomLibs where they mostly appear intended for debugging.
So I was conservative, mostly leaving them intact and silencing the warning via `UNUSED_VARIABLE`.
I did remove `static` from a handful of them.