### PR TITLE
ECSqlReader/ConcurrentQuery unable to see modification to file

### DIFF
--- a/iModelCore/BeSQLite/BeSQLite.cpp
+++ b/iModelCore/BeSQLite/BeSQLite.cpp
@@ -654,6 +654,14 @@ int BusyRetry::_OnBusy(int count) const {
 /*---------------------------------------------------------------------------------**//**
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/
+DbResult DbFile::GetFileDataVersion(uint32_t& version) const {
+    version = 0;
+    return (DbResult)sqlite3_file_control(m_sqlDb, nullptr, SQLITE_FCNTL_DATA_VERSION, &version);
+}
+
+/*---------------------------------------------------------------------------------**//**
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
 int DbFile::TraceCallback(unsigned t, void* data, void* p, void* x) {
     auto db = reinterpret_cast<DbFile*>(data);
     if (!db) return 0;
@@ -3892,8 +3900,17 @@ DbResult Db::AbandonChanges()
 +---------------+---------------+---------------+---------------+---------------+------*/
 void Db::_OnDbChangedByOtherConnection()
     {
+    ClearDbCache();
+    }
+
+//---------------------------------------------------------------------------------------
+//@bsimethod
+//+---------------+---------------+---------------+---------------+---------------+------
+void Db::ClearDbCache()
+    {
     m_dbFile->DeleteCachedPropertyMap();
     m_dbFile->m_blvCache.Clear();
+    m_dbFile->m_statements.Empty();
     }
 
 //---------------------------------------------------------------------------------------

--- a/iModelCore/BeSQLite/PublicAPI/BeSQLite/BeSQLite.h
+++ b/iModelCore/BeSQLite/PublicAPI/BeSQLite/BeSQLite.h
@@ -2448,6 +2448,7 @@ protected:
     void SaveCachedBlvs(bool isCommit);
     DbResult SetNoCaseCollation(NoCaseCollation col);
     NoCaseCollation GetNoCaseCollation() const { return m_noCaseCollation; }
+    BE_SQLITE_EXPORT DbResult GetFileDataVersion(uint32_t& version) const;
     BE_SQLITE_EXPORT void SetProgressHandler(std::function<DbProgressAction()>, int) const;
     BE_SQLITE_EXPORT DbResult SaveProperty(PropertySpecCR spec, Utf8CP strData, void const* value, uint32_t propsize, uint64_t majorId=0, uint64_t subId=0);
     BE_SQLITE_EXPORT bool HasProperty(PropertySpecCR spec, uint64_t majorId=0, uint64_t subId=0) const;
@@ -2798,6 +2799,7 @@ public:
     BE_SQLITE_EXPORT virtual ~Db();
     DbFile* GetDbFile() {return m_dbFile;}
 
+    
     //! SQLite supports the concept of an "implicit" transaction. That is, if no explicit transaction is active when you execute an SQL statement,
     //! SQLite will create an implicit transaction whose scope is the execution of the statement. However, it is rarely a good idea to rely on that behavior,
     //! since the overhead of starting/stopping a transaction can be very large, often much larger than the execution of the statement itself.
@@ -2846,6 +2848,8 @@ public:
     BE_SQLITE_EXPORT TraceProfileEvent& GetTraceProfileEvent() const;
     BE_SQLITE_EXPORT TraceCloseEvent& GetTraceCloseEvent() const;
 
+    DbResult GetFileDataVersion(uint32_t& version) const { return m_dbFile->GetFileDataVersion(version); }
+    BE_SQLITE_EXPORT void ClearDbCache();
     //! Determine whether there is an active transaction against this Db.
     bool IsTransactionActive() const {return 0 < GetCurrentSavepointDepth();}
 

--- a/iModelCore/ECDb/ECDb/ConcurrentQueryManagerImpl.h
+++ b/iModelCore/ECDb/ECDb/ConcurrentQueryManagerImpl.h
@@ -150,6 +150,7 @@ struct CachedConnection final : std::enable_shared_from_this<CachedConnection> {
         recursive_mutex_t m_mutexReq;
         std::unique_ptr<RunnableRequestBase> m_request;
         uint16_t m_id;
+        uint32_t m_primaryFileDataVer = 0;
         QueryAdaptorCache m_adaptorCache;
         QueryRetryHandler::Ptr m_retryHandler;
         void UpdateSqlFunctions(ConnectionAction);


### PR DESCRIPTION
`ConcurrentQuery` relies on `PRAGMA data_version` to detect if the database file has been modified by another connection. However, this mechanism doesn't work reliably when there are active statements, as these likely lock the database and prevent `PRAGMA data_version` from reflecting any changes until those statements are closed.

In ECDb, `InstanceReader` maintains active statements for performance reasons. For example, executing a query like `SELECT $ FROM Bis.Element` creates an active statement, which in turn blocks `PRAGMA data_version` from updating.

As a workaround, we now check the primary connection to determine if it has changed since the last time a query was executed via `ConcurrentQuery`. If a change is detected, we clear the cache to ensure consistency.