### PR TITLE
Fix constraint violation when inserting a new custom attribute

### DIFF
--- a/iModelCore/ECDb/ECDb/SchemaWriter.cpp
+++ b/iModelCore/ECDb/ECDb/SchemaWriter.cpp
@@ -2742,7 +2742,7 @@ BentleyStatus SchemaWriter::UpdateRelationshipConstraint(Context& ctx, ECContain
 BentleyStatus SchemaWriter::UpdateCustomAttributes(Context& ctx, SchemaPersistenceHelper::GeneralizedCustomAttributeContainerType containerType, ECContainerId containerId, CustomAttributeChanges& caChanges, IECCustomAttributeContainerCR oldContainer, IECCustomAttributeContainerCR newContainer)
     {
     if (caChanges.IsEmpty() || caChanges.GetStatus() == ECChange::Status::Done)
-    return SUCCESS;
+        return SUCCESS;
 
     int customAttributeIndex = 0;
     CachedStatementPtr stmt = ctx.GetCachedStatement("SELECT MAX(Ordinal) from main. " TABLE_CustomAttribute " WHERE ContainerId = ? AND ContainerType = ?");
@@ -2751,9 +2751,6 @@ BentleyStatus SchemaWriter::UpdateCustomAttributes(Context& ctx, SchemaPersisten
 
     stmt->BindId(1, containerId);
     stmt->BindInt(2, Enum::ToInt(containerType));
-
-    if (caChanges.IsEmpty() || caChanges.GetStatus() == ECChange::Status::Done)
-        return SUCCESS;
 
     if (stmt->Step() != BE_SQLITE_ROW)
         {

--- a/iModelCore/ECDb/ECDb/SchemaWriter.cpp
+++ b/iModelCore/ECDb/ECDb/SchemaWriter.cpp
@@ -2741,6 +2741,9 @@ BentleyStatus SchemaWriter::UpdateRelationshipConstraint(Context& ctx, ECContain
 //+---------------+---------------+---------------+---------------+---------------+------
 BentleyStatus SchemaWriter::UpdateCustomAttributes(Context& ctx, SchemaPersistenceHelper::GeneralizedCustomAttributeContainerType containerType, ECContainerId containerId, CustomAttributeChanges& caChanges, IECCustomAttributeContainerCR oldContainer, IECCustomAttributeContainerCR newContainer)
     {
+    if (caChanges.IsEmpty() || caChanges.GetStatus() == ECChange::Status::Done)
+    return SUCCESS;
+
     int customAttributeIndex = 0;
     CachedStatementPtr stmt = ctx.GetCachedStatement("SELECT MAX(Ordinal) from main. " TABLE_CustomAttribute " WHERE ContainerId = ? AND ContainerType = ?");
     if (stmt == nullptr)
@@ -2757,9 +2760,6 @@ BentleyStatus SchemaWriter::UpdateCustomAttributes(Context& ctx, SchemaPersisten
         return ERROR;
         }
     customAttributeIndex = stmt->GetValueInt(0);
-
-    if (caChanges.IsEmpty() || caChanges.GetStatus() == ECChange::Status::Done)
-        return SUCCESS;
 
     BeAssert(caChanges.GetParent() != nullptr);
     const bool caContainerIsNew = caChanges.GetParent()->GetOpCode() == ECChange::OpCode::New;

--- a/iModelCore/ECDb/Tests/NonPublished/ECDbTests.cpp
+++ b/iModelCore/ECDb/Tests/NonPublished/ECDbTests.cpp
@@ -286,65 +286,6 @@ TEST_F(ECDbTestFixture, TwoConnections)
     }
     }
 
-    TEST_F(ECDbTestFixture, CustomAttributeOrdinal)
-    {
-    auto testCaXml = R"xml(<?xml version="1.0" encoding="UTF-8"?>
-    <ECSchema schemaName="TestCA" alias="tsca" version="01.00.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.1">
-        <ECCustomAttributeClass typeName="TestCA1" modifier="Sealed" appliesTo="Any"/>
-        <ECCustomAttributeClass typeName="TestCA2" modifier="Sealed" appliesTo="Any"/>
-        <ECCustomAttributeClass typeName="TestCA3" modifier="Sealed" appliesTo="Any"/>
-    </ECSchema>)xml";
-
-    auto testSchemaXml = R"xml(<?xml version="1.0" encoding="UTF-8"?>
-    <ECSchema schemaName="TestSchema" alias="ts" version="01.00.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.1">
-        <ECSchemaReference name="TestCA" version="01.00.00" alias="tsca"/>
-        <ECEntityClass typeName="Pipe">
-            <ECProperty propertyName="p4" typeName="int">
-                <ECCustomAttributes>
-                    <TestCA1 xmlns="TestCA.01.00"/>
-                    <TestCA2 xmlns="TestCA.01.00"/>
-                    <TestCA3 xmlns="TestCA.01.00"/>
-                </ECCustomAttributes>
-            </ECProperty>
-        </ECEntityClass>
-    </ECSchema>)xml";
-
-    ASSERT_EQ(BentleyStatus::SUCCESS, SetupECDb("ca_ordinal.ecdb", SchemaItem(testCaXml)));
-    ASSERT_EQ(SUCCESS, ImportSchema(SchemaItem(testSchemaXml)));
-
-    // remove the first two custom attributes
-    auto testSchemaXmlV2 = R"xml(<?xml version="1.0" encoding="UTF-8"?>
-    <ECSchema schemaName="TestSchema" alias="ts" version="01.00.01" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.1">
-        <ECSchemaReference name="TestCA" version="01.00.00" alias="tsca"/>
-        <ECEntityClass typeName="Pipe">
-            <ECProperty propertyName="p4" typeName="int">
-                <ECCustomAttributes>
-                    <TestCA3 xmlns="TestCA.01.00"/>
-                </ECCustomAttributes>
-            </ECProperty>
-        </ECEntityClass>
-    </ECSchema>)xml";
-
-    ASSERT_EQ(SUCCESS, ImportSchema(SchemaItem(testSchemaXmlV2)));
-
-    // now add a new custom attribute
-    auto testSchemaXmlV3 = R"xml(<?xml version="1.0" encoding="UTF-8"?>
-    <ECSchema schemaName="TestSchema" alias="ts" version="01.00.02" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.1">
-        <ECSchemaReference name="TestCA" version="01.00.00" alias="tsca"/>
-        <ECEntityClass typeName="Pipe">
-            <ECProperty propertyName="p4" typeName="int">
-                <ECCustomAttributes>
-                    <TestCA1 xmlns="TestCA.01.00"/>
-                    <TestCA2 xmlns="TestCA.01.00"/>
-                    <TestCA3 xmlns="TestCA.01.00"/>
-                </ECCustomAttributes>
-            </ECProperty>
-        </ECEntityClass>
-    </ECSchema>)xml";
-
-    ASSERT_EQ(SUCCESS, ImportSchema(SchemaItem(testSchemaXmlV3)));
-    }
-
 TEST_F(ECDbTestFixture, TestDropSchemasWithInstances)
     {
     ASSERT_EQ(DbResult::BE_SQLITE_OK, SetupECDb("TestDropSchemasWithInstances.ecdb"));

--- a/iModelCore/ECDb/Tests/NonPublished/ECDbTests.cpp
+++ b/iModelCore/ECDb/Tests/NonPublished/ECDbTests.cpp
@@ -286,6 +286,65 @@ TEST_F(ECDbTestFixture, TwoConnections)
     }
     }
 
