### PR TITLE
Geomlibs cleanup for clang/LLVM 20

### DIFF
--- a/iModelCore/GeomLibs/PublicAPI/Geom/GeomApi.h
+++ b/iModelCore/GeomLibs/PublicAPI/Geom/GeomApi.h
@@ -398,19 +398,6 @@ struct  GeometryValidator : public RefCountedBase
 
 };
 
-//=======================================================================================
-//! Inlinable template for initial zeroing an object of size T.
-//!@bsiclass
-//=======================================================================================
-template<typename T> struct ZeroInit
-{
-    ZeroInit() 
-        {
-        static_assert(std::is_trivially_copyable<T>::value, 
-                      "ZeroInit can only be used with trivially copyable types.");
-        memset(this, 0, sizeof(T));
-        }
-};
 //! POD struct for pair of size_t values
 struct SizeSize
 {

--- a/iModelCore/GeomLibs/PublicAPI/Geom/MSBsplineSurface.h
+++ b/iModelCore/GeomLibs/PublicAPI/Geom/MSBsplineSurface.h
@@ -37,6 +37,8 @@ struct BSurfPatch
     //! flag set to true if this is a null interval (high multiplicity knot) in the v direction
     bool  isNullV;
 
+    GEOMDLLIMPEXP BSurfPatch();
+
     GEOMDLLIMPEXP bool Evaluate (DPoint2dCR uv, DPoint3dR xyz) const;
     GEOMDLLIMPEXP bool Evaluate (DPoint2dCR uv, DPoint3dR xyz, DVec3dR dXdu, DVec3dR dXdv) const;
     GEOMDLLIMPEXP DPoint2d PatchUVToKnotUV (DPoint2dCR patchUV) const;
@@ -44,7 +46,6 @@ struct BSurfPatch
 
     // return estimates of how far interior control points are from midpoints of chords.
     // for each grid edge and diagonal, the deviation is point distance from chord midpoint, divided by shorter edge length, capped at 10.
-    //
     GEOMDLLIMPEXP bool MidpointDeviations (double &uFraction, double &vFraction, double &twistFraction) const;
     };
 

--- a/iModelCore/GeomLibs/PublicAPI/Geom/SolidPrimitive.h
+++ b/iModelCore/GeomLibs/PublicAPI/Geom/SolidPrimitive.h
@@ -48,7 +48,7 @@ SolidPrimitiveType_DgnRuledSweep,
 typedef RefCountedPtr<ISolidPrimitive> ISolidPrimitivePtr;
 
 //! A DgnTorusPipeDetail represents a pipe elbow as a torus with partial sweep in the major circle and full circle of pipe.
-struct DgnTorusPipeDetail : ZeroInit<DgnTorusPipeDetail>
+struct DgnTorusPipeDetail
 {
 DPoint3d        m_center;       //!< Center of primary circle
 DVec3d          m_vectorX;      //!< X vector of primary circle
@@ -58,7 +58,7 @@ double          m_minorRadius;  //!< radius of pipe section
 double          m_sweepAngle;   //!< major circle sweep angle
 bool            m_capped;       //!< cap surface present (e.g. for incomplete sweep)
 
-//! Detail consructor with complete field list as parameters ...
+//! Detail constructor with complete field list as parameters ...
 //! @param [in] center Center of primary circle
 //! @param [in] vectorX X vector of primary circle
 //! @param [in] vectorY Y vector of primary circle
@@ -77,7 +77,7 @@ GEOMDLLIMPEXP DgnTorusPipeDetail
     bool        capped
     );
 
-//! Detail consructor with complete field list as parameters ...
+//! Detail constructor with complete field list as parameters ...
 //! @param [in] arc primary arc.
 //! @param [in] minorRadius radius of pipe section
 //! @param [in] capped true for solid
@@ -87,7 +87,6 @@ GEOMDLLIMPEXP DgnTorusPipeDetail
     double      minorRadius,
     bool        capped
     );
