### PR TITLE
Improve error message when deleting element that is a definition element

### DIFF
--- a/iModelCore/iModelPlatform/DgnCore/DgnCategory.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/DgnCategory.cpp
@@ -82,14 +82,6 @@ DgnCategoryId DgnCategory::QueryCategoryId(DgnDbR db, DgnCodeCR code)
     return DgnCategoryId(db.Elements().QueryElementIdByCode(code).GetValueUnchecked());
     }
 
-/*---------------------------------------------------------------------------------**//**
-* @bsimethod
-+---------------+---------------+---------------+---------------+---------------+------*/
-DgnDbStatus DgnCategory::_OnDelete() const
-    {
-    // can only be deleted through a purge operation
-    return GetDgnDb().IsPurgeOperationActive() ? T_Super::_OnDelete() : DgnDbStatus::DeletionProhibited;
-    }
 
 /*---------------------------------------------------------------------------------**//**
 * @bsimethod
@@ -399,14 +391,6 @@ DgnDbStatus DgnSubCategory::_OnInsert()
     return cat.IsValid() ? T_Super::_OnInsert() : DgnDbStatus::InvalidParent;
     }
 
-/*---------------------------------------------------------------------------------**//**
-* @bsimethod
-+---------------+---------------+---------------+---------------+---------------+------*/
-DgnDbStatus DgnSubCategory::_OnDelete() const
-    {
-    // can only be deleted through a purge operation
-    return GetDgnDb().IsPurgeOperationActive() ? T_Super::_OnDelete() : DgnDbStatus::DeletionProhibited;
-    }
 
 /*---------------------------------------------------------------------------------**//**
 * @bsimethod

--- a/iModelCore/iModelPlatform/DgnCore/DgnElement.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/DgnElement.cpp
@@ -368,6 +368,25 @@ DgnDbStatus DefinitionElement::_OnInsert()
 /*---------------------------------------------------------------------------------**//**
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/
+DgnDbStatus DefinitionElement::_OnDelete() const
+    {
+    if (GetDgnDb().IsPurgeOperationActive())
+        {
+        return T_Super::_OnDelete();
+        }
+
+    if (GetDgnDb().GetJsIModelDb() == nullptr)
+        {
+        return DgnDbStatus::DeletionProhibited;
+        }
+
+    GetDgnDb().ThrowException(
+        "DefinitionElements cannot be deleted directly. Use deleteDefinitionElements() instead.", (int)DgnDbStatus::DeletionProhibited);
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
 DefinitionModelPtr DefinitionElement::GetDefinitionModel() const
     {
     DgnModelPtr model = GetModel();

--- a/iModelCore/iModelPlatform/DgnCore/DgnMaterial.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/DgnMaterial.cpp
@@ -24,7 +24,7 @@ void RenderMaterial::_OnLoadedJsonProperties()
             BeJsValue map = materialAssets["renderMaterial"]["Map"];
             map.ForEachProperty([&](Utf8CP memberName, BeJsConst memberJson)
                 {
-                if (memberJson.isNumericMember("TextureId")) 
+                if (memberJson.isNumericMember("TextureId"))
                     {
                     // Fix IDs that were previously stored as 64-bit integers rather than as ID strings.
                     auto textureIdAsStringForLogging = memberJson["TextureId"].Stringify();
@@ -42,19 +42,11 @@ void RenderMaterial::_OnLoadedJsonProperties()
                 });
             }
     }
-/*---------------------------------------------------------------------------------**//**
-* @bsimethod
-+---------------+---------------+---------------+---------------+---------------+------*/
-DgnDbStatus RenderMaterial::_OnDelete() const
-    {
-    // can only be deleted through a purge operation
-    return GetDgnDb().IsPurgeOperationActive() ? T_Super::_OnDelete() : DgnDbStatus::DeletionProhibited;
-    }
 
 /*---------------------------------------------------------------------------------**//**
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/
-DgnDbStatus RenderMaterial::_SetParentId(DgnElementId parentId, DgnClassId parentRelClassId) 
+DgnDbStatus RenderMaterial::_SetParentId(DgnElementId parentId, DgnClassId parentRelClassId)
     {
     if (parentId.IsValid())
         {

--- a/iModelCore/iModelPlatform/DgnCore/DgnTexture.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/DgnTexture.cpp
@@ -129,15 +129,6 @@ void DgnTexture::_CopyFrom(DgnElementCR src, CopyFromOptions const& opts)
 /*---------------------------------------------------------------------------------**//**
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/
-DgnDbStatus DgnTexture::_OnDelete() const
-    {
-    // can only be deleted through a purge operation
-    return GetDgnDb().IsPurgeOperationActive() ? T_Super::_OnDelete() : DgnDbStatus::DeletionProhibited;
-    }
-
-/*---------------------------------------------------------------------------------**//**
-* @bsimethod
-+---------------+---------------+---------------+---------------+---------------+------*/
 DgnTextureId DgnTexture::QueryTextureId(DgnDbR db, DgnCodeCR code)
     {
     return DgnTextureId(db.Elements().QueryElementIdByCode(code).GetValueUnchecked());

--- a/iModelCore/iModelPlatform/DgnCore/GeomPart.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/GeomPart.cpp
@@ -140,15 +140,6 @@ DgnDbStatus DgnGeometryPart::_UpdateInDb()
 /*---------------------------------------------------------------------------------**//**
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/
-DgnDbStatus DgnGeometryPart::_OnDelete() const
-    {
-    // can only be deleted through a purge operation
-    return GetDgnDb().IsPurgeOperationActive() ? T_Super::_OnDelete() : DgnDbStatus::DeletionProhibited;
-    }
-
-/*---------------------------------------------------------------------------------**//**
-* @bsimethod
-+---------------+---------------+---------------+---------------+---------------+------*/
 DgnDbStatus DgnGeometryPart::WriteGeometryStream()
     {
     if (!m_multiChunkGeomStream)

--- a/iModelCore/iModelPlatform/DgnCore/ViewDefinition.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/ViewDefinition.cpp
@@ -158,14 +158,6 @@ DgnDbStatus ViewDefinition::_OnInsert()
     return T_Super::_OnInsert();
     }
 
-/*---------------------------------------------------------------------------------**//**
-* @bsimethod
-+---------------+---------------+---------------+---------------+---------------+------*/
-DgnDbStatus ViewDefinition::_OnDelete() const
-    {
-    // can only be deleted through a purge operation
-    return GetDgnDb().IsPurgeOperationActive() ? T_Super::_OnDelete() : DgnDbStatus::DeletionProhibited;
-    }
 
 /*---------------------------------------------------------------------------------**//**
 * @bsimethod
@@ -729,15 +721,6 @@ DgnDbStatus CategorySelector::_OnUpdate(DgnElementCR el)
 /*---------------------------------------------------------------------------------**//**
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/
-DgnDbStatus CategorySelector::_OnDelete() const
-    {
-    // can only be deleted through a purge operation
-    return GetDgnDb().IsPurgeOperationActive() ? T_Super::_OnDelete() : DgnDbStatus::DeletionProhibited;
-    }
-
-/*---------------------------------------------------------------------------------**//**
-* @bsimethod
-+---------------+---------------+---------------+---------------+---------------+------*/
 DgnDbStatus CategorySelector::WriteCategories()
     {
     if (!GetElementId().IsValid())
@@ -851,15 +834,6 @@ DgnDbStatus ModelSelector::_OnUpdate(DgnElementCR el)
         }
 
     return DgnDbStatus::Success;
-    }
-
-/*---------------------------------------------------------------------------------**//**
-* @bsimethod
-+---------------+---------------+---------------+---------------+---------------+------*/
-DgnDbStatus ModelSelector::_OnDelete() const
-    {
-    // can only be deleted through a purge operation
-    return GetDgnDb().IsPurgeOperationActive() ? T_Super::_OnDelete() : DgnDbStatus::DeletionProhibited;
     }
 
 /*---------------------------------------------------------------------------------**//**
@@ -1533,15 +1507,6 @@ void DisplayStyle::_CopyFrom(DgnElementCR el, CopyFromOptions const& opts)
     m_viewFlags = other.m_viewFlags;
     m_subCategories = other.m_subCategories;
     m_subCategoryOverrides = other.m_subCategoryOverrides;
-    }
-
-/*---------------------------------------------------------------------------------**//**
-* @bsimethod
-+---------------+---------------+---------------+---------------+---------------+------*/
-DgnDbStatus DisplayStyle::_OnDelete() const
-    {
-    // can only be deleted through a purge operation
-    return GetDgnDb().IsPurgeOperationActive() ? T_Super::_OnDelete() : DgnDbStatus::DeletionProhibited;
     }
 
 /*---------------------------------------------------------------------------------**//**

--- a/iModelCore/iModelPlatform/DgnCore/linestyle/LsDb.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/linestyle/LsDb.cpp
@@ -307,7 +307,7 @@ LineStyleStatus LsPointComponent::CreateFromJson(LsPointComponentP*newPoint, Jso
         }
 
     *newPoint = pPoint;
-    return LINESTYLE_STATUS_Success; 
+    return LINESTYLE_STATUS_Success;
     }
 
 
@@ -378,7 +378,7 @@ LineStyleStatus LsSymbolComponent::CreateFromJson(LsSymbolComponentP*newComp, Js
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //---------------------------------------------------------------------------------------
-void LsSymbolComponent::SaveSymbolDataToJson(Json::Value& result, DPoint3dCR base, DPoint3dCR size, DgnGeometryPartId const& geomPartId, int32_t flags, double storedScale) 
+void LsSymbolComponent::SaveSymbolDataToJson(Json::Value& result, DPoint3dCR base, DPoint3dCR size, DgnGeometryPartId const& geomPartId, int32_t flags, double storedScale)
     {
     if (base.x != 0)
         result["baseX"] = base.x;
@@ -505,7 +505,7 @@ size_t LineStyleElement::QueryCount(DgnDbR db)
     CachedECSqlStatementPtr select = db.GetPreparedECSqlStatement("SELECT count(*) FROM " BIS_SCHEMA(BIS_CLASS_LineStyle));
     if (!select.IsValid())
         return 0;
-    
+
     if (BE_SQLITE_ROW != select->Step())
         return 0;
 
@@ -521,15 +521,6 @@ LineStyleElement::Iterator LineStyleElement::MakeIterator(DgnDbR db)
     iter.Prepare(db, "SELECT ECInstanceId,[CodeValue],Description,Data FROM " BIS_SCHEMA(BIS_CLASS_LineStyle), 0);
 
     return iter;
-    }
-
-//---------------------------------------------------------------------------------------
-// @bsimethod
-//---------------------------------------------------------------------------------------
-DgnDbStatus LineStyleElement::_OnDelete() const
-    {
-    // can only be deleted through a purge operation
-    return GetDgnDb().IsPurgeOperationActive() ? T_Super::_OnDelete() : DgnDbStatus::DeletionProhibited;
     }
 
 //---------------------------------------------------------------------------------------
@@ -570,7 +561,7 @@ DgnStyleId DgnImportContext::_RemapLineStyleId(DgnStyleId sourceId)
     if (dest.IsValid())
         return dest;
 
-    
+
     dest = LineStyleElement::ImportLineStyle(sourceId, *this);
     AddLineStyleId(sourceId, dest);
 
@@ -605,7 +596,7 @@ void DgnImportContext::AddLineStyleComponentId(LsComponentId sourceId, LsCompone
 DgnStyleId LineStyleElement::ImportLineStyle(DgnStyleId srcStyleId, DgnImportContext& importer)
     {
     //  See if we already have a line style with the same code in the destination Db.
-    //  If so, we'll map the source line style to it.  
+    //  If so, we'll map the source line style to it.
     LineStyleElementCPtr srcStyle = LineStyleElement::Get(importer.GetSourceDb(), srcStyleId);
     BeAssert(srcStyle.IsValid());
     if (!srcStyle.IsValid())
@@ -665,7 +656,7 @@ DgnElementPtr LineStyleElement::_CloneForImport(DgnDbStatus* status, DgnModelR d
     if (!Json::Reader::Parse(srcData, jsonObj))
       return newElem;
     LsComponentId compId = LsDefinition::GetComponentId (jsonObj);
-    
+
     DgnStyleId dstStyleId = QueryId(context.GetDestinationDb(), this->GetName().c_str());
     if (dstStyleId.IsValid())
         {
@@ -690,7 +681,7 @@ DgnElementPtr LineStyleElement::_CloneForImport(DgnDbStatus* status, DgnModelR d
 
     LineStyleElementPtr lsElement = dynamic_cast<LineStyleElement*>(newElem.get());
     lsElement->SetData(data.c_str());
-   
+
     return newElem;
     }
 END_BENTLEY_DGNPLATFORM_NAMESPACE

--- a/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/Annotations/AnnotationFrameStyle.h
+++ b/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/Annotations/AnnotationFrameStyle.h
@@ -114,7 +114,6 @@ protected:
     DGNPLATFORM_EXPORT DgnDbStatus _ReadSelectParams(BeSQLite::EC::ECSqlStatement& statement, ECSqlClassParams const& selectParams) override;
     DGNPLATFORM_EXPORT void _BindWriteParams(BeSQLite::EC::ECSqlStatement&, ForInsert) override;
     DGNPLATFORM_EXPORT void _CopyFrom(DgnElementCR source, CopyFromOptions const&) override;
-    DgnDbStatus _OnDelete() const override { return GetDgnDb().IsPurgeOperationActive() ? T_Super::_OnDelete() : DgnDbStatus::DeletionProhibited; /* Must be "purged" */ }
     uint32_t _GetMemSize() const override { return (uint32_t)(m_description.size() + 1 + m_data.GetMemSize()); }
     DgnCode _GenerateDefaultCode() const override { return DgnCode(); }
     bool _SupportsCodeSpec(CodeSpecCR codeSpec) const override { return !codeSpec.IsNullCodeSpec(); }