+    TEST_F(ECDbTestFixture, CustomAttributeOrdinal)
+    {
+    auto testCaXml = R"xml(<?xml version="1.0" encoding="UTF-8"?>
+    <ECSchema schemaName="TestCA" alias="tsca" version="01.00.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.1">
+        <ECCustomAttributeClass typeName="TestCA1" modifier="Sealed" appliesTo="Any"/>
+        <ECCustomAttributeClass typeName="TestCA2" modifier="Sealed" appliesTo="Any"/>
+        <ECCustomAttributeClass typeName="TestCA3" modifier="Sealed" appliesTo="Any"/>
+    </ECSchema>)xml";
+
+    auto testSchemaXml = R"xml(<?xml version="1.0" encoding="UTF-8"?>
+    <ECSchema schemaName="TestSchema" alias="ts" version="01.00.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.1">
+        <ECSchemaReference name="TestCA" version="01.00.00" alias="tsca"/>
+        <ECEntityClass typeName="Pipe">
+            <ECProperty propertyName="p4" typeName="int">
+                <ECCustomAttributes>
+                    <TestCA1 xmlns="TestCA.01.00"/>
+                    <TestCA2 xmlns="TestCA.01.00"/>
+                    <TestCA3 xmlns="TestCA.01.00"/>
+                </ECCustomAttributes>
+            </ECProperty>
+        </ECEntityClass>
+    </ECSchema>)xml";
+
+    ASSERT_EQ(BentleyStatus::SUCCESS, SetupECDb("ca_ordinal.ecdb", SchemaItem(testCaXml)));
+    ASSERT_EQ(SUCCESS, ImportSchema(SchemaItem(testSchemaXml)));
+
+    // remove the first two custom attributes
+    auto testSchemaXmlV2 = R"xml(<?xml version="1.0" encoding="UTF-8"?>
+    <ECSchema schemaName="TestSchema" alias="ts" version="01.00.01" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.1">
+        <ECSchemaReference name="TestCA" version="01.00.00" alias="tsca"/>
+        <ECEntityClass typeName="Pipe">
+            <ECProperty propertyName="p4" typeName="int">
+                <ECCustomAttributes>
+                    <TestCA3 xmlns="TestCA.01.00"/>
+                </ECCustomAttributes>
+            </ECProperty>
+        </ECEntityClass>
+    </ECSchema>)xml";
+
+    ASSERT_EQ(SUCCESS, ImportSchema(SchemaItem(testSchemaXmlV2)));
+
+    // now add a new custom attribute
+    auto testSchemaXmlV3 = R"xml(<?xml version="1.0" encoding="UTF-8"?>
+    <ECSchema schemaName="TestSchema" alias="ts" version="01.00.02" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.1">
+        <ECSchemaReference name="TestCA" version="01.00.00" alias="tsca"/>
+        <ECEntityClass typeName="Pipe">
+            <ECProperty propertyName="p4" typeName="int">
+                <ECCustomAttributes>
+                    <TestCA1 xmlns="TestCA.01.00"/>
+                    <TestCA2 xmlns="TestCA.01.00"/>
+                    <TestCA3 xmlns="TestCA.01.00"/>
+                </ECCustomAttributes>
+            </ECProperty>
+        </ECEntityClass>
+    </ECSchema>)xml";
+
+    ASSERT_EQ(SUCCESS, ImportSchema(SchemaItem(testSchemaXmlV3)));
+    }
+
 TEST_F(ECDbTestFixture, TestDropSchemasWithInstances)
     {
     ASSERT_EQ(DbResult::BE_SQLITE_OK, SetupECDb("TestDropSchemasWithInstances.ecdb"));

--- a/iModelCore/ECDb/Tests/NonPublished/SchemaSyncTest.cpp
+++ b/iModelCore/ECDb/Tests/NonPublished/SchemaSyncTest.cpp
@@ -6509,7 +6509,7 @@ TEST_F(SchemaSyncTestFixture, AppendNewCA)
             }
     );
 
