### PR TITLE
Fix #1055: SchemaMerger inappropriately sorts schemas alphabetically instead of dependency order

### DIFF
--- a/iModelCore/ecobjects/src/SchemaComparer.cpp
+++ b/iModelCore/ecobjects/src/SchemaComparer.cpp
@@ -459,24 +459,25 @@ BentleyStatus SchemaComparer::Compare(SchemaDiff& diff, bvector<ECN::ECSchemaCP>
     {
     m_options = options;
     bmap<Utf8CP, ECSchemaCP, CompareIUtf8Ascii> oldSchemaMap, newSchemaMap;
-    bset<Utf8CP, CompareIUtf8Ascii> allSchemas;
+    bvector<Utf8CP> allSchemaNames;
 
     for (ECSchemaCP schema : oldSchemas)
         {
         Utf8CP schemaName = schema->GetName().c_str();
         oldSchemaMap[schemaName] = schema;
-        allSchemas.insert(schemaName);
+        if (allSchemaNames.end() == std::find_if(allSchemaNames.begin(), allSchemaNames.end(), [schemaName] (Utf8CP asName) ->bool { return BeStringUtilities::StricmpAscii(schemaName, asName) == 0; }))
+        allSchemaNames.push_back(schemaName);
         }
 
     for (ECSchemaCP schema : newSchemas)
         {
         Utf8CP schemaName = schema->GetName().c_str();
         newSchemaMap[schemaName] = schema;
-        allSchemas.insert(schemaName);
+        if (allSchemaNames.end() == std::find_if(allSchemaNames.begin(), allSchemaNames.end(), [schemaName] (Utf8CP asName) ->bool { return BeStringUtilities::StricmpAscii(schemaName, asName) == 0; }))
+        allSchemaNames.push_back(schemaName);
         }
 
-
-    for (Utf8CP schemaName : allSchemas)
+    for (Utf8CP schemaName : allSchemaNames)
         {
         auto oldIt = oldSchemaMap.find(schemaName);
         auto newIt = newSchemaMap.find(schemaName);

--- a/iModelCore/ecobjects/src/SchemaMerger.cpp
+++ b/iModelCore/ecobjects/src/SchemaMerger.cpp
@@ -317,7 +317,11 @@ ECObjectsStatus SchemaMerger::MergeSchemas(SchemaMergeResult& result, bvector<EC
     SchemaComparer comparer;
     SchemaComparer::Options comparerOptions = SchemaComparer::Options(SchemaComparer::DetailLevel::NoSchemaElements, SchemaComparer::DetailLevel::NoSchemaElements);
     SchemaDiff diff;
-    if (comparer.Compare(diff, result.GetResults(), right, comparerOptions) != BentleyStatus::SUCCESS)
+    // Have to sort schemas again because the SchemaMap in results somehow does not preserve the order of the schemas in which they were added.
+    auto resultSchemas = result.GetResults();
+    ECSchema::SortSchemasInDependencyOrder(resultSchemas, doNotMergeReferences);
+
+    if (comparer.Compare(diff, resultSchemas, right, comparerOptions) != BentleyStatus::SUCCESS)
         {
         result.Issues().Report(IssueSeverity::Error, IssueCategory::BusinessProperties, IssueType::ECSchema, ECIssueId::EC_0013, "SchemaComparer comparison failed.");
         return ECObjectsStatus::Error;


### PR DESCRIPTION
Fixes: https://github.com/iTwin/imodel-native/issues/1055

The changes are very close to what Carole suggested.

I am a bit puzzled about ECSchemaCache not preserving the order in which schemas were added to it. I know it has some additional logic, like, implicitly adding referenced schemas. But internally, it uses `bmap<SchemaKey , ECSchemaPtr>`, which to my knowledge should preserve the order. Anyways, we can revisit this later. For now these changes seem fine to me.

