### PR TITLE
Fix massive slowdown during ConcurrentQueryManager pause

### DIFF
--- a/iModelCore/ECDb/ECDb/ConcurrentQueryManagerImpl.cpp
+++ b/iModelCore/ECDb/ECDb/ConcurrentQueryManagerImpl.cpp
@@ -702,6 +702,13 @@ std::unique_ptr<RunnableRequestBase> RunnableRequestQueue::WaitForDequeue() {
     m_cond.wait(lock, [&](){
         return !m_requests.empty() || m_state.load() != State::Running;
     });
+
+    // If paused, wait until state changes to something else, if we return immediately, this would
+    // cause the caller to immediately call again and loop infinitely.
+    while (m_state.load() == State::Paused) {
+        m_cond.wait(lock, [&](){ return m_state.load() != State::Paused; });
+    }
+
     if (m_state.load() == State::Running)
         return Dequeue();
 


### PR DESCRIPTION
This was found through valgrind, but it affects normal runs as well, just much less significantly as locks/interrupts inside valgrind are more costly.

When we do ConcurrentQueryManager::Suspend, which for example happens during SchemaImport, the state changes to "Paused". But the implementation of this state ran an infinite loop, acquiring a lock and returning null in an endless loop which slowed down all other operations.

My suggested fix will wait in WaitForDequeue until the state is no longer Paused. The WaitCondition is still somewhat of an infinite loop, but we're using that already in the same method. At least now we're not unnecessarily acquiring millions of recursive locks.