-    const auto SCHEMA2_HASH_ECDB_SCHEMA = "a8cc0df53bb1339d49f8c2609edeeb4ffcb0cf77eae648966ec01a1284ffd7d4";
+    const auto SCHEMA2_HASH_ECDB_SCHEMA = "9874406c0869f7a2d01bf02293f1cc1859a6ad656b9152e9c04ae7d501d929fd";
     const auto SCHEMA2_HASH_ECDB_MAP = "80d2aae54ffc27813eb1bd1d660aa80e02c1bbdb8522af0c27e64040393bfc72";
     const auto SCHEMA2_HASH_SQLITE_SCHEMA = "f5d18dd4acb5c7c8a7980d29bc65fdcb530ad0df51dfcfe94d001ce821b0b57e";
     Test(
@@ -22946,7 +22946,7 @@ TEST_F(SchemaSyncTestFixture, DisallowMajorSchemaUpgrade)
                     </ECEntityClass>
                 </ECSchema>)xml";
 
-            const auto SCHEMA_HASH_ECDB_SCHEMA = "eea4d406b801b29d20ee53f7bf931d4fb4d2620ef47611aed3ff713c2f943afe";
+            const auto SCHEMA_HASH_ECDB_SCHEMA = "c89ed71c57044db21bb5ca374500016c0e191c140f3df73b6f302b8497665933";
             const auto SCHEMA_HASH_ECDB_MAP = "358afdf1d6bcfd8af6bc408fa9a1c11eb29907169db6d58e0ab7231d3dbb8e7a";
             const auto SCHEMA_HASH_SQLITE_SCHEMA = "6dd9dcc7cf66b8bef870ce37f21e666964fd9cc93e16945aba81e5d684bf4b67";
 
