### PR TITLE
Fix issue related to struct property mapping

### DIFF
--- a/iModelCore/ECDb/ECDb/ClassMapColumnFactory.h
+++ b/iModelCore/ECDb/ECDb/ClassMapColumnFactory.h
@@ -108,7 +108,7 @@ struct ClassMapColumnFactory final
                 ClassMap const& GetClassMap() const { return m_classMap; }
                 ColumnMaps& GetColumnMaps();
             };
-        
+
     private:
         ClassMap const& m_classMap;
         mutable DbTable* m_primaryOrJoinedTable = nullptr;
@@ -147,15 +147,16 @@ struct ClassMapColumnFactory final
             GetColumnMaps()->Insert(map.GetRelECClassIdPropertyMap());
             return true;
             }
-        DbColumn const* FindColumn(Utf8CP accessString) const 
+        DbColumn const* FindColumn(Utf8CP accessString) const
             {
             return GetColumnMaps()->FindP(accessString);
             }
-        void EvaluateIfPropertyGoesToOverflow(Utf8StringCR propertyName, SchemaImportContext& ctx) const;
-        void EvaluateIfPropertyGoesToOverflow(uint32_t columnsRequired, SchemaImportContext& ctx) const;
-        void ResetCurrentPropertyOverflowFlag() const { m_putCurrentPropertyToOverflow = false; }
-        void Debug() const { GetColumnMaps()->Debug(); }
-        DbColumn* Allocate(SchemaImportContext&, ECN::ECPropertyCR property, DbColumn::Type type, DbColumn::CreateParams const& param, Utf8StringCR accessString, bool forcePhysicalColum = false) const;
+            void EnsurePropertyGoesToOverflow(Utf8StringCR propertyName, SchemaImportContext& ctx) const;
+            void EvaluateIfPropertyGoesToOverflow(Utf8StringCR propertyName, SchemaImportContext& ctx) const;
+            void EvaluateIfPropertyGoesToOverflow(uint32_t columnsRequired, SchemaImportContext& ctx) const;
+            void ResetCurrentPropertyOverflowFlag() const { m_putCurrentPropertyToOverflow = false; }
+            void Debug() const { GetColumnMaps()->Debug(); }
+            DbColumn* Allocate(SchemaImportContext&, ECN::ECPropertyCR property, DbColumn::Type type, DbColumn::CreateParams const& param, Utf8StringCR accessString, bool forcePhysicalColum = false) const;
     };
 
 //======================================================================================