-
 
 //! Default value constructor.
 GEOMDLLIMPEXP DgnTorusPipeDetail ();
@@ -254,7 +253,7 @@ GEOMDLLIMPEXP bool ComputeSecondMomentAreaProducts (TransformR localToWorld, DMa
 //! @return false if unable to compute.
 GEOMDLLIMPEXP bool ComputeSecondMomentVolumeProducts (TransformR localToWorld, DMatrix4dR localProducts) const;
 
-//! Return curves which are silhoutte curves OTHER than hard edges
+//! Return curves which are silhouette curves OTHER than hard edges
 //! @return return false if not implemented.   return true if implemented -- but curves may still be empty.
 GEOMDLLIMPEXP bool SilhouetteCurves(DPoint4dCR eyePoint, CurveVectorPtr &curves) const;
 //! Return all intersection points of a curve with the pipe body
@@ -288,9 +287,8 @@ static GEOMDLLIMPEXP double GetVector90Sign ();
 static GEOMDLLIMPEXP bool GetReverseVector90 ();
 };
 
-
 //! A DgnConeDetail represents a (frustum of a) cone.
-struct DgnConeDetail : ZeroInit<DgnConeDetail>
+struct DgnConeDetail
 {
 DPoint3d    m_centerA;  // Center of base circle
 DPoint3d    m_centerB;  // Center of top circle
@@ -300,7 +298,7 @@ double      m_radiusA;  // radius at base (centerA)
 double      m_radiusB;  // radius at top (centerB)
 bool        m_capped;   // true if end cap is enabled
 
-//! Detail consructor with complete field list as parameters ...
+//! Detail constructor with complete field list as parameters ...
 //! @param [in] centerA Center of base circle
 //! @param [in] centerB Center of top circle
 //! @param [in] radiusA radius at base (centerA)
@@ -315,7 +313,7 @@ GEOMDLLIMPEXP DgnConeDetail
     bool        capped
     );
 
-//! Detail consructor with complete field list as parameters ...
+//! Detail constructor with complete field list as parameters ...
 //! @param [in] centerA Center of base circle
 //! @param [in] centerB Center of top circle
 //! @param [in] axes x and y columns give base, top circle parameterization.
@@ -332,7 +330,7 @@ GEOMDLLIMPEXP DgnConeDetail
     bool            capped
     );
 
-//! Detail consructor with complete field list as parameters ...
+//! Detail constructor with complete field list as parameters ...
 //! @param [in] centerA Center of base circle
 //! @param [in] centerB Center of top circle
 //! @param [in] vectorX
@@ -534,7 +532,7 @@ GEOMDLLIMPEXP bool ComputeSecondMomentAreaProducts (TransformR localToWorld, DMa
 //! @return false if unable to compute.
 GEOMDLLIMPEXP bool ComputeSecondMomentVolumeProducts (TransformR localToWorld, DMatrix4dR localProducts) const;
 
-//! Return curves which are silhoutte curves OTHER than hard edges
+//! Return curves which are silhouette curves OTHER than hard edges
 //! @return return false if not implemented.   return true if implemented -- but curves may still be empty.
 GEOMDLLIMPEXP bool SilhouetteCurves(DPoint4dCR eyePoint, CurveVectorPtr &curves) const;
 
@@ -577,9 +575,8 @@ double      r1             //!< [in] cone radius at w=1
 );
 };
 
