### PR TITLE
Avoid null deref when snapping to B-spline surface 

### DIFF
--- a/iModelCore/iModelPlatform/DgnCore/SnapContext.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/SnapContext.cpp
@@ -1160,6 +1160,9 @@ bool ProcessBsplineSurface(MSBsplineSurfaceCR surface, DPoint3dCR localPoint, Hi
 
         for (MSBsplineCurvePtr& isoCurveU : segmentsU)
             {
+            if (isoCurveU.IsNull())
+                continue;
+
             ICurvePrimitivePtr  curve = ICurvePrimitive::CreateBsplineCurveSwapFromSource(*isoCurveU);
 
             if (ProcessICurvePrimitive(*curve, localPoint, HitGeomType::Surface, parentGeomType))
@@ -1178,6 +1181,9 @@ bool ProcessBsplineSurface(MSBsplineSurfaceCR surface, DPoint3dCR localPoint, Hi
 
         for (MSBsplineCurvePtr& isoCurveV : segmentsV)
             {
+            if (isoCurveV.IsNull())
+                continue;
+
             ICurvePrimitivePtr  curve = ICurvePrimitive::CreateBsplineCurveSwapFromSource(*isoCurveV);
 
             if (ProcessICurvePrimitive(*curve, localPoint, HitGeomType::Surface, parentGeomType))


### PR DESCRIPTION
Fixes https://github.com/iTwin/imodel-native-internal/issues/759

Crash happens on snapping to a closed B-spline surface, but as this comes from Sentry, we don't know anything else about the element. This fix just avoids the crash.