### PR TITLE
TxnManager.deleteAllTxns not deleting briefcase changes

### DIFF
--- a/iModelCore/iModelPlatform/DgnCore/DgnDb.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/DgnDb.cpp
@@ -341,7 +341,7 @@ void DgnDb::_OnDbGuidChange(BeSQLite::BeGuid guid) {
 bool DgnDb::RequireStandaloneTxns() const {
     BeJsDocument standalone;
     QueryStandaloneEditFlags(standalone);
-    return standalone.isNull() ? false : standalone["txns"].asBool();
+    return standalone.isNull() ? false : standalone.asBool();
 }
 
 /*---------------------------------------------------------------------------------**/ /**

--- a/iModelCore/iModelPlatform/DgnCore/TxnManager.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/TxnManager.cpp
@@ -1998,12 +1998,27 @@ Utf8String TxnManager::GetRedoString() {
 /*---------------------------------------------------------------------------------**//**
  @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/
+void TxnManager::ClearAllTxns() {
+    if (PullMergeConf::Load(m_dgndb).InProgress()) {
+        m_dgndb.ThrowException("operation failed: pull merge in progress.", BE_SQLITE_ERROR);
+    }
+
+    m_dgndb.SaveChanges(); // in case there are outstanding changes that will create a new Txn
+    m_dgndb.ExecuteSql("DELETE FROM " DGN_TABLE_Txns);
+    m_dgndb.SaveChanges();
+    Initialize();
+}
+
+/*---------------------------------------------------------------------------------**//**
+ @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
 void TxnManager::DeleteAllTxns() {
     if (PullMergeConf::Load(m_dgndb).InProgress()) {
         m_dgndb.ThrowException("operation failed: pull merge in progress.", BE_SQLITE_ERROR);
     }
 
     m_dgndb.SaveChanges(); // in case there are outstanding changes that will create a new Txn
+    ReverseAll();
     m_dgndb.ExecuteSql("DELETE FROM " DGN_TABLE_Txns);
     m_dgndb.SaveChanges();
     Initialize();

--- a/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/TxnManager.h
+++ b/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/TxnManager.h
@@ -527,6 +527,7 @@ public:
     DGNPLATFORM_EXPORT static void AddTxnMonitor(TxnMonitor& monitor);
     DGNPLATFORM_EXPORT static void DropTxnMonitor(TxnMonitor& monitor);
     DGNPLATFORM_EXPORT void DeleteAllTxns();
+    DGNPLATFORM_EXPORT void ClearAllTxns();
     void DeleteFromStartTo(TxnId lastId);
     void DeleteReversedTxns();
     void OnBeginValidate();

--- a/iModelJsNodeAddon/IModelJsNative.cpp
+++ b/iModelJsNodeAddon/IModelJsNative.cpp
@@ -2579,7 +2579,15 @@ struct NativeDgnDb : BeObjectWrap<NativeDgnDb>, SQLiteOps<DgnDb>
             JsInterop::throwSqlResult("error deleting local value", name.c_str(), stat);
     }
 
-    // delete all local Txns. THIS IS VERY DANGEROUS! Don't use it unless you know what you're doing!
+    // only deletes all local Txns from the Db table without actually reverting the changes.
+    // THIS IS VERY DANGEROUS! Don't use it unless you know what you're doing!
+    void ClearAllTxns(NapiInfoCR info) {
+        GetOpenedDb(info).Txns().ClearAllTxns();
+    }
+
+    // reverts and then deletes all local Txns.
+    // THIS IS VERY DANGEROUS!
+    // Don't use it unless you know what you're doing!
     void DeleteAllTxns(NapiInfoCR info) {
         GetOpenedDb(info).Txns().DeleteAllTxns();
     }
@@ -2890,6 +2898,7 @@ struct NativeDgnDb : BeObjectWrap<NativeDgnDb>, SQLiteOps<DgnDb>
             InstanceMethod("createClassViewsInDb", &NativeDgnDb::CreateClassViewsInDb),
             InstanceMethod("createIModel", &NativeDgnDb::CreateIModel),
             InstanceMethod("deleteAllTxns", &NativeDgnDb::DeleteAllTxns),
+            InstanceMethod("clearAllTxns", &NativeDgnDb::ClearAllTxns),
             InstanceMethod("deleteElement", &NativeDgnDb::DeleteElement),
             InstanceMethod("deleteElementAspect", &NativeDgnDb::DeleteElementAspect),
             InstanceMethod("deleteLinkTableRelationship", &NativeDgnDb::DeleteLinkTableRelationship),

--- a/iModelJsNodeAddon/api_package/ts/src/NativeLibrary.ts
+++ b/iModelJsNodeAddon/api_package/ts/src/NativeLibrary.ts
@@ -609,6 +609,7 @@ export declare namespace IModelJsNative {
     public createClassViewsInDb(): BentleyStatus;
     public createIModel(fileName: string, props: CreateEmptyStandaloneIModelProps): void;
     public deleteAllTxns(): void;
+    public clearAllTxns(): void;
     public deleteElement(elemIdJson: string): void;
     public deleteElementAspect(aspectIdJson: string): void;
     public deleteLinkTableRelationship(props: RelationshipProps): DbResult;


### PR DESCRIPTION
Fixes https://github.com/iTwin/itwinjs-core/issues/8197

itwinjs-core: <TBD>

The function DeleteAllTxns was simply clearing the Dgn_Txns table without reverting/reversing any of the local changes.

This PR updates the function DeleteAllTxns to now reverse the changes before clearing the Dgn_Txns table.
A new function ClearAllTxns has been added which does that DeleteAllTxns used to do.
This was needed as we have tests where we want to setup data and clear the txns before starting a test.