--- a/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/Annotations/AnnotationLeaderStyle.h
+++ b/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/Annotations/AnnotationLeaderStyle.h
@@ -121,7 +121,6 @@ protected:
     DGNPLATFORM_EXPORT DgnDbStatus _ReadSelectParams(BeSQLite::EC::ECSqlStatement& statement, ECSqlClassParams const& selectParams) override;
     DGNPLATFORM_EXPORT void _BindWriteParams(BeSQLite::EC::ECSqlStatement&, ForInsert) override;
     DGNPLATFORM_EXPORT void _CopyFrom(DgnElementCR source, CopyFromOptions const&) override;
-    DgnDbStatus _OnDelete() const override { return GetDgnDb().IsPurgeOperationActive() ? T_Super::_OnDelete() : DgnDbStatus::DeletionProhibited; /* Must be "purged" */ }
     uint32_t _GetMemSize() const override { return (uint32_t)(m_description.size() + 1 + m_data.GetMemSize()); }
     DgnCode _GenerateDefaultCode() const override { return DgnCode(); }
     bool _SupportsCodeSpec(CodeSpecCR codeSpec) const override { return !codeSpec.IsNullCodeSpec(); }

--- a/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/Annotations/AnnotationTextStyle.h
+++ b/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/Annotations/AnnotationTextStyle.h
@@ -120,7 +120,6 @@ protected:
     DGNPLATFORM_EXPORT DgnDbStatus _ReadSelectParams(BeSQLite::EC::ECSqlStatement&, ECSqlClassParams const&) override;
     DGNPLATFORM_EXPORT void _BindWriteParams(BeSQLite::EC::ECSqlStatement&, ForInsert) override;
     DGNPLATFORM_EXPORT void _CopyFrom(DgnElementCR, CopyFromOptions const&) override;
