### PR TITLE
VS 17.14 build patch: don't compare doubles with exact values

### DIFF
--- a/iModelCore/GeomLibs/geom/src/bspline/bspcurv.cpp
+++ b/iModelCore/GeomLibs/geom/src/bspline/bspcurv.cpp
@@ -1004,7 +1004,7 @@ MSBsplineCurve  *inCurve
             {
             a = (U[p]-U[k])/(U[p+j+1]-U[k]);
 
-            if (1.0 == a)
+            if (fabs(1.0 - a) < fc_nearZero)
                 {
                 // too many start knots
                 bspcurv_freeCurve (&curve);
@@ -1031,7 +1031,7 @@ MSBsplineCurve  *inCurve
             {
             a = (U[n+1]-U[n-j])/(U[n-j+i+2]-U[n-j]);
 
-            if (0.0 == a)
+            if (fabs(a) < fc_nearZero)
                 {
                 // too many end knots
                 bspcurv_freeCurve (&curve);
@@ -1376,11 +1376,14 @@ int             closed
             }
         if (weight)
             *weight = h;
-        if (h == 0.0)
+        if (fabs(h) < fc_nearZero)
             h = 1.0;
-        point->x /= h;
-        point->y /= h;
-        point->z /= h;
+        else
+            {
+            point->x /= h;
+            point->y /= h;
+            point->z /= h;
+            }
         }
     else
         {


### PR DESCRIPTION
- Comparing doubles with exact values may not work anymore with VS 17.14
- Fix returning start/end points of rational b-spline with zero weights as zeroes