### PR TITLE
Presentation: Fix incorrect class grouping nodes' grouped instances count

### DIFF
--- a/iModelCore/ECPresentation/Source/Hierarchies/NavigationQueryBuilder.cpp
+++ b/iModelCore/ECPresentation/Source/Hierarchies/NavigationQueryBuilder.cpp
@@ -2813,10 +2813,14 @@ static SelectClassAcceptStatus ApplyClassFilter(SelectClassWithExcludes<>& selec
 static void ApplyClassFilter(bvector<SelectClassWithExcludes<>>& selectClasses, SelectClass<> const& groupingClass)
     {
     bvector<SelectClassWithExcludes<> const*> toErase;
-    for (auto& selectClass : selectClasses)
+    for (size_t i = 0; i < selectClasses.size(); ++i)
         {
-        if (SelectClassAcceptStatus::Drop == ApplyClassFilter(selectClass, groupingClass))
-            toErase.push_back(&selectClass);
+        auto& selectClass = selectClasses[i];
+        bool shouldErase = SelectClassAcceptStatus::Drop == ApplyClassFilter(selectClass, groupingClass);
+        for (size_t j = 0; j < i && !shouldErase; ++j)
+            shouldErase |= (selectClasses[j] == selectClass);
+        if (shouldErase)
+            toErase.push_back(&selectClass);        
         }
     ContainerHelpers::RemoveIf(selectClasses, [&toErase](auto const& item)
         {
@@ -2830,10 +2834,14 @@ static void ApplyClassFilter(bvector<SelectClassWithExcludes<>>& selectClasses, 
 static void ApplyClassFilter(bvector<RelatedClassPath>& selectPaths, SelectClass<> const& groupingClass)
     {
     bvector<RelatedClassPath const*> toErase;
-    for (RelatedClassPathR path : selectPaths)
+    for (size_t i = 0; i < selectPaths.size(); ++i)
         {
+        RelatedClassPathR path = selectPaths[i];
         auto& pathTarget = path.back().GetTargetClass();
-        if (SelectClassAcceptStatus::Drop == ApplyClassFilter(pathTarget, groupingClass))
+        bool shouldErase = SelectClassAcceptStatus::Drop == ApplyClassFilter(pathTarget, groupingClass);
+        for (size_t j = 0; j < i && !shouldErase; ++j)
+            shouldErase |= (selectPaths[j] == path);
+        if (shouldErase)
             toErase.push_back(&path);
         }
     ContainerHelpers::RemoveIf(selectPaths, [&toErase](auto const& item)

--- a/iModelCore/ECPresentation/Source/UpdateHandler.cpp
+++ b/iModelCore/ECPresentation/Source/UpdateHandler.cpp
@@ -556,12 +556,12 @@ private:
         if (newProvider.GetContext().GetPhysicalParentNode().IsNull())
             return;
 
-        // update parent hierarchy level if nodes count changed from/to 0
+        // update parent hierarchy level if nodes count changed from/to 0 or if parent node is a grouping node
         bool newProviderHasNodes = newProvider.HasNodes();
-        if (oldProviderHasNodes == newProviderHasNodes)
-            return;
-
         auto parent = newProvider.GetContext().GetPhysicalParentNode();
+        if (oldProviderHasNodes == newProviderHasNodes && !(parent.IsValid() && parent->GetKey()->AsGroupingNodeKey()))
+            return;
+        
         auto grandParent = parent.IsValid()
             ? m_nodesCache->GetPhysicalParentNode(parent->GetNodeId(), newProvider.GetContext().GetRulesetVariables(), newProvider.GetContext().GetInstanceFilter())
             : nullptr;


### PR DESCRIPTION
When a hierarchy specification selects from two base classes of the same instance (e.g. through the use of a mixin), `groupedInstancesCount` of class grouping nodes was being duplicated.

1. Improved hierarchies validation in tests to compare expected instances' count with the actual count set on grouping nodes.
2. Fixed navigation query builder to filter-out duplicate select classes, when the duplication happens due to class grouping.
3. Tests' improvement detected a bug in hierarchies update, where we weren't updating grouping nodes after deleting grouped instances. Fixed that as well.
