### PR TITLE
Fix event where ec presentation expect changes to be saved

### DIFF
--- a/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/TxnManager.h
+++ b/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/TxnManager.h
@@ -64,6 +64,8 @@ enum class TxnType : int32_t {
 //=======================================================================================
 struct TxnMonitor {
     virtual ~TxnMonitor() { }
+    virtual void _OnPullMergeEnd(TxnManager&) {}
+    virtual void _OnPullMergeBegin(TxnManager&) {}
     virtual void _OnCommit(TxnManager&) {}
     virtual void _OnCommitted(TxnManager&) {}
     virtual void _OnAppliedChanges(TxnManager&) {}

--- a/iModelJsNodeAddon/presentation/DgnDbECInstanceChangeEventSource.cpp
+++ b/iModelJsNodeAddon/presentation/DgnDbECInstanceChangeEventSource.cpp
@@ -164,9 +164,7 @@ void DgnDbECInstanceChangeEventSource::_OnCommit(Dgn::TxnManager& txns)
 +---------------+---------------+---------------+---------------+---------------+------*/
 void DgnDbECInstanceChangeEventSource::_OnAppliedChanges(TxnManager& txns)
     {
-    bvector<ECInstanceChangeEventSource::ChangedECInstance> changes;
-    AddChanges(changes, txns);
-    NotifyECInstancesChanged(txns.GetDgnDb(), changes);
+    AddChanges(m_changes, txns);
     }
 
 /*---------------------------------------------------------------------------------**//**
@@ -178,6 +176,22 @@ void DgnDbECInstanceChangeEventSource::_OnCommitted(Dgn::TxnManager& txns)
     m_changes.clear();
     }
 
+/*---------------------------------------------------------------------------------**//**
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+void DgnDbECInstanceChangeEventSource::_OnPullMergeEnd(Dgn::TxnManager& txns)
+    {
+    NotifyECInstancesChanged(txns.GetDgnDb(), m_changes);
+    m_changes.clear();
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+void DgnDbECInstanceChangeEventSource::_OnUndoRedo(TxnManager& txns, TxnAction){
+    NotifyECInstancesChanged(txns.GetDgnDb(), m_changes);
+    m_changes.clear();
+}
 /*---------------------------------------------------------------------------------**//**
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/

--- a/iModelJsNodeAddon/presentation/DgnDbECInstanceChangeEventSource.h
+++ b/iModelJsNodeAddon/presentation/DgnDbECInstanceChangeEventSource.h
@@ -29,8 +29,10 @@ private:
 protected:
     void _OnCommit(TxnManager&) override;
     void _OnCommitted(TxnManager&) override;
-    void _OnAppliedChanges(TxnManager&) override;
+    void _OnAppliedChanges(TxnManager&) override; // collect changes
     void _OnClassUsed(ECDbCR, ECClassCR, bool polymorphically) override;
+    void _OnPullMergeEnd(TxnManager&) override; //ensure changes are saved
+    void _OnUndoRedo(TxnManager&, TxnAction) override; //ensure changes are saved
 
 public:
     DgnDbECInstanceChangeEventSource();


### PR DESCRIPTION
itwinjs-core: https://github.com/iTwin/itwinjs-core/pull/8149

For 

1. PullMerge() - `TxnMonitor::_OnPullMergeEnd()` ensure saveChanges() have been called.
2. Do/Undo - `TxnMonitor::_OnUndoRedo()` ensure saveChanges() have been called.