### PR TITLE
circumvent test failure due to new CI Windows environment

### DIFF
--- a/iModelCore/GeomLibs/geom/src/bspline/BSurfPatch.cpp
+++ b/iModelCore/GeomLibs/geom/src/bspline/BSurfPatch.cpp
@@ -23,15 +23,12 @@ void bspsurf_setTimerControl (int select, int count)
 /*---------------------------------------------------------------------------------**//**
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/
-BSurfPatch::BSurfPatch()
-{
-xyzw.clear();
-uKnots.clear();
-vKnots.clear();
-uOrder = vOrder = uIndex = vIndex = 0;
-uMin = uMax = vMin = vMax = 0.0;
-isNullU = isNullV = false;
-}
+BSurfPatch::BSurfPatch(): xyzw(), uKnots(), vKnots()
+    {
+    uOrder = vOrder = uIndex = vIndex = 0;
+    uMin = uMax = vMin = vMax = 0.0;
+    isNullU = isNullV = false;
+    }
 
 /*---------------------------------------------------------------------------------**//**
 * @bsimethod

--- a/iModelCore/GeomLibs/geom/test/CurvePrimitiveTest/t_directEvaluateSpiral.cpp
+++ b/iModelCore/GeomLibs/geom/test/CurvePrimitiveTest/t_directEvaluateSpiral.cpp
@@ -1914,7 +1914,6 @@ void ShowProps(char const * name, ICurvePrimitiveR curve, double fraction, DPoin
 TEST(Spiral, MXCubicExample)
     {
     const double length = 20;
-    // const double startDirection = 3.397200148;
     double  endRadius = 160.0;
     double  startRadius = 0.0;
     Check::Print (length, "\nNominal Length");
@@ -1958,7 +1957,6 @@ TEST(Spiral, DirectSpiralWithViewingTransform)
     {
     auto oldVolume = Check::SetMaxVolume (100);
     const double length = 20;
-    // const double startDirection = 3.397200148;
     double  endRadius = 160.0;
     double  startRadius = 0.0;
     double startBearingRadians = 0.0;


### PR DESCRIPTION
Recently updated CI Windows version (microsoftwindowsdesktop:office-365:win11-23h2-avd-m365) is causing a CI build failure in the geomlibs test introduced in https://github.com/iTwin/imodel-native/pull/721.

The test logic that is failing is moved to "long tests" scope so that we can debug when dev machines move to the new environment.

Backports will be needed:
- [ ] PPBase
- [ ] imodel02 