@@ -22959,7 +22959,7 @@ TEST_F(SchemaSyncTestFixture, DisallowMajorSchemaUpgrade)
                 assertImport(newSchema, "1.1", SchemaManager::SchemaImportOptions::DisallowMajorSchemaUpgrade, {SCHEMA_HASH_ECDB_SCHEMA, SCHEMA_HASH_ECDB_MAP, SCHEMA_HASH_SQLITE_SCHEMA})
             ) << "Unique index on existing property must fail because adding a ECDbMap CA on existing class is not allowed.";
 
-            const auto SCHEMA2_HASH_ECDB_SCHEMA = "6b3f5b182b9b64f546090083ce65cf0706451481717f073a69ec4d66d7be7bcc";
+            const auto SCHEMA2_HASH_ECDB_SCHEMA = "e739593ce5078e5a718e91fb9875d7529b77be844d73e36b21650f05e8e5f710";
             EXPECT_EQ(
                 SchemaImportResult::OK,
                 assertImport(newSchema, "2.0", SchemaManager::SchemaImportOptions::None, {SCHEMA2_HASH_ECDB_SCHEMA, SCHEMA_HASH_ECDB_MAP, SCHEMA_HASH_SQLITE_SCHEMA})
@@ -23007,7 +23007,7 @@ TEST_F(SchemaSyncTestFixture, DisallowMajorSchemaUpgrade)
                     </ECEntityClass>
                 </ECSchema>)xml";
 
-            const auto SCHEMA_HASH_ECDB_SCHEMA = "6c0a59a3349d67cd61bed05f1b61c14ec042504154db7a2c1c45a914cfe5469b";
+            const auto SCHEMA_HASH_ECDB_SCHEMA = "308abbc500ec479f96ee8144de4d8872d85ca96a6833cd1a0b8d94f5d2c9973d";
             const auto SCHEMA_HASH_ECDB_MAP = "bdaba10f700ff097382ecc4edb11711b1f59dc5c0dbe3a7e0598ec1b4564dc0b";
             const auto SCHEMA_HASH_SQLITE_SCHEMA = "3d2258a5a3872f482a7fd354eec23fac9e2f16333121d98d1ce834220a006079";
 
@@ -23020,7 +23020,7 @@ TEST_F(SchemaSyncTestFixture, DisallowMajorSchemaUpgrade)
                 assertImport(newSchema, "1.1", SchemaManager::SchemaImportOptions::DisallowMajorSchemaUpgrade, {SCHEMA_HASH_ECDB_SCHEMA, SCHEMA_HASH_ECDB_MAP, SCHEMA_HASH_SQLITE_SCHEMA})
             ) << "Unique index on new property in existing class must fail because adding a ECDbMap CA on existing class is not allowed.";
 
