### PR TITLE
Fix FlatBuffers 1.12.0 compilation for clang-19

### DIFF
--- a/iModelCore/libsrc/flatbuffers/source/include/flatbuffers/flatbuffers.h
+++ b/iModelCore/libsrc/flatbuffers/source/include/flatbuffers/flatbuffers.h
@@ -1877,10 +1877,15 @@ class FlatBufferBuilder {
     vector_downward &buf_;
 
    private:
+#ifndef EXCLUDE_BENTLEY_MODIFICATIONS
+    // Fix clang-19 error 'candidate function has been explicitly deleted'
+    FLATBUFFERS_DELETE_FUNC(TableKeyComparator &operator=(const TableKeyComparator &other));
+#else
     TableKeyComparator &operator=(const TableKeyComparator &other) {
       buf_ = other.buf_;
       return *this;
     }
+#endif
   };
   /// @endcond
 


### PR DESCRIPTION
Fix [FlatBuffer 1.12.0](https://github.com/iTwin/imodel-native/pull/1009) [compilation for clang-19](https://github.com/iTwin/imodel-native/pull/1009#issuecomment-2684859454) with deleting TableKeyComparator operator referred to other deleted ones:

> /home/rob/code/imodel-native/out/LinuxX64/static/BuildContexts/geomlibs/VendorAPI/flatbuffers/flatbuffers.h:1881:12: error: overload resolution selected deleted operator '='
/home/rob/code/imodel-native/out/LinuxX64/static/BuildContexts/geomlibs/VendorAPI/flatbuffers/flatbuffers.h:1004:44: note: candidate function has been explicitly deleted'
/home/rob/code/imodel-native/out/LinuxX64/static/BuildContexts/geomlibs/VendorAPI/flatbuffers/flatbuffers.h:836:20: note: candidate function not viable: expects an rvalue for 1st argument'