### PR TITLE
Fix DwgHatchDefLine serialization into FB 1.12.0

### DIFF
--- a/iModelCore/iModelPlatform/DgnCore/ElementGeometry.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/ElementGeometry.cpp
@@ -1635,15 +1635,15 @@ void GeometryStreamIO::Writer::Append(GeometryParamsCR elParams, bool ignoreSubC
 
         if (0 != pattern->GetDwgHatchDef().size())
             {
-            for (auto defLine : pattern->GetDwgHatchDef())
+            for (const auto& defLine : pattern->GetDwgHatchDef())
                 {
-                FB::DwgHatchDefLineBuilder dashBuilder(fbb);
-
                 auto dashes = fbb.CreateVector(defLine.m_dashes, defLine.m_nDashes);
 
+                FB::DwgHatchDefLineBuilder dashBuilder(fbb);
+
                 dashBuilder.add_angle(defLine.m_angle);
-                dashBuilder.add_through((FB::DPoint2d*) &defLine.m_through);
-                dashBuilder.add_offset((FB::DPoint2d*) &defLine.m_offset);
+                dashBuilder.add_through((FB::DPoint2d const*) &defLine.m_through);
+                dashBuilder.add_offset((FB::DPoint2d const*) &defLine.m_offset);
                 dashBuilder.add_dashes(dashes);
 
                 defLineOffsets.push_back(dashBuilder.Finish());


### PR DESCRIPTION
Revit connector's Hatches unit test started to fail after migration FlatBuffer to 1.12.0 when it built with iModelCore sources with following FB assert:
```c++
    // If you hit this, you're trying to construct a Table/Vector/String
    // during the construction of its parent table (between the MyTableBuilder
    // and table.Finish().
    // Move the creation of these sub-objects to above the MyTableBuilder to
    // not get this assert.
    // Ignoring this assert may appear to work in simple cases, but the reason
    // it is here is that storing objects in-line may cause vtable offsets
    // to not fit anymore. It also leads to vtable duplication.
    FLATBUFFERS_ASSERT(!nested);
```
It's caused by DwgHatchDefLine's dashes serialization with CreateVector() after FB::DwgHatchDefLineBuilder initialization - this should be done before.
And also DwgHatchDefLine items are enumerated with copying that's not very effectively.