-    DgnDbStatus _OnDelete() const override { return GetDgnDb().IsPurgeOperationActive() ? T_Super::_OnDelete() : DgnDbStatus::DeletionProhibited; /* Must be "purged" */ }
     uint32_t _GetMemSize() const override { return (uint32_t)(m_description.size() + 1 + m_data.GetMemSize()); }
     DgnCode _GenerateDefaultCode() const override { return DgnCode(); }
     bool _SupportsCodeSpec(CodeSpecCR codeSpec) const override { return !codeSpec.IsNullCodeSpec(); }

--- a/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/Annotations/TextAnnotationSeed.h
+++ b/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/Annotations/TextAnnotationSeed.h
@@ -91,7 +91,6 @@ protected:
     DGNPLATFORM_EXPORT DgnDbStatus _ReadSelectParams(BeSQLite::EC::ECSqlStatement& statement, ECSqlClassParams const& selectParams) override;
     DGNPLATFORM_EXPORT void _BindWriteParams(BeSQLite::EC::ECSqlStatement&, ForInsert) override;
     DGNPLATFORM_EXPORT void _CopyFrom(DgnElementCR source, CopyFromOptions const&) override;
-    DgnDbStatus _OnDelete() const override { return GetDgnDb().IsPurgeOperationActive() ? T_Super::_OnDelete() : DgnDbStatus::DeletionProhibited; /* Must be "purged" */ }
     uint32_t _GetMemSize() const override { return (uint32_t)(m_description.size() + 1 + m_data.GetMemSize()); }
     DgnCode _GenerateDefaultCode() const override { return DgnCode(); }
     bool _SupportsCodeSpec(CodeSpecCR codeSpec) const override { return !codeSpec.IsNullCodeSpec(); }

