### PR TITLE
Reenable disabled font test

### DIFF
--- a/iModelJsNodeAddon/api_package/ts/src/test/EmbedFont.test.ts
+++ b/iModelJsNodeAddon/api_package/ts/src/test/EmbedFont.test.ts
@@ -37,10 +37,7 @@ describe("embed fonts", () => {
       fs.removeSync(tempSQLiteDbName);
     tempSQLiteDb.createDb(tempSQLiteDbName);
 
-    if (process.platform !== "darwin") {
-      // This is failing on CI Macs, so disabling it for now.
-      tempSQLiteDb.embedFont(dummyRsc);
-    }
+    tempSQLiteDb.embedFont(dummyRsc);
     tempSQLiteDb.embedFont({ fileName: shxFileName });
     tempSQLiteDb.embedFont({ fileName: ttfFileName });
     if (os.platform() === "win32") // Embedding system fonts is only supported on windows.
@@ -54,10 +51,7 @@ describe("embed fonts", () => {
     const tempDgnDbName = copyFile("testEmbedFont.bim", dbFileName);
     tempDgnDb.openIModel(tempDgnDbName, OpenMode.ReadWrite);
 
-    if (process.platform !== "darwin") {
-      // This is failing on CI Macs, so disabling it for now.
-      tempDgnDb.embedFont({ ...dummyRsc, compress: true });
-    }
+    tempDgnDb.embedFont({ ...dummyRsc, compress: true });
     tempDgnDb.embedFont({ fileName: shxFileName, compress: true });
     tempDgnDb.embedFont({ fileName: ttfFileName, compress: true });
     if (os.platform() === "win32") // Embedding system fonts is only supported on windows.


### PR DESCRIPTION
This will almost certainly cause the Mac pipelines to fail until we can figure out what is causing the failure, but these tests do need to run on all platforms.