### PR TITLE
Fix: Skip redundant [Element].[ParentRelECClassId] = NULL expression and avoid unnecessary SQL parentheses.

### DIFF
--- a/iModelCore/ECDb/Tests/NonPublished/ECSqlStatementTests.cpp
+++ b/iModelCore/ECDb/Tests/NonPublished/ECSqlStatementTests.cpp
@@ -24,6 +24,20 @@ struct ECSqlStatementTestFixture : ECDbTestFixture {};
                                                                         ASSERT_EQ(STEPSTATUS, stmt.Step());\
                                                                    }
 
+/*---------------------------------------------------------------------------------**//**
+* @bsimethod
+* ECSqlStatementTestFixture.BugFix
++---------------+---------------+---------------+---------------+---------------+------*/
+TEST_F(ECSqlStatementTestFixture, CountSpatialCategory)
+    {
+    ASSERT_EQ(BE_SQLITE_OK, OpenECDbTestDataFile("test.bim"));
+    ASSERT_FALSE(IsECSqlExperimentalFeaturesEnabled(m_ecdb));
+    auto query = R"(select 1 from bis.Element where Parent is NULL)";
+    ECSqlStatement stmt;
+    ASSERT_EQ(ECSqlStatus::Success, stmt.Prepare(m_ecdb, query));
+    ASSERT_STREQ(stmt.GetNativeSql(), "SELECT 1 FROM (SELECT [bis_Element].[Id] ECInstanceId,[bis_Element].[ECClassId],[bis_Element].[ParentId],(CASE WHEN [bis_Element].[ParentId] IS NULL THEN NULL ELSE [bis_Element].[ParentRelECClassId] END) [ParentRelECClassId] FROM [main].[bis_Element]) [Element] WHERE [Element].[ParentId] IS NULL");
+    stmt.Finalize();
+    }
 //---------------------------------------------------------------------------------------
 // @bsiclass
 //+---------------+---------------+---------------+---------------+---------------+------


### PR DESCRIPTION
Issue Link: https://github.com/iTwin/imodel-native/issues/912 

- Identified that [Element].[ParentRelECClassId] = NULL expressions were leading to redundant SQL.
- Added a conditional check to skip such expressions in the loop building SQL snippets.
- Introduced a fallback condition TRUE to avoid generating empty SQL when all snippets are skipped.
- Moved isFirstSnippet logic outside the loop to determine if any expressions were added.
- Updated logic to avoid adding parentheses when all snippets are skipped, preventing unnecessary wrapping.