-
-//! A DgnBoxDetail represents a boxlike surface with two paralell rectangular faces (bottom and top) and ruled side surfaces.
-struct DgnBoxDetail : ZeroInit<DgnBoxDetail>
+//! A DgnBoxDetail represents a boxlike surface with two parallel rectangular faces (bottom and top) and ruled side surfaces.
+struct DgnBoxDetail
 {
 DPoint3d m_baseOrigin; // origin of base rectangle
 DPoint3d m_topOrigin; // origin of Top rectangle
@@ -780,7 +777,7 @@ GEOMDLLIMPEXP bool ComputeSecondMomentAreaProducts (TransformR localToWorld, DMa
 //! @return false if unable to compute.
 GEOMDLLIMPEXP bool ComputeSecondMomentVolumeProducts (TransformR localToWorld, DMatrix4dR localProducts) const;
 
-//! Return curves which are silhoutte curves OTHER than hard edges
+//! Return curves which are silhouette curves OTHER than hard edges
 //! @return return false if not implemented.   return true if implemented -- but curves may still be empty.
 GEOMDLLIMPEXP bool SilhouetteCurves(DPoint4dCR eyePoint, CurveVectorPtr &curves) const;
 
@@ -795,13 +792,14 @@ GEOMDLLIMPEXP bool IsBlock (DPoint3dR origin, RotMatrixR unitAxes, DVec3dR local
 };
 
 //! A DgnSphereDetail represents an ellipsoid, possibly truncated on two planes parallel to the equator.
-struct DgnSphereDetail : ZeroInit<DgnSphereDetail>
+struct DgnSphereDetail
 {
 Transform m_localToWorld;   // origin is sphere center.  columns x,y to equator at 0 and 90 degrees latitude.  column z is to north pole.
 double m_startLatitude; // latitude for truncation plane parallel to the equator
 double m_latitudeSweep; // latitude difference from start truncation plane to end truncation plane
 bool m_capped;  // cap surface present (e.g. for partial latitude sweep)
-//! Detail consructor with complete field list as parameters ...
+
+//! Detail constructor with complete field list as parameters ...
 //! @param [in] center Sphere center
 //! @param [in] vectorX X vector of base plane
 //! @param [in] vectorZ Vector towards north pole
@@ -822,7 +820,7 @@ GEOMDLLIMPEXP DgnSphereDetail
     bool            capped
     );
 
-//! Detail consructor for complete true sphere
+//! Detail constructor for complete true sphere
 //! @param [in] center Sphere center
 //! @param [in] axes x,y,z axes
 //! @param [in] radius radius
@@ -1026,7 +1024,7 @@ GEOMDLLIMPEXP bool ComputeSecondMomentAreaProducts (TransformR localToWorld, DMa
 //! @return false if unable to compute.
 GEOMDLLIMPEXP bool ComputeSecondMomentVolumeProducts (TransformR localToWorld, DMatrix4dR localProducts) const;
 
-//! Return curves which are silhoutte curves OTHER than hard edges
+//! Return curves which are silhouette curves OTHER than hard edges
 //! @return return false if not implemented.   return true if implemented -- but curves may still be empty.
 GEOMDLLIMPEXP bool SilhouetteCurves(DPoint4dCR eyePoint, CurveVectorPtr &curves) const;
 
@@ -1054,15 +1052,14 @@ double sweepLatitude        //!< [in] latitude sweep for partial sphere.
 );
 };
 
-
 //! A DgnExtrusionDetail is a linear sweep of a base CurveVector.  All points on the base are swept by the same vector.
 struct DgnExtrusionDetail
 {
-CurveVectorPtr m_baseCurve{}; // Curve to be swept.
-DVec3d m_extrusionVector{}; // Vector from base to target curve
-bool m_capped{}; // true if end cap is enabled
+CurveVectorPtr m_baseCurve; // Curve to be swept.
+DVec3d m_extrusionVector; // Vector from base to target curve
+bool m_capped; // true if end cap is enabled
 
-//! Detail consructor with complete field list as parameters ...
+//! Detail constructor with complete field list as parameters ...
 //! @param [in] baseCurve Curve to be swept. This pointer is captured (not cloned) into the extrusion.
 //! @param [in] extrusionVector Vector from base to target curve
 //! @param [in] capped true if end cap is enabled
@@ -1070,7 +1067,6 @@ GEOMDLLIMPEXP DgnExtrusionDetail (
     CurveVectorPtr const &baseCurve,
     DVec3dCR extrusionVector,
     bool capped);
-
 
 //! Default value constructor.
 GEOMDLLIMPEXP DgnExtrusionDetail ();
@@ -1213,23 +1209,22 @@ GEOMDLLIMPEXP bool ComputeSecondMomentAreaProducts (TransformR localToWorld, DMa
 //! @return false if unable to compute.
 GEOMDLLIMPEXP bool ComputeSecondMomentVolumeProducts (TransformR localToWorld, DMatrix4dR localProducts) const;
 
-//! Return curves which are silhoutte curves OTHER than hard edges
+//! Return curves which are silhouette curves OTHER than hard edges
 //! @return return false if not implemented.   return true if implemented -- but curves may still be empty.
 GEOMDLLIMPEXP bool SilhouetteCurves(DPoint4dCR eyePoint, CurveVectorPtr &curves) const;
 
 };
 
-
 //! A DgnExtrusionDetail is a rotational sweep of a base CurveVector.
 struct DgnRotationalSweepDetail
 {
-CurveVectorPtr m_baseCurve{}; // Curve to be swept.
-DRay3d  m_axisOfRotation{};
-double m_sweepAngle{}; // major circle sweep angle
-bool m_capped{}; // true if end cap is enabled
-size_t m_numVRules{}; // Number of v rules (radial around) to display in wireframe.
+CurveVectorPtr m_baseCurve; // Curve to be swept.
+DRay3d  m_axisOfRotation;
+double m_sweepAngle; // major circle sweep angle
+bool m_capped; // true if end cap is enabled
+size_t m_numVRules; // Number of v rules (radial around) to display in wireframe.
 
-//! Detail consructor with complete field list as parameters ...
+//! Detail constructor with complete field list as parameters ...
 //! @param [in] baseCurve Curve to be swept. This pointer is captured (not cloned) into the extrusion.
 //! @param [in] center Center of rotation
 //! @param [in] axis axis of rotation.
@@ -1397,7 +1392,7 @@ GEOMDLLIMPEXP bool ComputeSecondMomentAreaProducts (TransformR localToWorld, DMa
 //! @return false if unable to compute.
 GEOMDLLIMPEXP bool ComputeSecondMomentVolumeProducts (TransformR localToWorld, DMatrix4dR localProducts) const;
 
-//! Return curves which are silhoutte curves OTHER than hard edges
+//! Return curves which are silhouette curves OTHER than hard edges
 //! @return return false if not implemented.   return true if implemented -- but curves may still be empty.
 GEOMDLLIMPEXP bool SilhouetteCurves(DPoint4dCR eyePoint, CurveVectorPtr &curves) const;
 
@@ -1437,15 +1432,13 @@ GEOMDLLIMPEXP bool   SetRadius (double radius, RadiusType type);
 
 }; // DgnRotationalSweepDetail
 
-
-
 //! A DgnRuledSweepDetail is a ruled surface between corresponding points of CurveVectors.
 struct DgnRuledSweepDetail
 {
-bvector<CurveVectorPtr> m_sectionCurves{}; // Successive section curves
-bool m_capped{}; // true if end cap is enabled
+bvector<CurveVectorPtr> m_sectionCurves; // Successive section curves
+bool m_capped; // true if end cap is enabled
 
-//! Detail consructor with complete field list as parameters ...
+//! Detail constructor with complete field list as parameters ...
 //! @param [in] sectionCurves Successive section curves
 //! @param [in] capped true if end cap is enabled
 GEOMDLLIMPEXP DgnRuledSweepDetail (
@@ -1453,7 +1446,7 @@ GEOMDLLIMPEXP DgnRuledSweepDetail (
     bool capped);
 
 
-//! Detail consructor for common case with exactly 2 sections.
+//! Detail constructor for common case with exactly 2 sections.
 //! @param [in] sectionA First section curve
 //! @param [in] sectionB Second section curve
 //! @param [in] capped true if end cap is enabled
@@ -1615,7 +1608,7 @@ GEOMDLLIMPEXP bool ComputeSecondMomentAreaProducts (TransformR localToWorld, DMa
 //! @return false if unable to compute.
 GEOMDLLIMPEXP bool ComputeSecondMomentVolumeProducts (TransformR localToWorld, DMatrix4dR localProducts) const;
 
-//! Return curves which are silhoutte curves OTHER than hard edges
+//! Return curves which are silhouette curves OTHER than hard edges
 //! @return return false if not implemented.   return true if implemented -- but curves may still be empty.
 GEOMDLLIMPEXP bool SilhouetteCurves(DPoint4dCR eyePoint, CurveVectorPtr &curves) const;
 
@@ -2018,7 +2011,7 @@ GEOMDLLIMPEXP bool ComputeSecondMomentVolumeProducts (TransformR localToWorld, D
 //! @return false if unable to compute.
 GEOMDLLIMPEXP bool ComputeSecondMomentAreaProducts (DMatrix4dR worldProducts) const;
 
-//! Return curves which are silhoutte curves OTHER than hard edges
+//! Return curves which are silhouette curves OTHER than hard edges
 //! @param [in] eyePoint For flat view, the view direction with weight=0.  For perspective, the eye point with weight=1.
 //! @param [in] curves silhouette curves.
 //! @return return false if not implemented.   return true if implemented -- but curves may still be empty.

--- a/iModelCore/GeomLibs/PublicAPI/Regions/rg_intern.h
+++ b/iModelCore/GeomLibs/PublicAPI/Regions/rg_intern.h
@@ -114,6 +114,7 @@ struct _RG_Header
                                                 search is required to determine
                                                 its contained or containing faces.
                                         */
+    _RG_Header();
     };
 
 struct _RG_Intersection

--- a/iModelCore/GeomLibs/geom/src/SolidPrimitive/SolidPrimitive.cpp
+++ b/iModelCore/GeomLibs/geom/src/SolidPrimitive/SolidPrimitive.cpp
@@ -251,7 +251,7 @@ public:
 
 };
 
-// Detail consructor with complete field list as parameters ...
+// Detail constructor with complete field list as parameters ...
 DgnTorusPipeDetail::DgnTorusPipeDetail
 (
 DPoint3dCR  center,
@@ -286,7 +286,7 @@ bool DgnTorusPipeDetail::IsValidGeometry(GeometryValidatorPtr &validator) const
         ;
     }
 
-// Detail consructor with complete field list as parameters ...
+// Detail constructor with complete field list as parameters ...
 DgnTorusPipeDetail::DgnTorusPipeDetail
 (
 DEllipse3dCR arc,
@@ -310,7 +310,7 @@ bool    capped
 
 
 
-// Detail consructor with complete field list as parameters ...
+// Detail constructor with complete field list as parameters ...
 DgnTorusPipeDetail::DgnTorusPipeDetail ()
     {
     m_center = DPoint3d::From (0,0,0);
@@ -319,6 +319,7 @@ DgnTorusPipeDetail::DgnTorusPipeDetail ()
     m_majorRadius = 1;
     m_minorRadius = 0;
     m_sweepAngle = Angle::PiOver2 ();
+    m_capped = false;
     }
 
 
@@ -642,7 +643,6 @@ DgnConeDetail::DgnConeDetail ()
     m_radiusB = 1;
     m_capped = false;
     }
-
 
 /*--------------------------------------------------------------------------------**//**
 * @bsimethod
@@ -1279,7 +1279,7 @@ public:
 
 };
 
-// Detail consructor with complete field list as parameters ...
+// Detail constructor with complete field list as parameters ...
 DgnSphereDetail::DgnSphereDetail
 (
 DPoint3dCR  center,
@@ -1360,7 +1360,6 @@ DgnSphereDetail::DgnSphereDetail()
     m_latitudeSweep = Angle::Pi ();
     m_capped = false;
     }
-
 
 /*--------------------------------------------------------------------------------**//**
 * @bsimethod
@@ -1592,7 +1591,7 @@ public:
     {}
 };
 
-// Detail consructor with complete field list as parameters ...
+// Detail constructor with complete field list as parameters ...
 DgnExtrusionDetail::DgnExtrusionDetail
 (
 CurveVectorPtr  const &baseCurve,
@@ -1603,6 +1602,7 @@ bool  capped)
     m_extrusionVector = extrusionVector;
     m_capped = capped;
     }
+
 bool DgnExtrusionDetail::IsValidGeometry(GeometryValidatorPtr &validator) const
     {
     if (!validator.IsValid())
@@ -1614,7 +1614,7 @@ bool DgnExtrusionDetail::IsValidGeometry(GeometryValidatorPtr &validator) const
         ;
     }
 
-// Detail consructor with complete field list as parameters ...
+// Detail constructor with complete field list as parameters ...
 DgnExtrusionDetail::DgnExtrusionDetail ()
     {
     m_baseCurve = NULL;
@@ -1709,7 +1709,7 @@ public:
 
 };
 
-// Detail consructor with complete field list as parameters ...
+// Detail constructor with complete field list as parameters ...
 DgnRotationalSweepDetail::DgnRotationalSweepDetail
 (
 CurveVectorPtr  const &baseCurve,
@@ -1738,7 +1738,7 @@ bool DgnRotationalSweepDetail::IsValidGeometry(GeometryValidatorPtr &validator) 
         ;
     }
 
-// Detail consructor with complete field list as parameters ...
+// Detail constructor with complete field list as parameters ...
 DgnRotationalSweepDetail::DgnRotationalSweepDetail ()
     {
     m_baseCurve = NULL;
@@ -2022,7 +2022,7 @@ public:
 
 };
 
-// Detail consructor with complete field list as parameters ...
+// Detail constructor with complete field list as parameters ...
 DgnRuledSweepDetail::DgnRuledSweepDetail
 (
 bvector<CurveVectorPtr> const &  sectionCurves,
@@ -2044,14 +2044,14 @@ bool DgnRuledSweepDetail::IsValidGeometry(GeometryValidatorPtr &validator) const
   // bool is always valid . . . . && validator->IsValidGeometry(m_capped)
     return true;
     }
-// Detail consructor with complete field list as parameters ...
+// Detail constructor with complete field list as parameters ...
 void DgnRuledSweepDetail::AddSection (CurveVectorP section)
     {
     m_sectionCurves.push_back (CurveVectorPtr (section));
     }
 
 
-// Detail consructor with complete field list as parameters ...
+// Detail constructor with complete field list as parameters ...
 DgnRuledSweepDetail::DgnRuledSweepDetail
 (
 CurveVectorPtr const & sectionA,
@@ -2064,7 +2064,7 @@ bool  capped)
     }
 
 
-// Detail consructor with complete field list as parameters ...
+// Detail constructor with complete field list as parameters ...
 DgnRuledSweepDetail::DgnRuledSweepDetail ()
     {
     m_sectionCurves = bvector<CurveVectorPtr>();

--- a/iModelCore/GeomLibs/geom/src/bspline/BSurfPatch.cpp
+++ b/iModelCore/GeomLibs/geom/src/bspline/BSurfPatch.cpp
@@ -20,6 +20,22 @@ void bspsurf_setTimerControl (int select, int count)
     s_timerCount = count;
     }
 
+/*---------------------------------------------------------------------------------**//**
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+BSurfPatch::BSurfPatch()
+{
+xyzw.clear();
+uKnots.clear();
+vKnots.clear();
+uOrder = vOrder = uIndex = vIndex = 0;
+uMin = uMax = vMin = vMax = 0.0;
+isNullU = isNullV = false;
+}
+
+/*---------------------------------------------------------------------------------**//**
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
 DPoint2d BSurfPatch::PatchUVToKnotUV (DPoint2dCR patchUV) const
     {
     return DPoint2d::From (
@@ -28,7 +44,9 @@ DPoint2d BSurfPatch::PatchUVToKnotUV (DPoint2dCR patchUV) const
             );
     }
 
-
+/*---------------------------------------------------------------------------------**//**
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
 void GetBasePole (size_t select, bool closed, double *knots, size_t order, size_t numPoles, size_t &basePole, size_t &maxBasePole)
     {
     basePole = select;
@@ -713,8 +731,6 @@ bool BSurfPatch::Evaluate (DPoint2dCR uv, DPoint3dR xyz) const
     xyz.Zero ();
     return false;
     }
-
-
 
 /*---------------------------------------------------------------------------------**//**
 * @bsimethod

--- a/iModelCore/GeomLibs/geom/src/bspline/MSBsplineSurface.cpp
+++ b/iModelCore/GeomLibs/geom/src/bspline/MSBsplineSurface.cpp
@@ -1059,8 +1059,6 @@ bvector<bvector<DRange2d>> *knotRanges
     bvector<DPoint3d> cps;
     bvector<double> cws;
     DPoint3d point;
-    // TODO: patch is non-trivially copyable, so this is not safe. sizeof(patch) is not guaranteed to be correct.
-    memset ((void*)&patch, 0, sizeof (patch));
 
     while (jPatch<num)
         {

--- a/iModelCore/GeomLibs/geom/src/regions/rg_header.cpp
+++ b/iModelCore/GeomLibs/geom/src/regions/rg_header.cpp
@@ -9,9 +9,7 @@
 #include <stdio.h>
 BEGIN_BENTLEY_GEOMETRY_NAMESPACE
 
-
 static int s_globalNoisy = 0;
-
 
 /*---------------------------------------------------------------------------------**//**
 *
@@ -33,6 +31,29 @@ static int s_globalNoisy = 0;
 +---------------+---------------+---------------+---------------+---------------+------*/
 
 /*---------------------------------------------------------------------------------**//**
+* Construct an invalid instance with all members zeroed.
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+RG_Header::_RG_Header(): funcs(), markSet(), graphRange()
+    {
+    pGraph = nullptr;
+    aborted = false;
+    pOutputLinestringFunc = nullptr;
+    pDebugContext = nullptr;
+    pVertexArray = nullptr;
+    vertexLabelIndex = 0;
+    edgeLabelIndex = 0;
+    parentLabelIndex = 0;
+    relTol = 0.0;
+    tolerance = 0.0;
+    minimumTolerance = 0.0;
+    pEdgeRangeTree = nullptr;
+    pFaceRangeTree = nullptr;
+    incrementalEdgeRanges = false;
+    pFaceHoleNodeIdArray = nullptr;
+    }
+
+/*---------------------------------------------------------------------------------**//**
 * Allocate a new region header.  This should be returned to jmdlRG_free
 * @return pointer to region header.
 * @bsimethod
@@ -42,11 +63,8 @@ Public RG_Header    *jmdlRG_new
 void
 )
     {
-    RG_Header *pRG = (RG_Header *)BSIBaseGeom::Malloc (sizeof (RG_Header));
-    // TODO: This is dangerous. RG_Header is not trivially-copyable, so using sizeof(RG_Header) is not guaranteed to return the actual
-    // size of the object. We should use the constructor to allocate the object instead. For now casting to void* to silence the warning because
-    // fixing requires many changes across this library.
-    memset ((void*)pRG, 0, sizeof (RG_Header));
+    RG_Header* pRG = new RG_Header();
+
     pRG->pGraph = jmdlMTGGraph_newGraph ();
     pRG->vertexLabelIndex   = jmdlMTGGraph_defineLabel
                             (
@@ -102,7 +120,7 @@ RG_Header       *pRG
         if (pRG->pFaceHoleNodeIdArray)
             jmdlEmbeddedIntArray_free (pRG->pFaceHoleNodeIdArray);
 
-        BSIBaseGeom::Free (pRG);
+        delete pRG;
         }
     }
 


### PR DESCRIPTION
Follows up https://github.com/iTwin/imodel-native/pull/1076
Addresses the geomlibs portion of https://github.com/iTwin/itwinjs-backlog/issues/1473