### PR TITLE
Update ec cache tables after schema changeset apply and schema sync pull

### DIFF
--- a/iModelCore/ECDb/ECDb/SchemaSync.h
+++ b/iModelCore/ECDb/ECDb/SchemaSync.h
@@ -23,7 +23,6 @@ struct SchemaSyncHelper final {
     static DbResult GetMetaTables(DbR conn, StringList& tables, Utf8CP dbAlias);
     static DbResult DropDataTables(DbR conn);
     static DbResult DropMetaTables(DbR conn);
-    static DbResult CreateMetaTablesFrom(ECDbR fromDb, DbR syncDb);
     static DbResult TryGetAttachDbs(AliasMap& aliasMap, ECDbR conn);
     static DbResult VerifyAlias(ECDbR conn);
     static DbResult GetColumnNames(DbCR db, Utf8CP dbAlias, Utf8CP tableName, StringList& columnNames);


### PR DESCRIPTION
Cache table were found to be out of date after apply changeset. Schema sync now recompute cache table on pull and apply changeset. 

Beside above removed a unused function `SchemaSyncHelper::CreateMetaTablesFrom()`

Issue found in connector on imodel02