--- a/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/DgnCategory.h
+++ b/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/DgnCategory.h
@@ -218,7 +218,6 @@ protected:
     bool _SupportsCodeSpec(CodeSpecCR codeSpec) const override {return !codeSpec.IsNullCodeSpec();}
     DGNPLATFORM_EXPORT DgnDbStatus _OnInsert() override;
     DGNPLATFORM_EXPORT DgnDbStatus _OnUpdate(DgnElementCR) override;
-    DGNPLATFORM_EXPORT DgnDbStatus _OnDelete() const override;
     DGNPLATFORM_EXPORT void _RemapIds(DgnImportContext&) override;
 
     uint32_t _GetMemSize() const override {return T_Super::_GetMemSize() + m_data.GetMemSize();}
@@ -316,7 +315,6 @@ protected:
     DGNPLATFORM_EXPORT void _CopyFrom(DgnElementCR source, CopyFromOptions const&) override;
     DGNPLATFORM_EXPORT void _RemapIds(DgnImportContext&) override;
     DGNPLATFORM_EXPORT DgnCode _GenerateDefaultCode() const override;
-    DGNPLATFORM_EXPORT DgnDbStatus _OnDelete() const override;
     DGNPLATFORM_EXPORT DgnDbStatus _OnInsert() override;
     DGNPLATFORM_EXPORT DgnDbStatus _OnUpdate(DgnElementCR) override;
     DGNPLATFORM_EXPORT void _OnInserted(DgnElementP copiedFrom) const override;

