### PR TITLE
Return Empty Object for Null Struct Array Values

### DIFF
--- a/iModelCore/ECDb/ECDb/ECSqlRowAdaptor.cpp
+++ b/iModelCore/ECDb/ECDb/ECSqlRowAdaptor.cpp
@@ -361,8 +361,10 @@ BentleyStatus ECSqlRowAdaptor::RenderPrimitiveArrayProperty(BeJsValue out, IECSq
 BentleyStatus ECSqlRowAdaptor::RenderStructArrayProperty(BeJsValue out, IECSqlValue const& in) const {
     out.SetEmptyArray();
     for (IECSqlValue const& arrayElementValue : in.GetArrayIterable()) {
-        if (arrayElementValue.IsNull())
+        if (arrayElementValue.IsNull()){
+            out.appendValue().SetEmptyObject();
             continue;
+        }
 
         if (SUCCESS != RenderStructProperty(out.appendValue(), arrayElementValue))
             return ERROR;


### PR DESCRIPTION
Returns an Empty Object when a null value is passed in to RenderStructArrayProperty. This ensures that https://github.com/iTwin/itwinjs-core/pull/6549 will maintain current functionality. 

Related Issue: https://github.com/iTwin/itwinjs-backlog/issues/1162