### PR TITLE
Adjust confusing log messages during schema import

### DIFF
--- a/iModelCore/ECDb/Tests/NonPublished/SchemaGraphTests.cpp
+++ b/iModelCore/ECDb/Tests/NonPublished/SchemaGraphTests.cpp
@@ -473,4 +473,120 @@ TEST_F(SchemaGraphTestFixture, DeepSchemaHierarchyWithNumerousUpdates)
     ASSERT_TRUE(a.get() == aFromB);
     }
     }
+
+
+TEST_F(SchemaGraphTestFixture, UpdatedBaseCASchema)
+    {
+    NativeLogging::Logging::SetLogger(&NativeLogging::ConsoleLogger::GetLogger());
+    NativeLogging::ConsoleLogger::GetLogger().SetSeverity("ECDb", BentleyApi::NativeLogging::LOG_TRACE);
+    NativeLogging::ConsoleLogger::GetLogger().SetSeverity("ECObjectsNative", BentleyApi::NativeLogging::LOG_TRACE);
+    // Scenario hit by iTwin Studio
+    // Simplified Schema Hierarchy: DomainSchema <- BisCore <- CoreCustomAttributes
+    // DomainSchema and CoreCustomAttributes get imported, while BisCore comes from the DB.
+    // The first import works fine, but when we attempt to repeat the import, we got a lot of problems indicating that BisCore is modified without incrementing its version.
+    SetupECDbForCurrentTest();
+
+    // Initial setup
+    SchemaKey myCustomAttributes_1_0_0_Key("MyCustomAttributes", 1, 0, 0);
+    Utf8String myCustomAttributes_1_0_0_Xml(
+    R"schema(<?xml version='1.0' encoding='utf-8' ?>
+    <ECSchema schemaName="MyCustomAttributes" alias="mca" version="01.00.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+        <ECCustomAttributeClass typeName="IsFoo" modifier="Sealed" >
+            <ECProperty propertyName="FooValue" typeName="string" />
+        </ECCustomAttributeClass>
+    </ECSchema>)schema");
+
+    SchemaKey myCore_1_0_0_Key("MyCore", 1, 0, 0);
+    Utf8String myCore_1_0_0_Xml(
+    R"schema(<?xml version='1.0' encoding='utf-8' ?>
+    <ECSchema schemaName="MyCore" alias="mc" version="01.00.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+        <ECSchemaReference name="MyCustomAttributes" version="01.00.00" alias="mca"/>
+        <ECEntityClass typeName="MyElement" modifier="Abstract">
+            <ECCustomAttributes>
+                <IsFoo xmlns="MyCustomAttributes.01.00.00">
+                    <FooValue>A</FooValue>
+                </IsFoo>
+            </ECCustomAttributes>
+        </ECEntityClass>
+    </ECSchema>)schema");
+
+    SchemaKey myDomain_1_0_0_Key("MyDomain", 1, 0, 0);
+    Utf8String myDomain_1_0_0_Xml(
+    R"schema(<?xml version='1.0' encoding='utf-8' ?>
+    <ECSchema schemaName="MyDomain" alias="md" version="01.00.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+        <ECSchemaReference name="MyCore" version="01.00.00" alias="mc"/>
+        <ECEntityClass typeName="MyDomainElement" modifier="Sealed">
+            <BaseClass>mc:MyElement</BaseClass>
+        </ECEntityClass>
+    </ECSchema>)schema");
+
+    SchemaKey myCustomAttributes_1_0_1_Key("MyCustomAttributes", 1, 0, 1);
+    Utf8String myCustomAttributes_1_0_1_Xml(
+    R"schema(<?xml version='1.0' encoding='utf-8' ?>
+    <ECSchema schemaName="MyCustomAttributes" alias="mca" version="01.00.01" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+        <ECCustomAttributeClass typeName="IsFoo" modifier="Sealed" >
+            <ECProperty propertyName="FooValue" typeName="string" />
+        </ECCustomAttributeClass>
+        <ECCustomAttributeClass typeName="IsBar" modifier="Sealed" >
+            <ECProperty propertyName="BarValue" typeName="string" />
+        </ECCustomAttributeClass>
+    </ECSchema>)schema");
+
+    { // initial import of CA and Core schemas
+    ECSchemaReadContextPtr context = ECSchemaReadContext::CreateContext();
+    StringSchemaLocater locater;
+    locater.AddSchemaString(myCustomAttributes_1_0_0_Key, myCustomAttributes_1_0_0_Xml);
+    locater.AddSchemaString(myCore_1_0_0_Key, myCore_1_0_0_Xml);
+    context->AddSchemaLocater(locater);
+    SanitizingSchemaLocater sanitizingLocater(m_ecdb.GetSchemaLocater());
+    context->SetFinalSchemaLocater(sanitizingLocater);
+    ECSchemaPtr myCustomAttributes = context->LocateSchema(myCustomAttributes_1_0_0_Key, SchemaMatchType::LatestReadCompatible);
+    ASSERT_TRUE(myCustomAttributes.IsValid());
+    ECSchemaPtr myCore = context->LocateSchema(myCore_1_0_0_Key, SchemaMatchType::LatestReadCompatible);
+    ASSERT_TRUE(myCore.IsValid());
+    SchemaImportResult result = m_ecdb.Schemas().ImportSchemas({ myCustomAttributes.get(), myCore.get() });
+    ASSERT_EQ(SchemaImportResult::OK, result);
+    m_ecdb.SaveChanges();
+    }
+
+    ReopenECDb();
+
+    { // Now import updated CA and Domain schemas
+    ECSchemaReadContextPtr context = ECSchemaReadContext::CreateContext();
+    StringSchemaLocater locater;
+    locater.AddSchemaString(myCustomAttributes_1_0_1_Key, myCustomAttributes_1_0_1_Xml);
+    locater.AddSchemaString(myDomain_1_0_0_Key, myDomain_1_0_0_Xml);
+    context->AddSchemaLocater(locater);
+    SanitizingSchemaLocater sanitizingLocater(m_ecdb.GetSchemaLocater());
+    context->SetFinalSchemaLocater(sanitizingLocater);
+    ECSchemaPtr myCustomAttributes = context->LocateSchema(myCustomAttributes_1_0_1_Key, SchemaMatchType::LatestReadCompatible);
+    ASSERT_TRUE(myCustomAttributes.IsValid());
+    ECSchemaPtr myDomain = context->LocateSchema(myDomain_1_0_0_Key, SchemaMatchType::LatestReadCompatible);
+    ASSERT_TRUE(myDomain.IsValid());
+    SchemaImportResult result = m_ecdb.Schemas().ImportSchemas({ myCustomAttributes.get(), myDomain.get() });
+    ASSERT_EQ(SchemaImportResult::OK, result);
+    m_ecdb.SaveChanges();
+    }
+
+    ReopenECDb();
+
+    { // Now import updated CA and Domain schemas again, here we ran into problems because ECDb thinks the Core schema is modified
+    ECSchemaReadContextPtr context = ECSchemaReadContext::CreateContext();
+    StringSchemaLocater locater;
+    locater.AddSchemaString(myCustomAttributes_1_0_1_Key, myCustomAttributes_1_0_1_Xml);
+    locater.AddSchemaString(myDomain_1_0_0_Key, myDomain_1_0_0_Xml);
+    context->AddSchemaLocater(locater);
+    SanitizingSchemaLocater sanitizingLocater(m_ecdb.GetSchemaLocater());
+    context->SetFinalSchemaLocater(sanitizingLocater);
+    ECSchemaPtr myCustomAttributes = context->LocateSchema(myCustomAttributes_1_0_1_Key, SchemaMatchType::LatestReadCompatible);
+    ASSERT_TRUE(myCustomAttributes.IsValid());
+    ECSchemaPtr myDomain = context->LocateSchema(myDomain_1_0_0_Key, SchemaMatchType::LatestReadCompatible);
+    ASSERT_TRUE(myDomain.IsValid());
+    SchemaImportResult result = m_ecdb.Schemas().ImportSchemas({ myCustomAttributes.get(), myDomain.get() });
+    ASSERT_EQ(SchemaImportResult::OK, result);
+    m_ecdb.SaveChanges();
+    }
+
+    CloseECDb();
+    }
 END_ECDBUNITTESTS_NAMESPACE