--- a/iModelCore/ECDb/ECDb/DbMappingManager.cpp
+++ b/iModelCore/ECDb/ECDb/DbMappingManager.cpp
@@ -38,7 +38,7 @@ PropertyMap* DbMappingManager::Classes::ProcessProperty(Context& ctx, ECProperty
     if (baseLineTable != nullptr && baseLineTable->GetType() == DbTable::Type::Overflow) {
         ctx.m_classMap.GetColumnFactory().EnsurePropertyGoesToOverflow(property.GetName(), *ctx.m_importCtx);
     }
-    
+
     RefCountedPtr<PropertyMap> propertyMap = nullptr;
     if (auto primitiveProperty = property.GetAsPrimitiveProperty())
         propertyMap = MapPrimitiveProperty(ctx, *primitiveProperty, nullptr);
@@ -100,7 +100,7 @@ PropertyMap* DbMappingManager::Classes::ProcessProperty(Context& ctx, ECProperty
 // @bsimethod
 //+===============+===============+===============+===============+===============+======
 BentleyStatus DbMappingManager::Classes::MoveProperty(Context& ctx, ECPropertyCR property, CompoundDataPropertyMapDiff& diff) {
-    LOG.infov("Moving property %s to overflow table.", property.GetTypeFullName().c_str());
+    LOG.infov("Moving struct property %s to overflow table as it does not fit into current table in which its mapped", property.GetTypeFullName().c_str());
     // This function is only called if sharedColumn strategy is enabled. So columnType and accessString has no effect.
     if(!Enum::Contains(PropertyMap::Type::Struct, diff.GetPropertyMap().GetType())) {
         BeAssert("Expecting struct property");

--- a/iModelCore/ECDb/ECDb/DbMappingManager.cpp
+++ b/iModelCore/ECDb/ECDb/DbMappingManager.cpp
@@ -32,6 +32,13 @@ PropertyMap* DbMappingManager::Classes::ProcessProperty(Context& ctx, ECProperty
     if (useColumnReservation)
         ctx.m_classMap.GetColumnFactory().EvaluateIfPropertyGoesToOverflow(property.GetName(), *ctx.m_importCtx);
 
+    // any new property of struct should go into overflow table if
+    // previsouly older properties were mapped into overflow
+    auto baseLineTable = compoundPropDiff.GetBaselineTable();
+    if (baseLineTable != nullptr && baseLineTable->GetType() == DbTable::Type::Overflow) {
+        ctx.m_classMap.GetColumnFactory().EnsurePropertyGoesToOverflow(property.GetName(), *ctx.m_importCtx);
+    }
+    
     RefCountedPtr<PropertyMap> propertyMap = nullptr;
     if (auto primitiveProperty = property.GetAsPrimitiveProperty())
         propertyMap = MapPrimitiveProperty(ctx, *primitiveProperty, nullptr);

--- a/iModelCore/ECDb/Tests/Data/fileformatbenchmark/schemas/dgndb/BisCore.ecschema.xml
+++ b/iModelCore/ECDb/Tests/Data/fileformatbenchmark/schemas/dgndb/BisCore.ecschema.xml
@@ -592,7 +592,7 @@
             <Class class="GraphicalType2d"/>
         </Target>
     </ECRelationshipClass>
-
+    
     <ECRelationshipClass typeName="GeometricElement3dHasTypeDefinition" strength="referencing" modifier="Abstract">
         <!-- @see GeometricElement3d.TypeDefinition ECNavigationProperty -->
         <Source multiplicity="(0..*)" roleLabel="has" polymorphic="true">
@@ -739,7 +739,7 @@
     <ECEntityClass typeName="LinkElement" modifier="Abstract" displayLabel="Link" description="An information element that specifies a link.">
         <BaseClass>InformationReferenceElement</BaseClass>
     </ECEntityClass>
-
+    
     <ECEntityClass typeName="UrlLink" displayLabel="URL Link" description="An information element that specifies a URL link.">
         <ECCustomAttributes>
             <ClassHasHandler xmlns="BisCore.1.0" />
@@ -1150,7 +1150,7 @@
             <Class class="TextAnnotationData"/>
         </Target>
     </ECRelationshipClass>
-
+    
     <ECEntityClass typeName="TextAnnotation3d" displayLabel="3D Text Annotation">
         <BaseClass>GraphicalElement3d</BaseClass>
         <ECCustomAttributes>
@@ -1334,7 +1334,7 @@
         <ECCustomAttributes>
             <ClassHasHandler xmlns="BisCore.1.0"/>
             <ClassMap xmlns="ECDbMap.2.0">
-                <!-- We must insist that all instances of all possible subclasses are stored together in a single table.
+                <!-- We must insist that all instances of all possible subclasses are stored together in a single table. 
                      TxnManager knows about this table, and expects to find all instances this kind of relationship there. -->
                 <MapStrategy>TablePerHierarchy</MapStrategy>
             </ClassMap>
@@ -1444,7 +1444,7 @@
         </ECCustomAttributes>
         <ECProperty propertyName="Description" typeName="string"/>
     </ECEntityClass>
-
+    
     <ECEntityClass typeName="RenderMaterial" modifier="Sealed" displayLabel="Render Material">
         <!-- Marked as "Sealed" because JsonProperties will be used to persist data. This allows a single instance to "morph" between a DgnV8 render material and a future PBR material. -->
         <BaseClass>DefinitionElement</BaseClass>
@@ -1821,7 +1821,7 @@
             <Class class="LinkElement"/>
         </Target>
     </ECRelationshipClass>
-
+    
     <ECEntityClass typeName="RoleElement" modifier="Abstract" displayLabel="Role Element" description="A real world entity is modeled as a Role Element when a set of external circumstances define an important role (one that is worth tracking) that is not intrinsic to the entity playing the role. For example, a person can play the role of a teacher or a rock can play the role of a boundary marker.">
         <BaseClass>Element</BaseClass>
         <ECCustomAttributes>

--- a/iModelCore/ECDb/Tests/Data/fileformatbenchmark/schemas/dgndb/BisCore.ecschema.xml
+++ b/iModelCore/ECDb/Tests/Data/fileformatbenchmark/schemas/dgndb/BisCore.ecschema.xml
@@ -592,7 +592,7 @@
             <Class class="GraphicalType2d"/>
         </Target>
     </ECRelationshipClass>
-    
+
     <ECRelationshipClass typeName="GeometricElement3dHasTypeDefinition" strength="referencing" modifier="Abstract">
         <!-- @see GeometricElement3d.TypeDefinition ECNavigationProperty -->
         <Source multiplicity="(0..*)" roleLabel="has" polymorphic="true">
@@ -739,7 +739,7 @@
     <ECEntityClass typeName="LinkElement" modifier="Abstract" displayLabel="Link" description="An information element that specifies a link.">
         <BaseClass>InformationReferenceElement</BaseClass>
     </ECEntityClass>
-    
+
     <ECEntityClass typeName="UrlLink" displayLabel="URL Link" description="An information element that specifies a URL link.">
         <ECCustomAttributes>
             <ClassHasHandler xmlns="BisCore.1.0" />
@@ -1150,7 +1150,7 @@
             <Class class="TextAnnotationData"/>
         </Target>
     </ECRelationshipClass>
-    
+
     <ECEntityClass typeName="TextAnnotation3d" displayLabel="3D Text Annotation">
         <BaseClass>GraphicalElement3d</BaseClass>
         <ECCustomAttributes>
@@ -1334,7 +1334,7 @@
         <ECCustomAttributes>
             <ClassHasHandler xmlns="BisCore.1.0"/>
             <ClassMap xmlns="ECDbMap.2.0">
-                <!-- We must insist that all instances of all possible subclasses are stored together in a single table. 
+                <!-- We must insist that all instances of all possible subclasses are stored together in a single table.
                      TxnManager knows about this table, and expects to find all instances this kind of relationship there. -->
                 <MapStrategy>TablePerHierarchy</MapStrategy>
             </ClassMap>
@@ -1444,7 +1444,7 @@
         </ECCustomAttributes>
         <ECProperty propertyName="Description" typeName="string"/>
     </ECEntityClass>
-    
+
     <ECEntityClass typeName="RenderMaterial" modifier="Sealed" displayLabel="Render Material">
         <!-- Marked as "Sealed" because JsonProperties will be used to persist data. This allows a single instance to "morph" between a DgnV8 render material and a future PBR material. -->
         <BaseClass>DefinitionElement</BaseClass>
@@ -1821,7 +1821,7 @@
             <Class class="LinkElement"/>
         </Target>
     </ECRelationshipClass>
-    
+
     <ECEntityClass typeName="RoleElement" modifier="Abstract" displayLabel="Role Element" description="A real world entity is modeled as a Role Element when a set of external circumstances define an important role (one that is worth tracking) that is not intrinsic to the entity playing the role. For example, a person can play the role of a teacher or a rock can play the role of a boundary marker.">
         <BaseClass>Element</BaseClass>
         <ECCustomAttributes>

--- a/iModelCore/ECDb/Tests/NonPublished/SchemaRemapTests.cpp
+++ b/iModelCore/ECDb/Tests/NonPublished/SchemaRemapTests.cpp
@@ -28,6 +28,135 @@ struct SchemaRemapTestFixture : public ECDbTestFixture
                                                                     if (PREPARESTATUS == ECSqlStatus::Success)\
                                                                         ASSERT_EQ(STEPSTATUS, stmt.Step());\
                                                                    }
+//---------------------------------------------------------------------------------------
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+------
+TEST_F(SchemaRemapTestFixture, StructPropertyRemap) {
+    SchemaItem schema1(R"xml(
+        <?xml version="1.0" encoding="utf-8" ?>
+        <ECSchema
+          schemaName="TestSchema"
+          alias="ts"
+          version="01.00.00"
+          xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+          <ECSchemaReference name="ECDbMap" version="02.00.00" alias="ecdbmap"/>
+          <ECStructClass typeName="S1" modifier="None">
+            <ECProperty propertyName="i0" typeName="int" />
+            <ECProperty propertyName="i1" typeName="int" />
+            <ECProperty propertyName="i2" typeName="int" />
+            <ECProperty propertyName="i3" typeName="int" />
+          </ECStructClass>
+          <ECStructClass typeName="S2" modifier="None">
+            <ECProperty propertyName="i0" typeName="int" />
+            <ECProperty propertyName="i1" typeName="int" />
+            <ECProperty propertyName="i2" typeName="int" />
+            <ECProperty propertyName="i3" typeName="int" />
+          </ECStructClass>
+          <ECEntityClass typeName="Element">
+            <ECCustomAttributes>
+                <ClassMap xmlns="ECDbMap.02.00.00">
+                    <MapStrategy>TablePerHierarchy</MapStrategy>
+                </ClassMap>
+                <ShareColumns xmlns="ECDbMap.02.00.00">
+                    <MaxSharedColumnsBeforeOverflow>10</MaxSharedColumnsBeforeOverflow>
+                    <ApplyToSubclassesOnly>False</ApplyToSubclassesOnly>
+                </ShareColumns>
+            </ECCustomAttributes>
+            <ECStructProperty propertyName="p0" typeName="S1"/>
+            <ECStructProperty propertyName="p1" typeName="S1"/>
+            <ECStructProperty propertyName="p2" typeName="S2"/>
+          </ECEntityClass>
+        </ECSchema>
+    )xml");
+
+    ASSERT_EQ(BentleyStatus::SUCCESS, SetupECDb("StructPropertyRemap.ecdb", schema1));
+
+    SchemaItem schema2(R"xml(
+        <?xml version="1.0" encoding="utf-8" ?>
+        <ECSchema
+          schemaName="TestSchema"
+          alias="ts"
+          version="02.00.00"
+          xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+          <ECSchemaReference name="ECDbMap" version="02.00.00" alias="ecdbmap"/>
+          <ECStructClass typeName="S1" modifier="None">
+            <ECProperty propertyName="i0" typeName="int" />
+            <ECProperty propertyName="i1" typeName="int" />
+            <ECProperty propertyName="i2" typeName="int" />
+            <ECProperty propertyName="i3" typeName="int" />
+          </ECStructClass>
+          <ECStructClass typeName="S2" modifier="None">
+            <ECProperty propertyName="i0" typeName="int" />
+            <ECProperty propertyName="i1" typeName="int" />
+            <ECProperty propertyName="i2" typeName="int" />
+            <ECProperty propertyName="i3" typeName="int" />
+          </ECStructClass>
+          <ECEntityClass typeName="Element">
+            <ECCustomAttributes>
+                <ClassMap xmlns="ECDbMap.02.00.00">
+                    <MapStrategy>TablePerHierarchy</MapStrategy>
+                </ClassMap>
+                <ShareColumns xmlns="ECDbMap.02.00.00">
+                    <MaxSharedColumnsBeforeOverflow>10</MaxSharedColumnsBeforeOverflow>
+                    <ApplyToSubclassesOnly>False</ApplyToSubclassesOnly>
+                </ShareColumns>
+            </ECCustomAttributes>
+            <ECStructProperty propertyName="p0" typeName="S1"/>
+            <ECStructProperty propertyName="p2" typeName="S2"/>
+          </ECEntityClass>
+        </ECSchema>
+    )xml");
+
+    ASSERT_EQ(BentleyStatus::SUCCESS, ImportSchema(schema2,
+      SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade |
+        SchemaManager::SchemaImportOptions::DoNotFailSchemaValidationForLegacyIssues
+    ));
+
+    SchemaItem schema3(R"xml(
+        <?xml version="1.0" encoding="utf-8" ?>
+        <ECSchema
+          schemaName="TestSchema"
+          alias="ts"
+          version="03.00.00"
+          xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+          <ECSchemaReference name="ECDbMap" version="02.00.00" alias="ecdbmap"/>
+          <ECStructClass typeName="S1" modifier="None">
+            <ECProperty propertyName="i0" typeName="int" />
+            <ECProperty propertyName="i1" typeName="int" />
+            <ECProperty propertyName="i2" typeName="int" />
+            <ECProperty propertyName="i3" typeName="int" />
+          </ECStructClass>
+          <ECStructClass typeName="S2" modifier="None">
+            <ECProperty propertyName="i0" typeName="int" />
+            <ECProperty propertyName="i1" typeName="int" />
+            <ECProperty propertyName="i2" typeName="int" />
+            <ECProperty propertyName="i3" typeName="int" />
+            <ECProperty propertyName="i4" typeName="int" />
+          </ECStructClass>
+          <ECEntityClass typeName="Element">
+            <ECCustomAttributes>
+                <ClassMap xmlns="ECDbMap.02.00.00">
+                    <MapStrategy>TablePerHierarchy</MapStrategy>
+                </ClassMap>
+                <ShareColumns xmlns="ECDbMap.02.00.00">
+                    <MaxSharedColumnsBeforeOverflow>10</MaxSharedColumnsBeforeOverflow>
+                    <ApplyToSubclassesOnly>False</ApplyToSubclassesOnly>
+                </ShareColumns>
+            </ECCustomAttributes>
+            <ECStructProperty propertyName="p0" typeName="S1"/>
+            <ECStructProperty propertyName="p1" typeName="S1"/>
+            <ECStructProperty propertyName="p2" typeName="S2"/>
+          </ECEntityClass>
+        </ECSchema>
+    )xml");
+
+    ASSERT_EQ(BentleyStatus::SUCCESS, ImportSchema(schema3,
+      SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade |
+        SchemaManager::SchemaImportOptions::DoNotFailSchemaValidationForLegacyIssues
+    ));
+
+    m_ecdb.SaveChanges();
+}
 
 //---------------------------------------------------------------------------------------
 // @bsimethod
@@ -4134,7 +4263,7 @@ TEST_F(SchemaRemapTestFixture, IfcProblemJune21)
 BentleyStatus SchemaRemapTestFixture::ImportSchemaFromFile(BeFileName const& fileName)
     {
     ECSchemaReadContextPtr ctx = ECSchemaReadContext::CreateContext(false, true);
-    
+
     ctx->AddSchemaLocater(m_ecdb.GetSchemaLocater());
     BeFileName directory = fileName.GetDirectoryName();
     ctx->AddSchemaPath(directory);
@@ -6821,7 +6950,7 @@ TEST_F(SchemaRemapTestFixture, RevitStoryScenario)
     </ECEntityClass>
 </ECSchema>
         )schema";
-        
+
     Utf8PrintfString schemaV1Xml(schemaBaseline, "01.00.00", "CompositeElement");
     SchemaItem schemaV1(schemaV1Xml);
 


### PR DESCRIPTION
When Struct definition of structType property is updated and now it has new properties and collectively it does not fit in joined table we moved it into overflow table.

The bug was that when structType property was already in overflow table we allocated columns in joined table. Then attempt to move the whole struct to different columns in overflow table along with newly allocated joined table column.

The fix is struct that already is in overflow always allocate column in overflow table and thus its not moved at all.