### PR TITLE
Revert a recent change to constraint and fix in a different place

### DIFF
--- a/iModelCore/ecobjects/src/ECClass.cpp
+++ b/iModelCore/ecobjects/src/ECClass.cpp
@@ -3606,9 +3606,6 @@ bool ECRelationshipConstraint::SupportsClass(ECClassCR ecClass) const
     if (classCompatibleWithConstraint(GetAbstractConstraint(), &ecClass, m_isPolymorphic))
         return true;
 
-    if (m_abstractConstraint == nullptr && !m_verify) // if no abstract constraint is set, and we are not verifying, we support any class
-        return true;
-
     for (ECClassCP constraintClass : GetConstraintClasses())
         {
         if (constraintClass->GetName().EqualsI("AnyClass"))

--- a/iModelCore/ecobjects/src/SchemaMerger.cpp
+++ b/iModelCore/ecobjects/src/SchemaMerger.cpp
@@ -588,7 +588,8 @@ BentleyStatus SchemaMerger::MergeRelationshipConstraint(SchemaMergeResult& resul
 
         if (MergeReferencedSchemaItem<ECClassCP>(result, *constraintClassChange,
             [&](ECClassCP value) {
-                if(!constraint.SupportsClass(*value))
+                // only verify if an abstract constraint has been set. If not, we will skip this check
+                if(constraint.GetAbstractConstraint(false) != nullptr && !constraint.SupportsClass(*value))
                     return ECObjectsStatus::Error;
                 
                 return constraint.AddClass(*value);


### PR DESCRIPTION
A recent change made in https://github.com/iTwin/imodel-native/pull/1010 caused side effects. Reverting the change and fixing it in a different spot now.
Presentation is using the method which had been modified to identify some candidate classes.