-            const auto SCHEMA2_HASH_ECDB_SCHEMA = "67fa399deab85627083b1b2457199c24d10de901e639211e1010af6c55bb1f16";
+            const auto SCHEMA2_HASH_ECDB_SCHEMA = "60cd82d6d4f17a0901a166be6bc36671490de135801ed79509df0ef3b5ccaf6c";
             EXPECT_EQ(
                 SchemaImportResult::OK,
                 assertImport(newSchema, "2.0", SchemaManager::SchemaImportOptions::None, {SCHEMA2_HASH_ECDB_SCHEMA, SCHEMA_HASH_ECDB_MAP, SCHEMA_HASH_SQLITE_SCHEMA})

--- a/iModelCore/ECDb/Tests/NonPublished/SchemaUpgradeTests.cpp
+++ b/iModelCore/ECDb/Tests/NonPublished/SchemaUpgradeTests.cpp
@@ -302,6 +302,23 @@ TEST_F(SchemaUpgradeTestFixture, CustomAttributeOrdinal){
     </ECSchema>)xml";
 
     ASSERT_EQ(SUCCESS, ImportSchema(SchemaItem(testSchemaXmlV3)));
+    
+    ReopenECDb(); // Close and reopen the DB to simulate persisted state
+ 
+    auto pipeClass = m_ecdb.Schemas().GetClass("TestSchema", "Pipe");
+    ASSERT_NE(nullptr, pipeClass) << "Pipe class not found in TestSchema";
+ 
+    auto prop = pipeClass->GetPropertyP("p4");
+    ASSERT_NE(nullptr, prop) << "Property p4 not found in Pipe class";
+ 
+    auto ca1 = prop->GetCustomAttributeLocal("TestCA", "TestCA1");
+    ASSERT_NE(nullptr, ca1) << "TestCA1 not found on property";
+ 
+    auto ca2 = prop->GetCustomAttributeLocal("TestCA", "TestCA2");
+    ASSERT_NE(nullptr, ca2) << "TestCA2 not found on property";
+ 
+    auto ca3 = prop->GetCustomAttributeLocal("TestCA", "TestCA3");
+    ASSERT_NE(nullptr, ca3) << "TestCA3 not found on property";
 }
 //---------------------------------------------------------------------------------------
 // @bsimethod

--- a/iModelCore/ECDb/Tests/NonPublished/SchemaUpgradeTests.cpp
+++ b/iModelCore/ECDb/Tests/NonPublished/SchemaUpgradeTests.cpp
@@ -310,15 +310,15 @@ TEST_F(SchemaUpgradeTestFixture, CustomAttributeOrdinal){
  
     auto prop = pipeClass->GetPropertyP("p4");
     ASSERT_NE(nullptr, prop) << "Property p4 not found in Pipe class";
- 
+
     auto ca1 = prop->GetCustomAttributeLocal("TestCA", "TestCA1");
-    ASSERT_NE(nullptr, ca1) << "TestCA1 not found on property";
+    ASSERT_TRUE(ca1.IsValid()) << "TestCA1 not found on property";
  
     auto ca2 = prop->GetCustomAttributeLocal("TestCA", "TestCA2");
-    ASSERT_NE(nullptr, ca2) << "TestCA2 not found on property";
+    ASSERT_TRUE(ca2.IsValid()) << "TestCA2 not found on property";
  
     auto ca3 = prop->GetCustomAttributeLocal("TestCA", "TestCA3");
-    ASSERT_NE(nullptr, ca3) << "TestCA3 not found on property";
+    ASSERT_TRUE(ca3.IsValid()) << "TestCA3 not found on property";
 }
 //---------------------------------------------------------------------------------------
 // @bsimethod


### PR DESCRIPTION
fixes :https://github.com/iTwin/imodel-native/issues/1078
Issue Link: https://dev.azure.com/bentleycs/ProductAdvancement/_workitems/edit/1647065
  
Changes made:
 
Enhanced existing test (CustomAttributeOrdinal) to validate that custom attributes correctly persisted in the database.
 
Added ECSQL query to check presence and order of applied custom attributes after schema import.
 
Ensured consistency of CA data after version upgrades.
 
Verified behavior across old and new code to confirm correctness post-fix.