--- a/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/DgnElement.h
+++ b/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/DgnElement.h
@@ -2996,8 +2996,10 @@ struct EXPORT_VTABLE_ATTRIBUTE DefinitionElement : InformationContentElement
     DGNPLATFORM_EXPORT void _CopyFrom(DgnElementCR, CopyFromOptions const&) override;
 
 protected:
+    DGNPLATFORM_EXPORT DgnDbStatus _OnDelete() const override;
     DGNPLATFORM_EXPORT DgnDbStatus _OnInsert() override;
     DefinitionElementCP _ToDefinitionElement() const override final {return this;}
+
 public:
     explicit DefinitionElement(CreateParams const& params) : T_Super(params) {}
 

--- a/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/DgnMaterial.h
+++ b/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/DgnMaterial.h
@@ -67,7 +67,6 @@ protected:
 
     DGNPLATFORM_EXPORT DgnDbStatus _SetParentId(DgnElementId parentId, DgnClassId parentRelClassId) override;
     DGNPLATFORM_EXPORT DgnDbStatus _OnChildImport(DgnElementCR child, DgnModelR destModel, DgnImportContext& importer) const override;
-    DGNPLATFORM_EXPORT DgnDbStatus _OnDelete() const override;
     DGNPLATFORM_EXPORT void _RemapIds(DgnImportContext& importer) override;
     DGNPLATFORM_EXPORT void _OnLoadedJsonProperties() override;
 

--- a/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/DgnTexture.h
+++ b/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/DgnTexture.h
@@ -66,7 +66,6 @@ protected:
     DGNPLATFORM_EXPORT void _FromJson(BeJsConst props) override;
     DGNPLATFORM_EXPORT void _BindWriteParams(BeSQLite::EC::ECSqlStatement&, ForInsert) override;
     DGNPLATFORM_EXPORT void _CopyFrom(DgnElementCR source, CopyFromOptions const&) override;
-    DGNPLATFORM_EXPORT DgnDbStatus _OnDelete() const override;
     DgnCode _GenerateDefaultCode() const override { return DgnCode::CreateEmpty(); }
     bool _SupportsCodeSpec(CodeSpecCR codeSpec) const override { return !codeSpec.IsNullCodeSpec(); }
     uint32_t _GetMemSize() const override {return T_Super::_GetMemSize() + (sizeof(*this) - sizeof(T_Super)) + m_data.GetByteStream().GetSize() + (uint32_t)m_descr.size();}

--- a/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/GeomPart.h
+++ b/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/GeomPart.h
@@ -41,7 +41,6 @@ private:
     DGNPLATFORM_EXPORT DgnDbStatus _OnInsert() override;
     DGNPLATFORM_EXPORT DgnDbStatus _InsertInDb() override;
     DGNPLATFORM_EXPORT DgnDbStatus _UpdateInDb() override;