--- a/iModelCore/ECDb/Tests/NonPublished/SchemaGraphTests.cpp
+++ b/iModelCore/ECDb/Tests/NonPublished/SchemaGraphTests.cpp
@@ -477,9 +477,6 @@ TEST_F(SchemaGraphTestFixture, DeepSchemaHierarchyWithNumerousUpdates)
 
 TEST_F(SchemaGraphTestFixture, UpdatedBaseCASchema)
     {
-    NativeLogging::Logging::SetLogger(&NativeLogging::ConsoleLogger::GetLogger());
-    NativeLogging::ConsoleLogger::GetLogger().SetSeverity("ECDb", BentleyApi::NativeLogging::LOG_TRACE);
-    NativeLogging::ConsoleLogger::GetLogger().SetSeverity("ECObjectsNative", BentleyApi::NativeLogging::LOG_TRACE);
     // Scenario hit by iTwin Studio
     // Simplified Schema Hierarchy: DomainSchema <- BisCore <- CoreCustomAttributes
     // DomainSchema and CoreCustomAttributes get imported, while BisCore comes from the DB.

--- a/iModelCore/ecobjects/src/ECSchema.cpp
+++ b/iModelCore/ecobjects/src/ECSchema.cpp
@@ -3079,7 +3079,7 @@ void SearchPathSchemaFileLocater::AddCandidateSchemas(bvector<CandidateSchema>& 
         SchemaKey key;
         if (SchemaKey::ParseSchemaFullName(key, fileName.c_str()) != ECObjectsStatus::Success)
             {
-            LOG.warningv(L"Failed to parse schema file name %s. Skipping that file.", fileName.c_str());
+            LOG.warningv("Failed to parse schema file name %s. Skipping that file.", fileName.c_str());
             continue;
             }
 
@@ -3119,7 +3119,7 @@ void SearchPathSchemaFileLocater::AddCandidateNoExtensionSchema(bvector<Candidat
     if(!result)
     {
         BeAssert(s_noAssert);
-        LOG.warningv(L"Failed to read schema from %ls: %s", schemaPathname.c_str(), result.description());
+        LOG.warningv("Failed to read schema from %ls: %s", schemaPathname.c_str(), result.description());
         return;
     }
 
@@ -3128,7 +3128,7 @@ void SearchPathSchemaFileLocater::AddCandidateNoExtensionSchema(bvector<Candidat
     pugi::xml_node schemaNode;
     if (SchemaReadStatus::Success != SchemaXmlReader::ReadSchemaStub(key, ecXmlMajorVersion, ecXmlMinorVersion, schemaNode, xmlDoc))
         {
-        LOG.warningv(L"Failed to read schema version from %ls", schemaPathname.c_str());
+        LOG.warningv("Failed to read schema version from %ls", schemaPathname.c_str());
         return;
         }
 
@@ -3281,6 +3281,7 @@ ECSchemaPtr SanitizingSchemaLocater::_LocateSchema(SchemaKeyR key, SchemaMatchTy
         return nullptr;
 
     ECSchemaPtr sanitizedSchema;
+    LOG.infov("Creating copy of returned schema %s to clean schema graph", innerSchema->GetName().c_str());
     auto status = innerSchema->CopySchema(sanitizedSchema, &schemaContext, false);
     if(status != ECObjectsStatus::Success || !sanitizedSchema.IsValid() || schemaContext.AddSchema(*sanitizedSchema) == ECObjectsStatus::DuplicateSchema)
         return nullptr;
@@ -3953,7 +3954,7 @@ ECObjectsStatus ECSchemaCache::AddSchema(ECSchemaR ecSchema)
             ECSchemaP existingSchema = result.first->second.get();
             if(existingSchema != referencedSchema)
                 {
-                LOG.warningv(L"ECSchemaCache: Adding schema '%s' which references schema '%s'. However, a different in-memory instance of this referenced schema already exists in the cache. This may indicate an issue with the schema graph.",
+                LOG.warningv("ECSchemaCache: Adding schema '%s' which references schema '%s'. However, a different in-memory instance of this referenced schema already exists in the cache. This may indicate an issue with the schema graph.",
                      ecSchema.GetSchemaKey().GetFullSchemaName().c_str(), existingSchema->GetSchemaKey().GetFullSchemaName().c_str());
                 }
             }
@@ -3978,7 +3979,7 @@ void ECSchemaCache::CheckCleanSchemaGraph(ECSchemaP schema) const
         {
         if(kvPair.first.CompareByName(name) == 0 && !schema->GetSchemaKey().Matches(kvPair.first, SchemaMatchType::Exact))
             {
-            LOG.warningv(L"ECSchemaCache: Adding schema '%s' to the cache while schema '%s' already exists. Typically, only one version of a schema with the same name is expected. This may indicate an issue with the schema graph.",
+            LOG.warningv("ECSchemaCache: Adding schema '%s' to the cache while schema '%s' already exists. Typically, only one version of a schema with the same name is expected. This may indicate an issue with the schema graph.",
                     schema->GetSchemaKey().GetFullSchemaName().c_str(), kvPair.first.GetFullSchemaName().c_str());
             }
         }


### PR DESCRIPTION
OpenSite+ while migrating to iTwin.js 5 noticed some confusing log messages. Turned out they were suggesting a failed schema import which actually worked fine.

Our new mechanism of copying schemas during import which are located through ECDb caused a cascade of log messages complaining about modified schemas that do not have their version incremented. This message is now skipped if the only changes is to the schema's references.

Also cleaned up some mixup of wchar and char in log messages.