### PR TITLE
Presentation: Fix support for related ECView properties

### DIFF
--- a/iModelCore/ECPresentation/Tests/NonPublished/Helpers/TestHelpers.h
+++ b/iModelCore/ECPresentation/Tests/NonPublished/Helpers/TestHelpers.h
@@ -59,6 +59,7 @@ template<typename TRegistry> struct RegisterSchemaHelper
         } \
     void registry::RegisterSchemaXml(Utf8String name, Utf8String schemaXml) \
         { \
+        schemaXml.ReplaceAll("{SCHEMA_NAME}", name.c_str()); \
         GetRegisteredSchemaXmls().push_back(bpair<Utf8String, Utf8String>(name, CreateValidSchemaString(name, schemaXml))); \
         } \
     void registry::RegisterMultipleSchemasXml(Utf8StringCR name, bvector<Utf8String> const& schemasXml) \


### PR DESCRIPTION
Fixed a couple of issues:

- When setting up a relationship path to an [ECView](https://www.itwinjs.org/learning/ecsqlreference/views/), it's likely that "target" of the relationship will be a concrete ECClass rather than the ECView. In that case our (debug build -only) target class validation becomes invalid, removed it.

- For some reason ECSQL doesn't allow selecting from ECViews with `ONLY` keyword. Make sure we don't.