-    DGNPLATFORM_EXPORT DgnDbStatus _OnDelete() const override;
     DGNPLATFORM_EXPORT void _CopyFrom(DgnElementCR, CopyFromOptions const&) override;
     DGNPLATFORM_EXPORT void _RemapIds(DgnImportContext&) override;
 

--- a/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/LineStyle.h
+++ b/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/LineStyle.h
@@ -1541,7 +1541,6 @@ private:
         }
 
 protected:
-    DGNPLATFORM_EXPORT DgnDbStatus _OnDelete() const override;
     DGNPLATFORM_EXPORT DgnDbStatus _OnInsert() override;
     DgnCode _GenerateDefaultCode() const override { return DgnCode(); }
     bool _SupportsCodeSpec(CodeSpecCR codeSpec) const override { return !codeSpec.IsNullCodeSpec(); }

--- a/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/ViewDefinition.h
+++ b/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/ViewDefinition.h
@@ -258,7 +258,6 @@ protected:
     DGNPLATFORM_EXPORT void _OnSaveJsonProperties() override;
     DGNPLATFORM_EXPORT void _ToJson(BeJsValue val, BeJsConst opts) const override;
     DGNPLATFORM_EXPORT void _CopyFrom(DgnElementCR rhs, CopyFromOptions const&) override;
-    DGNPLATFORM_EXPORT DgnDbStatus _OnDelete() const override;
     explicit DisplayStyle(CreateParams const& params) : T_Super(params) {}
     virtual DisplayStyle2dCP _ToDisplayStyle2d() const {return nullptr;}
     virtual DisplayStyle3dCP _ToDisplayStyle3d() const {return nullptr;}
@@ -667,7 +666,6 @@ protected:
     DGNPLATFORM_EXPORT void _RemapIds(DgnImportContext&) override;
     DGNPLATFORM_EXPORT DgnDbStatus _InsertInDb() override;
     DGNPLATFORM_EXPORT DgnDbStatus _OnUpdate(DgnElementCR) override;
-    DGNPLATFORM_EXPORT DgnDbStatus _OnDelete() const override;
     DGNPLATFORM_EXPORT void _OnDeleted() const override;
     DGNPLATFORM_EXPORT void _ToJson(BeJsValue out, BeJsConst opts) const override;
     DGNPLATFORM_EXPORT void _FromJson(BeJsConst props) override;
@@ -726,7 +724,6 @@ protected:
     DGNPLATFORM_EXPORT void _RemapIds(DgnImportContext&) override;
     DGNPLATFORM_EXPORT DgnDbStatus _InsertInDb() override;
     DGNPLATFORM_EXPORT DgnDbStatus _OnUpdate(DgnElementCR) override;
-    DGNPLATFORM_EXPORT DgnDbStatus _OnDelete() const override;
     DGNPLATFORM_EXPORT void _ToJson(BeJsValue out, BeJsConst opts) const override;
     DGNPLATFORM_EXPORT void _FromJson(BeJsConst props) override;
 
@@ -811,7 +808,6 @@ protected:
     DGNPLATFORM_EXPORT void _BindWriteParams(BeSQLite::EC::ECSqlStatement&, ForInsert) override;
     DGNPLATFORM_EXPORT DgnDbStatus _OnInsert() override;
     void _OnInserted(DgnElementP copiedFrom) const override {ClearState(); T_Super::_OnInserted(copiedFrom);}
-    DGNPLATFORM_EXPORT DgnDbStatus _OnDelete() const override;
     void _OnDeleted() const override {DeleteThumbnail(); T_Super::_OnDeleted();}
     DGNPLATFORM_EXPORT void _CopyFrom(DgnElementCR el, CopyFromOptions const&) override;
     DGNPLATFORM_EXPORT void _RemapIds(DgnImportContext&) override;


### PR DESCRIPTION
itwinjs-core: https://github.com/iTwin/itwinjs-core/pull/8035

closes https://github.com/iTwin/itwinjs-core/issues/8029

This pull request enhances the error message displayed when trying to delete a definition element. Instead of a generic error, it now provides a specific message indicating that definition elements cannot be deleted directly. Developers are advised to use the `deleteDefinitionElements()` method instead. This change offers clearer guidance and helps prevent accidental deletions of crucial elements.
