### PR TITLE
replace sqlite3_interrupt() wiht sqlite3_progress_handler() to cancel query

### DIFF
--- a/iModelCore/BeSQLite/BeSQLite.cpp
+++ b/iModelCore/BeSQLite/BeSQLite.cpp
@@ -6623,6 +6623,22 @@ DbResult DbFile::SetBusyTimeout(int ms) {
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //---------------------------------------------------------------------------------------
+void DbFile::SetProgressHandler(std::function<DbProgressAction()> cb, int n) const {
+    m_progressHandler = cb;
+    if (m_progressHandler != nullptr) {
+        sqlite3_progress_handler(m_sqlDb, 1, nullptr, nullptr);
+    } else {
+        sqlite3_progress_handler(m_sqlDb, n, [](void* ctx)->int {
+            auto& cb = static_cast<DbFile*>(ctx)->m_progressHandler;
+            if (cb != nullptr)
+                return static_cast<int>(cb());
+            return (int)DbProgressAction::Continue;
+        }, (void*)this);
+    }
+}
+//---------------------------------------------------------------------------------------
+// @bsimethod
+//---------------------------------------------------------------------------------------
 DbResult Db::CheckDbIntegrity(BeFileNameCR dbFileName)
     {
     Utf8String dbName(dbFileName.c_str());

--- a/iModelCore/BeSQLite/SQLite/bentley-sqlite.c
+++ b/iModelCore/BeSQLite/SQLite/bentley-sqlite.c
@@ -25,7 +25,6 @@
 #define SQLITE_OMIT_AUTOINIT            1
 #define SQLITE_OMIT_COMPLETE            1
 #define SQLITE_OMIT_DEPRECATED          1
-#define SQLITE_OMIT_PROGRESS_CALLBACK   1
 #define SQLITE_USE_URI                  1
 
 #define HAVE_STDINT_H

--- a/iModelCore/ECDb/ECDb/ConcurrentQueryManagerImpl.cpp
+++ b/iModelCore/ECDb/ECDb/ConcurrentQueryManagerImpl.cpp
@@ -328,15 +328,7 @@ void ConnectionCache::InterruptIf(std::function<bool(RunnableRequestBase const&)
             conn->InterruptIf(predicate, cancel);
     }
 }
-//---------------------------------------------------------------------------------------
-// @bsimethod
-//---------------------------------------------------------------------------------------
-void ConnectionCache::SetCacheStatementsPerWork(uint32_t newSize) {
-    recursive_guard_t lock(m_mutex);
-    for (auto& conn: m_conns) {
-        conn->SetAdaptorCacheSize(newSize);
-    }
-}
+
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //---------------------------------------------------------------------------------------
@@ -574,23 +566,7 @@ RunnableRequestQueue::RunnableRequestQueue(ECDbCR ecdb): m_nextId(0), m_state(St
     m_shutdownWhenIdleFor = env.GetAutoShutdowWhenIdlelForSeconds();
     m_lastDequeueTime = std::chrono::time_point_cast<std::chrono::seconds>(std::chrono::steady_clock::now());
 }
-//---------------------------------------------------------------------------------------
-// @bsimethod
-//---------------------------------------------------------------------------------------
-void RunnableRequestQueue::SetMaxQuota(QueryQuota const& quota) {
-    recursive_guard_t lock(m_mutex);
-    m_quota = quota;
-}
-//---------------------------------------------------------------------------------------
-// @bsimethod
-//---------------------------------------------------------------------------------------
-void RunnableRequestQueue::SetRequestQueueMaxSize(uint32_t size) {
-    recursive_guard_t lock(m_mutex);
-    if (size < kMinQueueSize )
-        size = kMinQueueSize;
 
-    m_maxQueueSize = size;
-}
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //---------------------------------------------------------------------------------------
@@ -1317,13 +1293,7 @@ void QueryHelper::Execute(QueryAdaptorCache& adaptorCache, RunnableRequestBase& 
         setError(QueryResponse::Status::Error, "unsupported kind of request");
     }
 }
