### PR TITLE
mark cloud container destructor virtual

### DIFF
--- a/iModelCore/BeSQLite/PublicAPI/BeSQLite/CloudSqlite.h
+++ b/iModelCore/BeSQLite/PublicAPI/BeSQLite/CloudSqlite.h
@@ -94,7 +94,7 @@ struct CloudContainer {
     bool m_isPublic = false;
 
     CloudContainer() {}
-    ~CloudContainer() { Disconnect(false, false); }
+    virtual ~CloudContainer() { Disconnect(false, false); }
     CloudContainer(Utf8StringCR storageType, Utf8StringCR baseUri, Utf8StringCR containerId, Utf8StringCR alias, Utf8StringCR accessToken) :
         m_storageType(storageType), m_baseUri(baseUri), m_containerId(containerId), m_alias(alias), m_accessToken(accessToken) {}
 


### PR DESCRIPTION
I suppose the use of unique_ptr in mark's PR is flagging errors like the below:


"\x1b[1m/usr/lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/unique_ptr.h:85:2: \x1b[0m\x1b[0;1;31merror: \x1b[0m\x1b[1mdelete called on non-final 'BentleyM0200::BeSQLite::CloudContainer' that has virtual functions but non-virtual destructor [-Werror,-Wdelete-non-abstract-non-virtual-dtor]\x1b[0m" 

b"\x1b[1m/usr/lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/unique_ptr.h:361:4: \x1b[0m\x1b[0;1;30mnote: \x1b[0min instantiation of member function 'std::default_deleteBentleyM0200::BeSQLite::CloudContainer::operator()' requested here\x1b[0m" 

b"\x1b[1m/home/GeoCoord.cpp:26:11: \x1b[0m\x1b[0;1;30mnote: \x1b[0min instantiation of member function 'std::unique_ptrBentleyM0200::BeSQLite::CloudContainer::~unique_ptr' requested here\x1b[0m"