### PR TITLE
Fixed findSchemaPath.mki

### DIFF
--- a/schemas/BisSchemas/findSchemaPath.mki
+++ b/schemas/BisSchemas/findSchemaPath.mki
@@ -47,16 +47,11 @@ BisSchemasDir = $(SrcRoot)BisSchemas/
 %else
   searchStr = $(BBPYTHONCMD) -c "import os; print('$(SCHEMA_PATTERN)'.split('.')[0] if '*' in '$(SCHEMA_PATTERN)' else '$(SCHEMA_PATTERN)');"
 
-  data = $(BBPYTHONCMD) -c "import os; import json; inventoryJson = json.load(open(r'$(BisSchemasDir)SchemaInventory.json'));\
-       print([json.loads(json.dumps(sd).replace('\\\\\\', '\/')) for sd in inventoryJson['$(SCHEMA_PATTERN)'.split('.')[0]]]);"
-
-  status = $(BBPYTHONCMD) -c "dic=$[@readstdout "$(data)"]; print('true' if True in [obj['released'] for obj in dic if 'released' in obj and 'path' in obj] else 'false')"
-
-  postfix = $(BBPYTHONCMD) -c "dic=$[@readstdout "$(data)"];\
-       print ([(obj['path']) for obj in dic if ('path' in obj and '$[@readstdout "$(searchStr)"]' in obj['path'] and str(obj['released']).lower() == '$[@readstdout "$(status)"]')])"
-
-  relativePath = $(BBPYTHONCMD) -c "import os; postfixPath = $[@readstdout "$(postfix)"];\
-              print ('pathNotFound' if not postfixPath else os.path.join(os.path.dirname(postfixPath[0]), '$(SCHEMA_PATTERN)'))"
+  relativePath = $(BBPYTHONCMD) -c "import os; import json; inventoryJson = json.load(open(r'$(BisSchemasDir)SchemaInventory.json')); \
+        dic = [json.loads(json.dumps(sd).replace('\\\\\\', '\/')) for sd in inventoryJson['$(SCHEMA_PATTERN)'.split('.')[0]]]; \
+        status = 'true' if True in [obj['released'] for obj in dic if 'released' in obj and 'path' in obj] else 'false'; \
+        postfix = [(obj['path']) for obj in dic if ('path' in obj and '$[@readstdout "$(searchStr)"]' in obj['path'] and str(obj['released']).lower() == status)]; \
+        print ('pathNotFound' if not postfix else os.path.join(os.path.dirname(postfix[0]), '$(SCHEMA_PATTERN)'))"
 
   normalizedPath = $(BBPYTHONCMD) -c "import os; normalizedPath = r'$(BisSchemasDir)$[@readstdout "$(relativePath)"]';\
                 normalizedPath = os.path.normpath(normalizedPath);\


### PR DESCRIPTION
Printing and then reading a schema section for processing will eventually lead to the error `The command line is too long`, when the number of schemas in each section will increase from a certain limit.