### PR TITLE
Add new entries to bcv_stat table to debug memory issue

### DIFF
--- a/iModelCore/BeSQLite/SQLite/blockcachevfs.c
+++ b/iModelCore/BeSQLite/SQLite/blockcachevfs.c
@@ -6358,6 +6358,10 @@ u8 *bcvDatabaseVtabData(
     bcvBufferAppendU64(&rc, &buf, (u64)pCommon->nBlk);
     bcvBufferMsgString(&rc, &buf, "cachesize");
     bcvBufferAppendU64(&rc, &buf, (u64)(pCommon->nMaxCache / pCommon->szBlk));
+    bcvBufferMsgString(&rc, &buf, "memory_used");
+    bcvBufferAppendU64(&rc, &buf, (u64)sqlite3_memory_used());
+    bcvBufferMsgString(&rc, &buf, "memory_highwater");
+    bcvBufferAppendU64(&rc, &buf, (u64)sqlite3_memory_highwater(0));
   }
 
   if( rc!=SQLITE_OK ){


### PR DESCRIPTION
Changes come from this cloudsqlite commit: https://sqlite.org/cloudsqlite/info/5a8c00d32086439d
A future PR will update our sqlite to have all the latest changes from cloudsqlite and update our sqlite version. This one just adds the one set of changes, which as far as I can tell aren't dependent on any other changes.