### PR TITLE
Permit a material to not override element transparency.

### DIFF
--- a/iModelCore/iModelPlatform/DgnCore/Render.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/Render.cpp
@@ -420,8 +420,10 @@ Material::CreateParams::CreateParams(MaterialKeyCR key, RenderingAssetCR asset, 
     if (asset.GetBool(RENDER_MATERIAL_FlagHasFinish, false))
         m_specularExponent = asset.GetDouble(RENDER_MATERIAL_Finish, Defaults::SpecularExponent());
 
-    auto transparency = asset.GetBool(RENDER_MATERIAL_FlagHasTransmit, false) ? asset.GetDouble(RENDER_MATERIAL_Transmit, 0.0) : 0.0;
-    m_transparency.SetValue(transparency);
+    auto transparency = asset.GetTransparency();
+    if (transparency.has_value()) {
+        m_transparency.SetValue(*transparency);
+    }
 
     if (asset.GetBool(RENDER_MATERIAL_FlagHasDiffuse, false))
         m_diffuse = asset.GetDouble(RENDER_MATERIAL_Diffuse, Defaults::Diffuse());

--- a/iModelCore/iModelPlatform/DgnCore/RenderMaterial.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/RenderMaterial.cpp
@@ -422,6 +422,16 @@ BentleyStatus RenderingAsset::TextureMap::ComputeUVParams (bvector<DPoint2d>& pa
     return mapParams.ComputeUVParams(params, visitor, drapeParams);
     }
 
+std::optional<double> RenderingAsset::GetTransparency() const {
+    if (!GetValue(RENDER_MATERIAL_FlagHasTransmit).isBool()) {
+        // If HasTransmit is not defined, the material does not override transparency.
+        return std::optional<double>();
+    }
+
+    // If HasTransmit is false, the material overrides transparency to zero.
+    return GetBool(RENDER_MATERIAL_FlagHasTransmit, false) ? GetDouble(RENDER_MATERIAL_Transmit, 0.0) : 0.0;
+}
+
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //---------------------------------------------------------------------------------------

--- a/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/RenderMaterial.h
+++ b/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/RenderMaterial.h
@@ -6,6 +6,7 @@
 
 #include <json/value.h>
 #include "Render.h"
+#include <optional>
 
 #define RENDER_MATERIAL_Type                                        "Type"
 #define RENDER_MATERIAL_PatternFlags                                "PatternFlags"
@@ -276,6 +277,9 @@ public:
     TextureMap GetNormalMap() const { return GetTextureMap(TextureMap::Type::Normal, RENDER_MATERIAL_MAP_Normal); }
     double GetNormalScale() const { return GetDouble(RENDER_MATERIAL_NormalScale, 1.0); }
 
+    // The transparency from 0 (fully opaque) to 1 (fully transparent), or nullptr if transparency is not overridden.
+    DGNPLATFORM_EXPORT std::optional<double> GetTransparency() const;
+    
     //=======================================================================================
     //! Helper class for constructing a Render::TextureMapping::Trans2x3 from scratch or
     //! from a RenderingAsset::TextureMap.

--- a/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/RenderMaterial.h
+++ b/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/RenderMaterial.h
@@ -142,11 +142,11 @@ struct ElevationDrapeParams
 //! The specular exponent can be specified as a floating point value > 0.0 by setting:
 //!     RENDER_MATERIAL_FlagHasFinish=true; and
 //!     RENDER_MATERIAL_Finish=exponent
-//! A material *always* overrides element transparency as a value from 0 (fully opaque) to 1 (fully transparent).
-//!     If RENDER_MATERIAL_FlagHasTransmit=true, then RENDER_MATERIAL_Transmit holds that transparency value.
-//!     Otherwise, the transparency value is 0.0.
+//! A material can override element transparency as a value from 0 (fully opaque) to 1 (fully transparent).
+//!     If RENDER_MATERIAL_FlagHasTransmit=true, then RENDER_MATERIAL_Transmit holds the transparency override.
+//!     If RENDER_MATERIAL_FlagHasTransmit=false, then the transparency override is 0.0.
+//      If RENDER_MATERIAL_FlagHasTransmit is not defined, then the material does not override element transparency.
 //!     If the material has a pattern map, the alpha of the sampled texture will be multiplied by the material's alpha (inverse of its transparency).
-//!     ###TODO Revit wants to be able to *not* override element transparency. This should be doable.
 //! The diffuse lighting weight can be specified as a value in [0..1] by setting:
 //!     RENDER_MATERIAL_FlagHasDiffuse=true; and
 //!     RENDER_MATERIAL_Diffuse=weight


### PR DESCRIPTION
Fixes https://github.com/iTwin/itwin-graphics-backlog/issues/681.
imodel-native-internal: https://github.com/iTwin/imodel-native-internal/pull/870