### PR TITLE
Add Db::ReanalyzeIfStale to detect and recompute stale query planner statistics

### DIFF
--- a/iModelCore/BeSQLite/BeSQLite.cpp
+++ b/iModelCore/BeSQLite/BeSQLite.cpp
@@ -20,6 +20,7 @@
 #include <Bentley/bvector.h>
 #include <Bentley/bmap.h>
 #include <string>
+#include <cmath>
 #include "BeSQLiteProfileManager.h"
 #include <prg.h>
 #include <unordered_map>
@@ -6756,8 +6757,8 @@ DbResult Db::ReanalyzeIfStale(double threshold, ReanalyzeMode mode, bool* didAna
     if (didAnalyze)
         *didAnalyze = false;
 
-    if (threshold <= 0.0)
-        threshold = 0.3;
+    if (!std::isfinite(threshold) || threshold <= 0.0)
+        return BE_SQLITE_ERROR;
 
     // If sqlite_stat1 doesn't exist or is empty, the database has never been meaningfully analyzed.
     if (!TableExists("sqlite_stat1")) {
@@ -6804,7 +6805,7 @@ DbResult Db::ReanalyzeIfStale(double threshold, ReanalyzeMode mode, bool* didAna
         int64_t recordedCount = statStmt.GetValueInt64(1);
 
         Statement countStmt;
-        auto countRc = countStmt.TryPrepare(*this, SqlPrintfString("SELECT count(*) FROM \"%w\"", tableName));
+        auto countRc = countStmt.TryPrepare(*this, SqlPrintfString("SELECT count(*) FROM %w", tableName));
         if (countRc != BE_SQLITE_OK)
             continue; // table may have been dropped since last ANALYZE
 
@@ -6842,9 +6843,8 @@ DbResult Db::ReanalyzeIfStale(double threshold, ReanalyzeMode mode, bool* didAna
         if (rc != BE_SQLITE_OK)
             return rc;
     } else {
-            rc = TryExecuteSql(SqlPrintfString("ANALYZE %w", table.c_str()));
         for (auto const& table : staleTables) {
-            rc = TryExecuteSql(SqlPrintfString("ANALYZE \"%w\"", table.c_str()));
+            rc = TryExecuteSql(SqlPrintfString("ANALYZE %w", table.c_str()));
             if (rc != BE_SQLITE_OK)
                 return rc;
         }

--- a/iModelCore/BeSQLite/BeSQLite.cpp
+++ b/iModelCore/BeSQLite/BeSQLite.cpp
@@ -6786,11 +6786,12 @@ DbResult Db::ReanalyzeIfStale(double threshold, ReanalyzeMode mode, bool* didAna
     }
     emptyCheck.Finalize();
 
-    // For each table in sqlite_stat1, compare its recorded row count with the actual count.
-    // The stat column format is "N d1 d2 ..." where N is the total row count;
-    // CAST(stat AS INTEGER) extracts N.
-    Statement statStmt;
-    rc = statStmt.TryPrepare(*this, "SELECT tbl, CAST(stat AS INTEGER) FROM sqlite_stat1 GROUP BY tbl");
+    // For each table-level row in sqlite_stat1, compare its recorded row count with the actual count.
+    // The stat column format is "N d1 d2 ..." where N is the total row count;
+    // CAST(stat AS INTEGER) extracts N. Restrict to idx IS NULL so we read the table row,
+    // not an arbitrary index row for the table.
+    Statement statStmt;
+    rc = statStmt.TryPrepare(*this, "SELECT tbl, CAST(stat AS INTEGER) FROM sqlite_stat1 WHERE idx IS NULL");
     if (rc != BE_SQLITE_OK)
         return rc;
 

--- a/iModelCore/BeSQLite/BeSQLite.cpp
+++ b/iModelCore/BeSQLite/BeSQLite.cpp
@@ -6787,10 +6787,12 @@ DbResult Db::ReanalyzeIfStale(double threshold, ReanalyzeMode mode, bool* didAna
     emptyCheck.Finalize();
 
     // For each table-level row in sqlite_stat1, compare its recorded row count with the actual count.
-    // The stat column format is "N d1 d2 ..." where N is the total row count;
+    // The stat column format is "N d1 d2 ..." where N is the total row count;
+
     // CAST(stat AS INTEGER) extracts N. Restrict to idx IS NULL so we read the table row,
     // not an arbitrary index row for the table.
-    Statement statStmt;
+    Statement statStmt;
+
     rc = statStmt.TryPrepare(*this, "SELECT tbl, CAST(stat AS INTEGER) FROM sqlite_stat1 WHERE idx IS NULL");
     if (rc != BE_SQLITE_OK)
         return rc;
@@ -6840,7 +6842,7 @@ DbResult Db::ReanalyzeIfStale(double threshold, ReanalyzeMode mode, bool* didAna
         if (rc != BE_SQLITE_OK)
             return rc;
     } else {
-        SuspendDefaultTxn noDefault(*this);
+            rc = TryExecuteSql(SqlPrintfString("ANALYZE %w", table.c_str()));
         for (auto const& table : staleTables) {
             rc = TryExecuteSql(SqlPrintfString("ANALYZE \"%w\"", table.c_str()));
             if (rc != BE_SQLITE_OK)

--- a/iModelCore/BeSQLite/BeSQLite.cpp
+++ b/iModelCore/BeSQLite/BeSQLite.cpp
@@ -6748,6 +6748,110 @@ DbResult Db::Analyze() {
     return TryExecuteSql("analyze");
 }
 
+/** Check if query planner statistics are stale and, if so, recompute them.
+ *  In Full mode, breaks on the first stale table and reanalyzes everything.
+ *  In PerTable mode, collects all stale tables and reanalyzes each individually.
+ *  Does NOT clear any caches — caller is responsible for that when didAnalyze is true. */
+DbResult Db::ReanalyzeIfStale(double threshold, ReanalyzeMode mode, bool* didAnalyze) {
+    if (didAnalyze)
+        *didAnalyze = false;
+
+    if (threshold <= 0.0)
+        threshold = 0.3;
+
+    // If sqlite_stat1 doesn't exist or is empty, the database has never been meaningfully analyzed.
+    if (!TableExists("sqlite_stat1")) {
+        auto rc = Analyze();
+        if (rc != BE_SQLITE_OK)
+            return rc;
+        if (didAnalyze)
+            *didAnalyze = true;
+        return BE_SQLITE_OK;
+    }
+
+    // Check if sqlite_stat1 has any rows at all. CreateNewDb creates the table but empties it.
+    Statement emptyCheck;
+    auto rc = emptyCheck.TryPrepare(*this, "SELECT 1 FROM sqlite_stat1 LIMIT 1");
+    if (rc != BE_SQLITE_OK)
+        return rc;
+
+    if (emptyCheck.Step() != BE_SQLITE_ROW) {
+        emptyCheck.Finalize();
+        rc = Analyze();
+        if (rc != BE_SQLITE_OK)
+            return rc;
+        if (didAnalyze)
+            *didAnalyze = true;
+        return BE_SQLITE_OK;
+    }
+    emptyCheck.Finalize();
+
+    // For each table in sqlite_stat1, compare its recorded row count with the actual count.
+    // The stat column format is "N d1 d2 ..." where N is the total row count;
+    // CAST(stat AS INTEGER) extracts N.
+    Statement statStmt;
+    rc = statStmt.TryPrepare(*this, "SELECT tbl, CAST(stat AS INTEGER) FROM sqlite_stat1 GROUP BY tbl");
+    if (rc != BE_SQLITE_OK)
+        return rc;
+
+    bool anyStale = false;
+    bvector<Utf8String> staleTables;
+    while (statStmt.Step() == BE_SQLITE_ROW) {
+        Utf8CP tableName = statStmt.GetValueText(0);
+        int64_t recordedCount = statStmt.GetValueInt64(1);
+
+        Statement countStmt;
+        auto countRc = countStmt.TryPrepare(*this, SqlPrintfString("SELECT count(*) FROM \"%w\"", tableName));
+        if (countRc != BE_SQLITE_OK)
+            continue; // table may have been dropped since last ANALYZE
+
+        if (countStmt.Step() != BE_SQLITE_ROW)
+            continue;
+
+        int64_t actualCount = countStmt.GetValueInt64(0);
+
+        bool isStale = false;
+        if (recordedCount == 0) {
+            isStale = (actualCount > 0);
+        } else {
+            int64_t diff = actualCount - recordedCount;
+            if (diff < 0)
+                diff = -diff;
+            isStale = (static_cast<double>(diff) / static_cast<double>(recordedCount) >= threshold);
+        }
+
+        if (!isStale)
+            continue;
+
+        anyStale = true;
+        if (mode == ReanalyzeMode::Full)
+            break; // one stale table is enough — reanalyze everything
+
+        staleTables.push_back(tableName);
+    }
+    statStmt.Finalize();
+
+    if (!anyStale)
+        return BE_SQLITE_OK;
+
+    if (mode == ReanalyzeMode::Full) {
+        rc = Analyze();
+        if (rc != BE_SQLITE_OK)
+            return rc;
+    } else {
+        SuspendDefaultTxn noDefault(*this);
+        for (auto const& table : staleTables) {
+            rc = TryExecuteSql(SqlPrintfString("ANALYZE \"%w\"", table.c_str()));
+            if (rc != BE_SQLITE_OK)
+                return rc;
+        }
+    }
+
+    if (didAnalyze)
+        *didAnalyze = true;
+    return BE_SQLITE_OK;
+}
+
 /**
  * Commit and then re-start current Txn. This may only happen when no nested transactions are active.
  * It is useful for readonly connections to load changes made by other connections.

--- a/iModelCore/BeSQLite/BeSQLite.cpp
+++ b/iModelCore/BeSQLite/BeSQLite.cpp
@@ -6806,11 +6806,15 @@ DbResult Db::ReanalyzeIfStale(double threshold, ReanalyzeMode mode, bool* didAna
 
         Statement countStmt;
         auto countRc = countStmt.TryPrepare(*this, SqlPrintfString("SELECT count(*) FROM %w", tableName));
-        if (countRc != BE_SQLITE_OK)
-            continue; // table may have been dropped since last ANALYZE
+        if (countRc != BE_SQLITE_OK) {
+            if (!TableExists(tableName))
+                continue; // table was dropped since last ANALYZE — skip it
+            return countRc;
+        }
 
-        if (countStmt.Step() != BE_SQLITE_ROW)
-            continue;
+        auto stepRc = countStmt.Step();
+        if (stepRc != BE_SQLITE_ROW)
+            return (stepRc == BE_SQLITE_DONE) ? BE_SQLITE_ERROR : stepRc;
 
         int64_t actualCount = countStmt.GetValueInt64(0);
 
@@ -6847,7 +6851,10 @@ DbResult Db::ReanalyzeIfStale(double threshold, ReanalyzeMode mode, bool* didAna
             rc = TryExecuteSql(SqlPrintfString("ANALYZE %w", table.c_str()));
             if (rc != BE_SQLITE_OK)
                 return rc;
+            if (didAnalyze)
+                *didAnalyze = true;
         }
+        return BE_SQLITE_OK;
     }
 
     if (didAnalyze)

--- a/iModelCore/BeSQLite/PublicAPI/BeSQLite/BeSQLite.h
+++ b/iModelCore/BeSQLite/PublicAPI/BeSQLite/BeSQLite.h
@@ -3342,6 +3342,29 @@ public:
     //! Run ANALYZE command to gather statistics about tables and indices.
     BE_SQLITE_EXPORT DbResult Analyze();
 
+    //! Controls the scope of reanalysis when stale tables are detected.
+    enum class ReanalyzeMode
+        {
+        Full,     //!< If any table is stale, run ANALYZE on the entire database.
+        PerTable, //!< Run ANALYZE only on the individual stale tables.
+        };
+
+    //! Check if query planner statistics are stale and, if so, recompute them.
+    //! Statistics are considered stale when a table's actual row count has diverged from
+    //! its recorded count in sqlite_stat1 by more than the given threshold ratio. If the
+    //! database has never been analyzed, a full ANALYZE is always performed regardless of mode.
+    //! @note This method does NOT clear any caches. If it returns didAnalyze=true, the caller
+    //!       is responsible for clearing statement caches or any higher-level caches as needed.
+    //! @param threshold The minimum fractional change in row count to trigger reanalysis
+    //!        (e.g., 0.3 means 30% change). Must be > 0.
+    //! @param mode Controls whether stale tables are reanalyzed individually or the entire
+    //!        database is reanalyzed when any staleness is detected.
+    //! @param[out] didAnalyze If non-null, set to true if ANALYZE was actually performed,
+    //!             false otherwise. When true the caller should clear relevant caches.
+    //! @return BE_SQLITE_OK if completed successfully (whether or not ANALYZE was run),
+    //!         or an error code if ANALYZE or a staleness query failed.
+    BE_SQLITE_EXPORT DbResult ReanalyzeIfStale(double threshold = 0.3, ReanalyzeMode mode = ReanalyzeMode::Full, bool* didAnalyze = nullptr);
+
     BE_SQLITE_EXPORT DbResult RestartDefaultTxn();
 
     //! DO NOT call this under normal circumstances. It is for obscure cases where you are opening an untrusted file (i.e. NOT from the hub).

--- a/iModelCore/BeSQLite/PublicAPI/BeSQLite/BeSQLite.h
+++ b/iModelCore/BeSQLite/PublicAPI/BeSQLite/BeSQLite.h
@@ -3359,7 +3359,8 @@ public:
     //!        (e.g., 0.3 means 30% change). Must be finite and > 0; returns BE_SQLITE_ERROR otherwise.
     //! @param mode Controls whether stale tables are reanalyzed individually or the entire
     //!        database is reanalyzed when any staleness is detected.
-    //! @param[out] didAnalyze If non-null, set to true if ANALYZE was actually performed,
+    //! @param[out] didAnalyze If non-null, set to true if at least one ANALYZE was performed
+    //!             (in PerTable mode, may be true even if a later table's ANALYZE fails),
     //!             false otherwise. When true the caller should clear relevant caches.
     //! @return BE_SQLITE_OK if completed successfully (whether or not ANALYZE was run),
     //!         or an error code if ANALYZE or a staleness query failed.

--- a/iModelCore/BeSQLite/PublicAPI/BeSQLite/BeSQLite.h
+++ b/iModelCore/BeSQLite/PublicAPI/BeSQLite/BeSQLite.h
@@ -3356,7 +3356,7 @@ public:
     //! @note This method does NOT clear any caches. If it returns didAnalyze=true, the caller
     //!       is responsible for clearing statement caches or any higher-level caches as needed.
     //! @param threshold The minimum fractional change in row count to trigger reanalysis
-    //!        (e.g., 0.3 means 30% change). Must be > 0.
+    //!        (e.g., 0.3 means 30% change). Must be finite and > 0; returns BE_SQLITE_ERROR otherwise.
     //! @param mode Controls whether stale tables are reanalyzed individually or the entire
     //!        database is reanalyzed when any staleness is detected.
     //! @param[out] didAnalyze If non-null, set to true if ANALYZE was actually performed,

--- a/iModelCore/BeSQLite/Tests/NonPublished/BeSQLite_Test.cpp
+++ b/iModelCore/BeSQLite/Tests/NonPublished/BeSQLite_Test.cpp
@@ -458,6 +458,166 @@ TEST_F(BeSQliteTestFixture, sqlite_stat1)
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //---------------------------------------------------------------------------------------
+TEST_F(BeSQliteTestFixture, ReanalyzeIfStale_NeverAnalyzed)
+    {
+    // When sqlite_stat1 has no rows (freshly created DB), ReanalyzeIfStale should run ANALYZE unconditionally.
+    auto db = Create("reanalyze_never.db");
+    ASSERT_TRUE(db != nullptr);
+    ASSERT_EQ(BE_SQLITE_OK, db->ExecuteSql("CREATE TABLE t1(id INTEGER PRIMARY KEY, a, b)"));
+    ASSERT_EQ(BE_SQLITE_OK, db->ExecuteSql("CREATE INDEX idx_t1_a ON t1(a)"));
+    for (int i = 0; i < 100; i++)
+        ASSERT_EQ(BE_SQLITE_OK, db->ExecuteSql(SqlPrintfString("INSERT INTO t1(a, b) VALUES(%d, %d)", i, i * 2)));
+
+    db->SaveChanges();
+
+    // sqlite_stat1 exists (created during CreateNewDb) but is empty
+    ASSERT_EQ(0, GetRowCount(*db, "sqlite_stat1"));
+
+    ASSERT_EQ(BE_SQLITE_OK, db->ReanalyzeIfStale(0.3));
+
+    // After ReanalyzeIfStale, sqlite_stat1 should have rows
+    ASSERT_NE(0, GetRowCount(*db, "sqlite_stat1"));
+    }
+
+//---------------------------------------------------------------------------------------
+// @bsimethod
+//---------------------------------------------------------------------------------------
+TEST_F(BeSQliteTestFixture, ReanalyzeIfStale_NotStale)
+    {
+    // When stats are current, ReanalyzeIfStale should not re-run ANALYZE.
+    auto db = Create("reanalyze_fresh.db");
+    ASSERT_TRUE(db != nullptr);
+    ASSERT_EQ(BE_SQLITE_OK, db->ExecuteSql("CREATE TABLE t1(id INTEGER PRIMARY KEY, a, b)"));
+    ASSERT_EQ(BE_SQLITE_OK, db->ExecuteSql("CREATE INDEX idx_t1_a ON t1(a)"));
+    for (int i = 0; i < 100; i++)
+        ASSERT_EQ(BE_SQLITE_OK, db->ExecuteSql(SqlPrintfString("INSERT INTO t1(a, b) VALUES(%d, %d)", i, i * 2)));
+
+    db->SaveChanges();
+    ASSERT_EQ(BE_SQLITE_OK, db->Analyze());
+
+    // Record the stat content before
+    Statement stmt;
+    ASSERT_EQ(BE_SQLITE_OK, stmt.Prepare(*db, "SELECT stat FROM sqlite_stat1 WHERE tbl='t1' LIMIT 1"));
+    ASSERT_EQ(BE_SQLITE_ROW, stmt.Step());
+    Utf8String statBefore = stmt.GetValueText(0);
+    stmt.Finalize();
+
+    // Add only a few rows (well under 30% threshold)
+    for (int i = 100; i < 105; i++)
+        ASSERT_EQ(BE_SQLITE_OK, db->ExecuteSql(SqlPrintfString("INSERT INTO t1(a, b) VALUES(%d, %d)", i, i * 2)));
+    db->SaveChanges();
+
+    ASSERT_EQ(BE_SQLITE_OK, db->ReanalyzeIfStale(0.3));
+
+    // Stats should remain unchanged since 5% change < 30% threshold
+    ASSERT_EQ(BE_SQLITE_OK, stmt.Prepare(*db, "SELECT stat FROM sqlite_stat1 WHERE tbl='t1' LIMIT 1"));
+    ASSERT_EQ(BE_SQLITE_ROW, stmt.Step());
+    Utf8String statAfter = stmt.GetValueText(0);
+    stmt.Finalize();
+    ASSERT_TRUE(statBefore.Equals(statAfter));
+    }
+
+//---------------------------------------------------------------------------------------
+// @bsimethod
+//---------------------------------------------------------------------------------------
+TEST_F(BeSQliteTestFixture, ReanalyzeIfStale_Stale)
+    {
+    // When stats are stale, ReanalyzeIfStale should re-run ANALYZE and update stats.
+    auto db = Create("reanalyze_stale.db");
+    ASSERT_TRUE(db != nullptr);
+    ASSERT_EQ(BE_SQLITE_OK, db->ExecuteSql("CREATE TABLE t1(id INTEGER PRIMARY KEY, a, b)"));
+    ASSERT_EQ(BE_SQLITE_OK, db->ExecuteSql("CREATE INDEX idx_t1_a ON t1(a)"));
+    for (int i = 0; i < 100; i++)
+        ASSERT_EQ(BE_SQLITE_OK, db->ExecuteSql(SqlPrintfString("INSERT INTO t1(a, b) VALUES(%d, %d)", i, i * 2)));
+
+    db->SaveChanges();
+    ASSERT_EQ(BE_SQLITE_OK, db->Analyze());
+
+    int statRowsBefore = GetRowCount(*db, "sqlite_stat1");
+    ASSERT_NE(0, statRowsBefore);
+
+    // Record the stat content before
+    Statement stmt;
+    ASSERT_EQ(BE_SQLITE_OK, stmt.Prepare(*db, "SELECT stat FROM sqlite_stat1 WHERE tbl='t1' LIMIT 1"));
+    ASSERT_EQ(BE_SQLITE_ROW, stmt.Step());
+    Utf8String statBefore = stmt.GetValueText(0);
+    stmt.Finalize();
+
+    // Double the rows - 100% increase well above 30% threshold
+    for (int i = 100; i < 300; i++)
+        ASSERT_EQ(BE_SQLITE_OK, db->ExecuteSql(SqlPrintfString("INSERT INTO t1(a, b) VALUES(%d, %d)", i, i * 2)));
+    db->SaveChanges();
+
+    ASSERT_EQ(BE_SQLITE_OK, db->ReanalyzeIfStale(0.3));
+
+    // Stats should have been updated
+    ASSERT_EQ(BE_SQLITE_OK, stmt.Prepare(*db, "SELECT stat FROM sqlite_stat1 WHERE tbl='t1' LIMIT 1"));
+    ASSERT_EQ(BE_SQLITE_ROW, stmt.Step());
+    Utf8String statAfter = stmt.GetValueText(0);
+    stmt.Finalize();
+    ASSERT_FALSE(statBefore.Equals(statAfter)) << "Stats should have been updated after adding 200% more rows";
+    }
+
+//---------------------------------------------------------------------------------------
+// @bsimethod
+//---------------------------------------------------------------------------------------
+TEST_F(BeSQliteTestFixture, ReanalyzeIfStale_PerTable)
+    {
+    // In PerTable mode, only the stale table should be reanalyzed, not the fresh one.
+    auto db = Create("reanalyze_pertable.db");
+    ASSERT_TRUE(db != nullptr);
+    ASSERT_EQ(BE_SQLITE_OK, db->ExecuteSql("CREATE TABLE t1(id INTEGER PRIMARY KEY, a, b)"));
+    ASSERT_EQ(BE_SQLITE_OK, db->ExecuteSql("CREATE TABLE t2(id INTEGER PRIMARY KEY, x, y)"));
+    ASSERT_EQ(BE_SQLITE_OK, db->ExecuteSql("CREATE INDEX idx_t1_a ON t1(a)"));
+    ASSERT_EQ(BE_SQLITE_OK, db->ExecuteSql("CREATE INDEX idx_t2_x ON t2(x)"));
+
+    for (int i = 0; i < 100; i++)
+        {
+        ASSERT_EQ(BE_SQLITE_OK, db->ExecuteSql(SqlPrintfString("INSERT INTO t1(a, b) VALUES(%d, %d)", i, i * 2)));
+        ASSERT_EQ(BE_SQLITE_OK, db->ExecuteSql(SqlPrintfString("INSERT INTO t2(x, y) VALUES(%d, %d)", i, i * 3)));
+        }
+
+    db->SaveChanges();
+    ASSERT_EQ(BE_SQLITE_OK, db->Analyze());
+
+    // Record t2 stat before (t2 won't change)
+    Statement stmt;
+    ASSERT_EQ(BE_SQLITE_OK, stmt.Prepare(*db, "SELECT stat FROM sqlite_stat1 WHERE tbl='t2' AND idx='idx_t2_x'"));
+    ASSERT_EQ(BE_SQLITE_ROW, stmt.Step());
+    Utf8String t2StatBefore = stmt.GetValueText(0);
+    stmt.Finalize();
+
+    // Record t1 stat before
+    ASSERT_EQ(BE_SQLITE_OK, stmt.Prepare(*db, "SELECT stat FROM sqlite_stat1 WHERE tbl='t1' AND idx='idx_t1_a'"));
+    ASSERT_EQ(BE_SQLITE_ROW, stmt.Step());
+    Utf8String t1StatBefore = stmt.GetValueText(0);
+    stmt.Finalize();
+
+    // Make t1 stale (double its rows) but leave t2 unchanged
+    for (int i = 100; i < 300; i++)
+        ASSERT_EQ(BE_SQLITE_OK, db->ExecuteSql(SqlPrintfString("INSERT INTO t1(a, b) VALUES(%d, %d)", i, i * 2)));
+    db->SaveChanges();
+
+    ASSERT_EQ(BE_SQLITE_OK, db->ReanalyzeIfStale(0.3, Db::ReanalyzeMode::PerTable));
+
+    // t1 stats should have been updated
+    ASSERT_EQ(BE_SQLITE_OK, stmt.Prepare(*db, "SELECT stat FROM sqlite_stat1 WHERE tbl='t1' AND idx='idx_t1_a'"));
+    ASSERT_EQ(BE_SQLITE_ROW, stmt.Step());
+    Utf8String t1StatAfter = stmt.GetValueText(0);
+    stmt.Finalize();
+    ASSERT_FALSE(t1StatBefore.Equals(t1StatAfter)) << "t1 stats should have been updated";
+
+    // t2 stats should remain unchanged since it was not stale
+    ASSERT_EQ(BE_SQLITE_OK, stmt.Prepare(*db, "SELECT stat FROM sqlite_stat1 WHERE tbl='t2' AND idx='idx_t2_x'"));
+    ASSERT_EQ(BE_SQLITE_ROW, stmt.Step());
+    Utf8String t2StatAfter = stmt.GetValueText(0);
+    stmt.Finalize();
+    ASSERT_TRUE(t2StatBefore.Equals(t2StatAfter)) << "t2 stats should NOT have been updated";
+    }
+
+//---------------------------------------------------------------------------------------
+// @bsimethod
+//---------------------------------------------------------------------------------------
 TEST_F(BeSQliteTestFixture, variable_limit)
     {
     auto db1 = Create("first.db");

--- a/iModelCore/BeSQLite/Tests/NonPublished/BeSQLite_Test.cpp
+++ b/iModelCore/BeSQLite/Tests/NonPublished/BeSQLite_Test.cpp
@@ -473,7 +473,9 @@ TEST_F(BeSQliteTestFixture, ReanalyzeIfStale_NeverAnalyzed)
     // sqlite_stat1 exists (created during CreateNewDb) but is empty
     ASSERT_EQ(0, GetRowCount(*db, "sqlite_stat1"));
 
-    ASSERT_EQ(BE_SQLITE_OK, db->ReanalyzeIfStale(0.3));
+    bool didAnalyze = false;
+    ASSERT_EQ(BE_SQLITE_OK, db->ReanalyzeIfStale(0.3, Db::ReanalyzeMode::Full, &didAnalyze));
+    ASSERT_TRUE(didAnalyze) << "didAnalyze should be true when DB had never been analyzed";
 
     // After ReanalyzeIfStale, sqlite_stat1 should have rows
     ASSERT_NE(0, GetRowCount(*db, "sqlite_stat1"));
@@ -507,9 +509,10 @@ TEST_F(BeSQliteTestFixture, ReanalyzeIfStale_NotStale)
         ASSERT_EQ(BE_SQLITE_OK, db->ExecuteSql(SqlPrintfString("INSERT INTO t1(a, b) VALUES(%d, %d)", i, i * 2)));
     db->SaveChanges();
 
-    ASSERT_EQ(BE_SQLITE_OK, db->ReanalyzeIfStale(0.3));
-
     // Stats should remain unchanged since 5% change < 30% threshold
+    bool didAnalyze = true; // start true to confirm it gets set false
+    ASSERT_EQ(BE_SQLITE_OK, db->ReanalyzeIfStale(0.3, Db::ReanalyzeMode::Full, &didAnalyze));
+    ASSERT_FALSE(didAnalyze) << "didAnalyze should be false when stats are not stale";
     ASSERT_EQ(BE_SQLITE_OK, stmt.Prepare(*db, "SELECT stat FROM sqlite_stat1 WHERE tbl='t1' LIMIT 1"));
     ASSERT_EQ(BE_SQLITE_ROW, stmt.Step());
     Utf8String statAfter = stmt.GetValueText(0);
@@ -548,7 +551,9 @@ TEST_F(BeSQliteTestFixture, ReanalyzeIfStale_Stale)
         ASSERT_EQ(BE_SQLITE_OK, db->ExecuteSql(SqlPrintfString("INSERT INTO t1(a, b) VALUES(%d, %d)", i, i * 2)));
     db->SaveChanges();
 
-    ASSERT_EQ(BE_SQLITE_OK, db->ReanalyzeIfStale(0.3));
+    bool didAnalyze = false;
+    ASSERT_EQ(BE_SQLITE_OK, db->ReanalyzeIfStale(0.3, Db::ReanalyzeMode::Full, &didAnalyze));
+    ASSERT_TRUE(didAnalyze) << "didAnalyze should be true when stats are stale";
 
     // Stats should have been updated
     ASSERT_EQ(BE_SQLITE_OK, stmt.Prepare(*db, "SELECT stat FROM sqlite_stat1 WHERE tbl='t1' LIMIT 1"));
@@ -598,7 +603,9 @@ TEST_F(BeSQliteTestFixture, ReanalyzeIfStale_PerTable)
         ASSERT_EQ(BE_SQLITE_OK, db->ExecuteSql(SqlPrintfString("INSERT INTO t1(a, b) VALUES(%d, %d)", i, i * 2)));
     db->SaveChanges();
 
-    ASSERT_EQ(BE_SQLITE_OK, db->ReanalyzeIfStale(0.3, Db::ReanalyzeMode::PerTable));
+    bool didAnalyze = false;
+    ASSERT_EQ(BE_SQLITE_OK, db->ReanalyzeIfStale(0.3, Db::ReanalyzeMode::PerTable, &didAnalyze));
+    ASSERT_TRUE(didAnalyze) << "didAnalyze should be true when stats are stale";
 
     // t1 stats should have been updated
     ASSERT_EQ(BE_SQLITE_OK, stmt.Prepare(*db, "SELECT stat FROM sqlite_stat1 WHERE tbl='t1' AND idx='idx_t1_a'"));

--- a/iModelJsNodeAddon/IModelJsNative.cpp
+++ b/iModelJsNodeAddon/IModelJsNative.cpp
@@ -352,6 +352,26 @@ template<typename T_Db> struct SQLiteOps {
             JsInterop::throwSqlResult("error analyzing", db.GetDbFileName(), status);
     }
 
+    Napi::Value ReanalyzeIfStale(NapiInfoCR info) {
+        Db& db = GetOpenedDb(info);
+        double threshold = 0.3;
+        Db::ReanalyzeMode mode = Db::ReanalyzeMode::Full;
+        if (info[0].IsObject()) {
+            auto opts = info[0].As<Napi::Object>();
+            auto threshMember = opts.Get("threshold");
+            if (threshMember.IsNumber())
+                threshold = threshMember.ToNumber().DoubleValue();
+            auto modeStr = stringMember(opts, "mode", "full");
+            if (modeStr.EqualsI("perTable"))
+                mode = Db::ReanalyzeMode::PerTable;
+        }
+        bool didAnalyze = false;
+        auto status = db.ReanalyzeIfStale(threshold, mode, &didAnalyze);
+        if (status != BE_SQLITE_OK)
+            JsInterop::throwSqlResult("error in reanalyzeIfStale", db.GetDbFileName(), status);
+        return Napi::Boolean::New(info.Env(), didAnalyze);
+    }
+
     void EnableWalMode(Napi::CallbackInfo const& info) {
         Db& db = GetOpenedDb(info);
         OPTIONAL_ARGUMENT_BOOL(0, yesNo, true);
@@ -823,6 +843,7 @@ public:
             InstanceMethod("saveFileProperty", &SQLiteDb::SaveFileProperty),
             InstanceMethod("vacuum", &SQLiteDb::Vacuum),
             InstanceMethod("analyze", &SQLiteDb::Analyze),
+            InstanceMethod("reanalyzeIfStale", &SQLiteDb::ReanalyzeIfStale),
             InstanceMethod("enableWalMode", &SQLiteDb::EnableWalMode),
             InstanceMethod("performCheckpoint", &SQLiteDb::PerformCheckpoint),
             InstanceMethod("setAutoCheckpointThreshold", &SQLiteDb::SetAutoCheckpointThreshold),
@@ -3301,6 +3322,7 @@ struct NativeDgnDb : BeObjectWrap<NativeDgnDb>, SQLiteOps<DgnDb>
             InstanceMethod("writeFullElementDependencyGraphToFile", &NativeDgnDb::WriteFullElementDependencyGraphToFile),
             InstanceMethod("vacuum", &NativeDgnDb::Vacuum),
             InstanceMethod("analyze", &NativeDgnDb::Analyze),
+            InstanceMethod("reanalyzeIfStale", &NativeDgnDb::ReanalyzeIfStale),
             InstanceMethod("enableWalMode", &NativeDgnDb::EnableWalMode),
             InstanceMethod("performCheckpoint", &NativeDgnDb::PerformCheckpoint),
             InstanceMethod("enableChangesetStatsTracking", &NativeDgnDb::EnableChangesetStatsTracking),

--- a/iModelJsNodeAddon/IModelJsNative.cpp
+++ b/iModelJsNodeAddon/IModelJsNative.cpp
@@ -18,6 +18,7 @@
 #include "presentation/UpdateRecordsHandler.h"
 #include <BeSQLite/Profiler.h>
 #include <folly/BeFolly.h>
+#include <cmath>
 #include "SchemaUtil.h"
 #include "JsLogger.h"
 
@@ -359,8 +360,11 @@ template<typename T_Db> struct SQLiteOps {
         if (info[0].IsObject()) {
             auto opts = info[0].As<Napi::Object>();
             auto threshMember = opts.Get("threshold");
-            if (threshMember.IsNumber())
+            if (threshMember.IsNumber()) {
                 threshold = threshMember.ToNumber().DoubleValue();
+                if (!std::isfinite(threshold) || threshold <= 0.0)
+                    THROW_JS_IMODEL_NATIVE_EXCEPTION(info.Env(), "threshold must be finite and > 0", IModelJsNativeErrorKey::BadArg);
+            }
             auto modeStr = stringMember(opts, "mode", "full");
             if (modeStr.EqualsI("perTable"))
                 mode = Db::ReanalyzeMode::PerTable;

--- a/iModelJsNodeAddon/api_package/ts/src/NativeLibrary.ts
+++ b/iModelJsNodeAddon/api_package/ts/src/NativeLibrary.ts
@@ -471,6 +471,10 @@ export declare namespace IModelJsNative {
     saveFileProperty(props: FilePropertyProps, strValue: string | undefined, blobVal: Uint8Array | undefined): void;
     vacuum(arg?: { pageSize?: number, into?: LocalFileName }): void;
     analyze(): void;
+    /** Check if query planner statistics are stale and recompute them if needed.
+     * @returns true if ANALYZE was performed and caches should be cleared, false otherwise.
+     */
+    reanalyzeIfStale(arg?: { threshold?: number, mode?: "full" | "perTable" }): boolean;
     enableWalMode(yesNo?: boolean): void;
     /** perform a checkpoint if this db is in WAL mode. Otherwise this function does nothing.
      * @param mode the checkpoint mode. Default is `Truncate`.
@@ -791,6 +795,10 @@ export declare namespace IModelJsNative {
     public writeFullElementDependencyGraphToFile(dotFileName: string): BentleyStatus;
     public vacuum(arg?: { pageSize?: number, into?: LocalFileName }): void;
     public analyze(): void;
+    /** Check if query planner statistics are stale and recompute them if needed.
+     * @returns true if ANALYZE was performed and caches should be cleared, false otherwise.
+     */
+    public reanalyzeIfStale(arg?: { threshold?: number, mode?: "full" | "perTable" }): boolean;
     public enableWalMode(yesNo?: boolean): void;
     public performCheckpoint(mode?: WalCheckpointMode): void;
     public setAutoCheckpointThreshold(frames: number): void;
@@ -1055,6 +1063,10 @@ export declare namespace IModelJsNative {
     public saveFileProperty(props: FilePropertyProps, strValue: string | undefined, blobVal?: Uint8Array): void;
     public vacuum(arg?: { pageSize?: number, into?: LocalFileName }): void;
     public analyze(): void;
+    /** Check if query planner statistics are stale and recompute them if needed.
+     * @returns true if ANALYZE was performed and caches should be cleared, false otherwise.
+     */
+    public reanalyzeIfStale(arg?: { threshold?: number, mode?: "full" | "perTable" }): boolean;
     public enableWalMode(yesNo?: boolean): void;
     public performCheckpoint(mode?: WalCheckpointMode): void;
     public setAutoCheckpointThreshold(frames: number): void;


### PR DESCRIPTION
## Summary

Adds `Db::ReanalyzeIfStale()` which checks if SQLite query planner statistics (`sqlite_stat1`) have become stale relative to actual table row counts and recomputes them if needed.

### Features
- **Staleness detection**: Compares recorded row counts in `sqlite_stat1` against actual `count(*)` for each table. A configurable threshold (default 30%) determines when stats are considered stale.
- **Two modes**:
  - `ReanalyzeMode::Full` — breaks on first stale table and runs full `ANALYZE` on the entire database.
  - `ReanalyzeMode::PerTable` — collects all stale tables and runs `ANALYZE` on each individually.
- **Cache invalidation signal**: Returns a `bool` (`didAnalyze`) indicating whether `ANALYZE` was performed, so the caller can clear statement caches or other higher-level caches as needed. No internal cache clearing is done.
- **Edge cases handled**: Fresh databases where `sqlite_stat1` exists but is empty, missing `sqlite_stat1` table, dropped tables.

### N-API / TypeScript
Exposed via `reanalyzeIfStale(arg?: { threshold?: number, mode?: "full" | "perTable" }): boolean` on both `NativeDgnDb` and `NativeSQLiteDb`.

### Tests
4 unit tests covering: never-analyzed DB, not-stale DB, stale (full mode), and stale (per-table mode).