-//---------------------------------------------------------------------------------------
-// @bsimethod
-//---------------------------------------------------------------------------------------
-void QueryExecutor::SetWorkerPoolSize(uint32_t newSize) {
-    m_maxPoolSize = newSize;
-    m_connCache.SetMaxPoolSize(newSize);
-}
+
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //---------------------------------------------------------------------------------------
@@ -1466,10 +1436,6 @@ void ConcurrentQueryMgr::Enqueue(QueryRequest::Ptr request, OnCompletion onCompl
 bool ConcurrentQueryMgr::Suspend(ClearCacheOption clearCache, DetachAttachDbs detachDbs) { return m_impl->Suspend(clearCache,detachDbs); }
 bool ConcurrentQueryMgr::Resume() { return m_impl->Resume(); }
 bool ConcurrentQueryMgr::IsSuspended() const { return m_impl->IsSuspended(); }
-void ConcurrentQueryMgr::SetWorkerPoolSize(uint32_t newSize) {m_impl->SetWorkerPoolSize(newSize);}
-void ConcurrentQueryMgr::SetRequestQueueMaxSize(uint32_t newSize) {m_impl->SetRequestQueueMaxSize(newSize);}
-void ConcurrentQueryMgr::SetCacheStatementsPerWork(uint32_t newSize) {m_impl->SetCacheStatementsPerWork(newSize);}
-void ConcurrentQueryMgr::SetMaxQuota(QueryQuota const& newQuota) {m_impl->SetMaxQuota(newQuota);}
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //---------------------------------------------------------------------------------------

--- a/iModelCore/ECDb/ECDb/ConcurrentQueryManagerImpl.h
+++ b/iModelCore/ECDb/ECDb/ConcurrentQueryManagerImpl.h
@@ -195,7 +195,6 @@ struct ConnectionCache final {
         CachedConnection& GetSyncConnection();
         void Interrupt(bool reset_conn, bool detachDbs);
         void InterruptIf(std::function<bool(RunnableRequestBase const&)> predicate, bool cancel);
-        void SetCacheStatementsPerWork(uint32_t);
         void SetMaxPoolSize(uint32_t newSize)  {m_poolSize = newSize; }
         void SyncAttachDbs();
 };
@@ -317,8 +316,6 @@ struct RunnableRequestQueue final {
         explicit RunnableRequestQueue(ECDbCR ecdb);
         ~RunnableRequestQueue() { Stop();}
         bool CancelRequest(uint32_t id);
-        void SetRequestQueueMaxSize(uint32_t size);
-        void SetMaxQuota(QueryQuota const&);
         bool Suspend();
         bool Resume();
         ECDbCR GetECDb() const { return m_ecdb; }
@@ -344,7 +341,6 @@ struct QueryExecutor final {
     public:
         QueryExecutor(RunnableRequestQueue& queue, ECDbCR primaryDb, uint32_t pool_size = 0);
         ~QueryExecutor();
-        void SetWorkerPoolSize(uint32_t);
         ConnectionCache& GetConnectionCache() {return m_connCache; }
 };
 
@@ -413,11 +409,6 @@ struct ConcurrentQueryMgr::Impl : ECDb::IECDbCacheClearListener {
         bool Suspend(ClearCacheOption clearCache, DetachAttachDbs detachDbs);
         bool Resume() {return m_queue.Resume();}
         bool IsSuspended() const { return m_queue.GetState() == RunnableRequestQueue::State::Paused;}
-        // change config
-        void SetWorkerPoolSize(uint32_t newSize) { m_executor.SetWorkerPoolSize(newSize); }
-        void SetRequestQueueMaxSize(uint32_t newSize) { m_queue.SetRequestQueueMaxSize(newSize); }
-        void SetCacheStatementsPerWork(uint32_t newSize) { m_executor.GetConnectionCache().SetCacheStatementsPerWork(newSize); }
-        void SetMaxQuota(QueryQuota const& newQuota) {m_queue.SetMaxQuota(newQuota); }
 };
 
 //=======================================================================================

--- a/iModelCore/ECDb/ECDb/ConcurrentQueryManagerImpl.h
+++ b/iModelCore/ECDb/ECDb/ConcurrentQueryManagerImpl.h
@@ -159,15 +159,11 @@ struct CachedConnection final : std::enable_shared_from_this<CachedConnection> {
         std::vector<FunctionInfo> GetPrimaryDbSqlFunctions() const;
         void SetRequest(std::unique_ptr<RunnableRequestBase> request);
         void ClearRequest();
-        std::atomic_bool m_canBeInterrupted;
     public:
         CachedConnection(ConnectionCache& cache, uint16_t id):m_cache(cache), m_id(id), m_adaptorCache(*this),m_isChangeSummaryCacheAttached(false),m_retryHandler(QueryRetryHandler::Create(60s)){}
         recursive_mutex_t& GetMutex() { return m_mutexReq; }
         ~CachedConnection();
         void SyncAttachDbs();
-        void Interrupt() const { m_db.Interrupt();}
-        bool CanBeInterrupted() const { return m_canBeInterrupted.load(); }
-        void SetCanBeInterrupted(bool val) { return m_canBeInterrupted.store(val); }
         void Execute(std::function<void(QueryAdaptorCache&,RunnableRequestBase&)>, std::unique_ptr<RunnableRequestBase>);
         void Reset(bool detachDbs);
         void InterruptIf(std::function<bool(RunnableRequestBase const&)>,bool cancel);
@@ -362,7 +358,6 @@ struct QueryHelper final {
         static ECSqlRowProperty::List GetMetaInfo(CachedQueryAdaptor&,bool);
         static void Execute(CachedQueryAdaptor& cachedAdaptor, RunnableRequestBase& request);
         static void ReadBlob(ECDbCR conn, RunnableRequestBase& request);
-        static void ExecutePing(Json::Value const& pingJson, RunnableRequestBase& runnableRequest);
     public:
         static void Execute(QueryAdaptorCache& adaptorCache, RunnableRequestBase& request);
 };

--- a/iModelCore/ECDb/PublicAPI/ECDb/ConcurrentQueryManager.h
+++ b/iModelCore/ECDb/PublicAPI/ECDb/ConcurrentQueryManager.h
@@ -571,10 +571,6 @@ struct ConcurrentQueryMgr final {
         ECDB_EXPORT bool Resume();
         ECDB_EXPORT bool IsSuspended() const;
         // change config
-        ECDB_EXPORT void SetWorkerPoolSize(uint32_t);
-        ECDB_EXPORT void SetRequestQueueMaxSize(uint32_t);
-        ECDB_EXPORT void SetCacheStatementsPerWork(uint32_t);
-        ECDB_EXPORT void SetMaxQuota(QueryQuota const&);
         ECDB_EXPORT static ConcurrentQueryMgr& GetInstance(ECDb const&);
         ECDB_EXPORT static void Shutdown(ECDbCR ecdb);
 };


### PR DESCRIPTION
Reasons

* `sqlite3_interrupt()` need to be called from seperate thread. It cancel current running statement. But timing of when interrupt can cause a different statement to get cancelled instead one intented.
* `sqlite3_progress_handler()` on otherside can cancel query from same thread and its timing can precisouly controlled in a scope of statement that we intent to cancel if it spend more time then allocated.

Generally speaking sqlite3_interrupt() is more risky as when a thread a call interrupt on connection running in thread b it is possiable the thread 1 has completed the statement and now processing a different one or preparing a statement. This causes a flaky behaviour on backend.