### PR TITLE
Fix update issue in ECPresentation where after applychangeset() it was unable to see recent changesges

### DIFF
--- a/iModelCore/iModelPlatform/DgnCore/TxnManager.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/TxnManager.cpp
@@ -898,6 +898,10 @@ ChangesetStatus TxnManager::MergeDataChanges(ChangesetPropsCR revision, Changese
 
         if (status == ChangesetStatus::Success) {
             result = m_dgndb.SaveChanges();
+            if (BE_SQLITE_OK == result) {
+                CallMonitors([&](TxnMonitor& monitor) { monitor._OnAppliedChangesCommitted(*this); });
+            }
+
             // Note: All that the above operation does is to COMMIT the current Txn and BEGIN a new one.
             // The user should NOT be able to revert the revision id by a call to AbandonChanges() anymore, since
             // the merged changes are lost after this routine and cannot be used for change propagation anymore.

--- a/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/TxnManager.h
+++ b/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/TxnManager.h
@@ -66,6 +66,7 @@ struct TxnMonitor {
     virtual ~TxnMonitor() { }
     virtual void _OnCommit(TxnManager&) {}
     virtual void _OnCommitted(TxnManager&) {}
+    virtual void _OnAppliedChangesCommitted(TxnManager&) {}
     virtual void _OnAppliedChanges(TxnManager&) {}
     virtual void _OnUndoRedo(TxnManager&, TxnAction) {}
     virtual void _OnGeometricModelChanges(TxnManager&, BeJsConst) {}

--- a/iModelJsNodeAddon/presentation/DgnDbECInstanceChangeEventSource.cpp
+++ b/iModelJsNodeAddon/presentation/DgnDbECInstanceChangeEventSource.cpp
@@ -164,15 +164,22 @@ void DgnDbECInstanceChangeEventSource::_OnCommit(Dgn::TxnManager& txns)
 +---------------+---------------+---------------+---------------+---------------+------*/
 void DgnDbECInstanceChangeEventSource::_OnAppliedChanges(TxnManager& txns)
     {
-    bvector<ECInstanceChangeEventSource::ChangedECInstance> changes;
-    AddChanges(changes, txns);
-    NotifyECInstancesChanged(txns.GetDgnDb(), changes);
+    AddChanges(m_changes, txns);
     }
 
 /*---------------------------------------------------------------------------------**//**
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/
 void DgnDbECInstanceChangeEventSource::_OnCommitted(Dgn::TxnManager& txns)
+    {
+    NotifyECInstancesChanged(txns.GetDgnDb(), m_changes);
+    m_changes.clear();
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+void DgnDbECInstanceChangeEventSource::_OnAppliedChangesCommitted(Dgn::TxnManager& txns)
     {
     NotifyECInstancesChanged(txns.GetDgnDb(), m_changes);
     m_changes.clear();

--- a/iModelJsNodeAddon/presentation/DgnDbECInstanceChangeEventSource.h
+++ b/iModelJsNodeAddon/presentation/DgnDbECInstanceChangeEventSource.h
@@ -30,6 +30,7 @@ protected:
     void _OnCommit(TxnManager&) override;
     void _OnCommitted(TxnManager&) override;
     void _OnAppliedChanges(TxnManager&) override;
+    void _OnAppliedChangesCommitted(TxnManager&) override;
     void _OnClassUsed(ECDbCR, ECClassCR, bool polymorphically) override;
 
 public:


### PR DESCRIPTION
itwinjs-core: https://github.com/iTwin/itwinjs-core/pull/7934

Prensetation framework update UI when new changeset is applied to db. This feature was broken due to change in `applyChanges()` which was to remove any  `saveChanges()` call during `applyChanges()` to avoid saving currupt changeset. 

To provide alternative way for ECPresetnation to listen to after commit applychangeset a new event has been added to TxnMonitor that is called after apply changeset is completed and changes are commited. ECPresentation use seperate connection and thread and will not see committed changes in  `_OnAppliedChanges()`. Previously we called `saveChanges()` before `_OnAppliedChanges()` so ECPresentation could see it over its other connection. Now event `_OnAppliedChangesCommitted()` ensure `saveChanges()` has been called before ECPresentation need to update the tree.

For: [Issue](https://dev.azure.com/bentleycs/Facilities%20Engineering/_workitems/edit/1627051)

> Note:This PR is for 4.x and should not be ported to 5.x as 5.x use rebase and it has different events.