### PR TITLE
Add SqliteChangesetReader.openInMemory() to allow read unsaved changes

### DIFF
--- a/iModelCore/iModelPlatform/DgnCore/ChangesetTxns.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/ChangesetTxns.cpp
@@ -773,6 +773,23 @@ void TxnManager::WriteChangesToFile(BeFileNameCR pathname, DdlChangesCR ddlChang
     if (!pathname.DoesPathExist())
         m_dgndb.ThrowException("changeset file not created", (int) ChangesetStatus::FileWriteError);
 }
+
+/**
+ * Create changeset from in-memory changes
+ */
+std::unique_ptr<ChangeSet> TxnManager::CreateChangesetFromInMemoryChanges() {
+    DbResult rc;
+    if (!HasDataChanges()) {
+        return nullptr;
+    }
+    ChangeSet inMemChangeSet;
+    rc = inMemChangeSet.FromChangeTrack(*this);
+    if (BE_SQLITE_OK != rc)
+        m_dgndb.ThrowException("fail to add in memory changes", (int) rc);
+
+    return std::make_unique<ChangeSet>(std::move(inMemChangeSet));
+}
+
 /**
  * Create changeset from local changes
 */

--- a/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/TxnManager.h
+++ b/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/TxnManager.h
@@ -496,6 +496,7 @@ public:
     DGNPLATFORM_EXPORT void RevertTimelineChanges(std::vector<ChangesetPropsPtr> changesets, bool skipSchemaChanges);
     DGNPLATFORM_EXPORT void ReverseChangeset(ChangesetPropsCR revision);
     DGNPLATFORM_EXPORT std::unique_ptr<BeSQLite::ChangeSet> CreateChangesetFromLocalChanges(bool includeInMemoryChanges);
+    DGNPLATFORM_EXPORT std::unique_ptr<BeSQLite::ChangeSet> CreateChangesetFromInMemoryChanges();
     DGNPLATFORM_EXPORT void ForEachLocalChange(std::function<void(BeSQLite::EC::ECInstanceKey const&, BeSQLite::DbOpcode)>, bvector<Utf8String> const&, bool includeInMemoryChanges = false);
     void SaveParentChangeset(Utf8StringCR revisionId, int32_t changesetIndex);
     ChangesetPropsPtr CreateChangesetProps(BeFileNameCR pathName);

--- a/iModelJsNodeAddon/IModelJsNative.cpp
+++ b/iModelJsNodeAddon/IModelJsNative.cpp
@@ -4770,6 +4770,7 @@ public:
           InstanceMethod("openGroup", &NativeChangesetReader::OpenGroup),
           InstanceMethod("writeToFile", &NativeChangesetReader::WriteToFile),
           InstanceMethod("openLocalChanges", &NativeChangesetReader::OpenLocalChanges),
+          InstanceMethod("openInMemoryChanges", &NativeChangesetReader::OpenInMemoryChanges),
           InstanceMethod("openTxn", &NativeChangesetReader::OpenTxn),
           InstanceMethod("reset", &NativeChangesetReader::Reset),
           InstanceMethod("step", &NativeChangesetReader::Step),
@@ -4907,6 +4908,20 @@ public:
 
         m_changeset.OpenChangeStream(Env(), std::move(changeset), invert);
         }
+    void OpenInMemoryChanges(NapiInfoCR info)
+        {
+        REQUIRE_ARGUMENT_ANY_OBJ(0, dbObj);
+        REQUIRE_ARGUMENT_BOOL(1, invert);
+        NativeDgnDb* nativeDgnDb = NativeDgnDb::Unwrap(dbObj);
+        if (!nativeDgnDb->IsOpen())
+            THROW_JS_DGN_DB_EXCEPTION(info.Env(), "Provided db is not open", DgnDbStatus::NotOpen);
+
+        auto changeset = nativeDgnDb->GetDgnDb().Txns().CreateChangesetFromInMemoryChanges();
+        if (changeset == nullptr)
+            THROW_JS_IMODEL_NATIVE_EXCEPTION(info.Env(), "no in-memory changes", IModelJsNativeErrorKey::ChangesetError);
+
+        m_changeset.OpenChangeStream(Env(), std::move(changeset), invert);
+        }        
     void OpenTxn(NapiInfoCR info)
         {
         REQUIRE_ARGUMENT_ANY_OBJ(0, dbObj);

--- a/iModelJsNodeAddon/api_package/ts/src/NativeLibrary.ts
+++ b/iModelJsNodeAddon/api_package/ts/src/NativeLibrary.ts
@@ -1510,6 +1510,7 @@ export declare namespace IModelJsNative {
     public openFile(fileName: string, invert: boolean): void;
     public openGroup(fileName: string[], db: AnyECDb, invert: boolean): void;
     public openLocalChanges(db: DgnDb, includeInMemoryChanges: boolean, invert: boolean): void;
+    public openInMemoryChanges(db: DgnDb, invert: boolean): void;
     public openTxn(db: DgnDb, txnId: Id64String, invert: boolean): void;
     public reset(): void;
     public step(): boolean;


### PR DESCRIPTION
itwinjs-core: https://github.com/iTwin/itwinjs-core/pull/8555

This has been added to help developer debug problem by looking into changes before calling `saveChanges()`.