### PR TITLE
Fix for: Clearing ECDb cache causes repeated ConcurrentQuery to fail

### DIFF
--- a/iModelCore/ECDb/ECDb/ConcurrentQueryManagerImpl.cpp
+++ b/iModelCore/ECDb/ECDb/ConcurrentQueryManagerImpl.cpp
@@ -397,6 +397,9 @@ void ConnectionCache::Interrupt(bool reset_conn, bool detach_dbs) {
         std::this_thread::yield();
     }
     if (reset_conn) {
+        if(m_syncConn)
+            m_syncConn->Reset(detach_dbs);
+
         for (auto& it : m_conns) {
             it->Reset(detach_dbs);
         }

--- a/iModelCore/ECDb/Tests/NonPublished/ConcurrentQueryTest_V2.cpp
+++ b/iModelCore/ECDb/Tests/NonPublished/ConcurrentQueryTest_V2.cpp
@@ -1234,4 +1234,60 @@ TEST_F(ConcurrentQueryFixture, ReaderBindingForIdSetVirtualTable) {
         }
 }
 
+//---------------------------------------------------------------------------------------
+//@bsimethod
+//+---------------+---------------+---------------+---------------+---------------+------
+TEST_F(ConcurrentQueryFixture, ImportSchemaShouldClearQueryCache) {
+    // There was a bug that importing a schema did not clean the cached prepared statements for concurrent queries.
+    // So running a query that is cached would result in an error because the query needs to be reprepared.
+    ASSERT_EQ(BentleyStatus::SUCCESS, SetupECDbForCurrentTest(SchemaItem(
+        R"xml(<ECSchema schemaName="TestSchema" alias="ts" version="1.0.0" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+                <ECEntityClass typeName="testEntity">
+                    <ECProperty propertyName="entity_id" typeName="int" />
+                </ECEntityClass>
+            </ECSchema>)xml")));
+
+    ECSqlStatement stmt;
+    ASSERT_EQ(ECSqlStatus::Success, stmt.Prepare(m_ecdb, "INSERT INTO ts.testEntity(entity_id) VALUES(?)"));
+    stmt.BindInt(1, 1);
+    ASSERT_EQ(stmt.Step(), BE_SQLITE_DONE);
+    m_ecdb.SaveChanges();
+
+    auto& mgr = ConcurrentQueryMgr::GetInstance(m_ecdb);
+
+    {
+        auto req = ECSqlRequest::MakeRequest("SELECT entity_id FROM ts.testEntity");
+        req->SetUsePrimaryConnection(true);
+        auto r = mgr.Enqueue(std::move(req)).Get();
+        ASSERT_EQ(r->GetStatus(), QueryResponse::Status::Done);
+
+        auto res = ((ECSqlResponse*) r.get());
+        BeJsDocument resJson;
+        res->ToJs(resJson, true);
+        ASSERT_EQ(res->asJsonString(), "[[1]]");
+    }
+
+    // Import a new schema to clear the cache
+    SchemaItem updatedSchema(
+        R"xml(<ECSchema schemaName="TestSchema" alias="ts" version="1.0.1" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+        <ECEntityClass typeName="testEntity">
+            <ECProperty propertyName="entity_id" typeName="int" />
+            <ECProperty propertyName="new_prop" typeName="int" />
+        </ECEntityClass>
+    </ECSchema>)xml");
+    ASSERT_EQ(BentleyStatus::SUCCESS, ImportSchema(updatedSchema));
+    // Run an identical query again
+    {
+        auto req = ECSqlRequest::MakeRequest("SELECT entity_id FROM ts.testEntity");
+        req->SetUsePrimaryConnection(true);
+        auto r = mgr.Enqueue(std::move(req)).Get();
+        ASSERT_EQ(r->GetStatus(), QueryResponse::Status::Done);
+
+        auto res = ((ECSqlResponse*) r.get());
+        BeJsDocument resJson;
+        res->ToJs(resJson, true);
+        ASSERT_EQ(res->asJsonString(), "[[1]]");
+    }
+}
+
 END_ECDBUNITTESTS_NAMESPACE


### PR DESCRIPTION
fixes: https://github.com/iTwin/itwinjs-core/issues/7984

The cleared cache did not properly clean ConcurrentQuery's internal caches, so if an identical query was sent again, the statement would be reused, which triggers an internal failsafe to protect against that.

Now we clean concurrent query caches.

@khanaffan please check. There are so many classes and caches in concurrent query, I'm only 80% sure that I hit the right spot and didn't miss anything. My added test passes after fix and fails without.