### PR TITLE
Support for running against libnode.dll

### DIFF
--- a/node-addon-api/napi_stub.cpp
+++ b/node-addon-api/napi_stub.cpp
@@ -39,6 +39,12 @@ static FARPROC delayLoadNotify(unsigned dliNotify, PDelayLoadInfo pdli)
 {
     if (dliNotePreLoadLibrary != dliNotify || 0 != _stricmp(pdli->szDll, "iTwinNapi.dll"))
         return nullptr;
+
+    HMODULE embedded = ::GetModuleHandle("libnode.dll");
+    if (embedded != nullptr) {
+        return (FARPROC)embedded;
+    }
+
     return (FARPROC)::GetModuleHandle(nullptr);
 }
 decltype(__pfnDliNotifyHook2) __pfnDliNotifyHook2 = delayLoadNotify;


### PR DESCRIPTION
The convention of GetModuleHandle(NULL) in addon delay load handlers (https://github.com/nodejs/node-gyp/blob/e6f4ede10cca28e9edeaa85d7830914c5d1499c7/src/win_delay_load_hook.cc#L31) does not work when node is built as a shared library on windows in an embedding scenario, since the napi_* APIs are then defined in a dll, not the host exe.