### PR TITLE
Add imodel_geom_stream virtual table for GeometryStream decomposition

### DIFF
--- a/iModelCore/ECDb/ECDb/SchemaManagerDispatcher.cpp
+++ b/iModelCore/ECDb/ECDb/SchemaManagerDispatcher.cpp
@@ -76,7 +76,7 @@ BentleyStatus VirtualSchemaManager::AddAndValidateVirtualSchema(Utf8StringCR sch
     }
     if (validate) {
         Utf8String err;
-        if (IsValidVirtualSchema(*schema, err)) {
+        if (!IsValidVirtualSchema(*schema, err)) {
             // log err
             return ERROR;
         }
@@ -202,7 +202,7 @@ bool VirtualSchemaManager::IsValidVirtualSchema(ECN::ECSchemaR schema, Utf8Strin
             err = "only abstract entity classes are allowed in virtual schema";
             return false;
         }
-        if (schemaClass->IsDefinedLocal("ECDbVirtual", "VirtualType")) {
+        if (!schemaClass->IsDefinedLocal("ECDbVirtual", "VirtualType")) {
             err = "entity classes must have ECDbVirtual::VirtualType customattribute";
             return false;
         }

--- a/iModelCore/iModelPlatform/DgnCore/DgnSqlFuncs.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/DgnSqlFuncs.cpp
@@ -880,7 +880,7 @@ struct iModel_geom_json : ScalarFunction
                 { ctx.SetResultNull(); return; }
 
             Utf8String jsonStr;
-            if (!BentleyGeometry::IModelJson::TryGeometryToIModelJsonString(jsonStr, *igeom))
+            if (!IModelJson::TryGeometryToIModelJsonString(jsonStr, *igeom))
                 { ctx.SetResultNull(); return; }
 
             ctx.SetResultText(jsonStr.c_str(), (int)jsonStr.size(), Context::CopyData::Yes);

--- a/iModelCore/iModelPlatform/DgnCore/DgnSqlFuncs.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/DgnSqlFuncs.cpp
@@ -4,6 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 #include "DgnPlatformInternal.h"
 #include "GeomStreamVTab.h"
+#include <GeomSerialization/GeomLibsJsonSerialization.h>
 
 BEGIN_UNNAMED_NAMESPACE
 
@@ -760,7 +761,335 @@ struct iModel_point_value : ScalarFunction
 };
 
 //=======================================================================================
+// Helper: decompress a raw GeometryStream blob (header + Snappy data) into opcodes.
+// Returns true and fills 'out' on success; returns false if blob is NULL/corrupt.
+//=======================================================================================
+static bool DecompressGeomStream(void const* blob, int blobBytes, bvector<uint8_t>& out)
+    {
+    if (nullptr == blob || blobBytes < 8)
+        return false;
+
+    SnappyFromMemory& snappy = SnappyFromMemory::GetForThread();
+    snappy.Init(const_cast<void*>(blob), static_cast<uint32_t>(blobBytes));
+
+    struct GeomBlobHeader { uint32_t m_signature; uint32_t m_size; };
+    GeomBlobHeader header;
+    uint32_t nRead = 0;
+    if (ZIP_SUCCESS != snappy._Read(reinterpret_cast<Byte*>(&header), sizeof(header), nRead) || nRead != sizeof(header))
+        return false;
+
+    if (0x0600 != header.m_signature || 0 == header.m_size)
+        return false;
+
+    out.resize(header.m_size);
+    if (ZIP_SUCCESS != snappy._Read(out.data(), header.m_size, nRead) || nRead != header.m_size)
+        {
+        out.clear();
+        return false;
+        }
+    return true;
+    }
+
+//=======================================================================================
+// Helper: walk decompressed opcode bytes, calling visitor for each opcode.
+// Visitor signature: bool (uint32_t opCode, uint8_t const* data, uint32_t dataSize)
+// Return false from visitor to stop early.
+//=======================================================================================
+template<typename TVisitor>
+static void WalkOpcodes(uint8_t const* data, size_t dataSize, TVisitor&& visitor)
+    {
+    size_t offset = 0;
+    while (offset + 8 <= dataSize)
+        {
+        uint32_t opCode   = *reinterpret_cast<uint32_t const*>(data + offset);
+        uint32_t paySize  = *reinterpret_cast<uint32_t const*>(data + offset + sizeof(uint32_t));
+        if (offset + 8 + paySize > dataSize)
+            break;
+        uint8_t const* payload = (0 != paySize) ? (data + offset + 8) : nullptr;
+        if (!visitor(opCode, payload, paySize))
+            break;
+        offset += 8 + paySize;
+        }
+    }
+
+//=======================================================================================
+//! imodel_geom_json(blob) — Decode a GeometryBlob value (from imodel_geom_stream) into
+//! iModel.js-compatible geometry JSON. BRep entries return NULL.
+//! The input blob is [4-byte opcode uint32][flatbuffer payload].
 // @bsiclass
+//=======================================================================================
+struct iModel_geom_json : ScalarFunction
+    {
+    DgnDbP m_db;
+    explicit iModel_geom_json(Utf8CP name, DgnDbP db) : ScalarFunction(name, 1, DbValueType::TextVal), m_db(db) {}
+
+    void _ComputeScalar(Context& ctx, int nArgs, DbValue* args) override
+        {
+        try
+            {
+            if (args[0].IsNull())
+                { ctx.SetResultNull(); return; }
+
+            int blobSize = args[0].GetValueBytes();
+            if (blobSize <= (int)sizeof(uint32_t))
+                { ctx.SetResultNull(); return; }
+
+            uint8_t const* blobData = reinterpret_cast<uint8_t const*>(args[0].GetValueBlob());
+            uint32_t opCode = *reinterpret_cast<uint32_t const*>(blobData);
+
+            // BRep → NULL
+            if (opCode == static_cast<uint32_t>(GeometryStreamIO::OpCode::ParasolidBRep))
+                { ctx.SetResultNull(); return; }
+
+            uint8_t const* flatData = blobData + sizeof(uint32_t);
+            uint32_t flatSize = static_cast<uint32_t>(blobSize) - static_cast<uint32_t>(sizeof(uint32_t));
+
+            GeometryStreamIO::Operation op(static_cast<GeometryStreamIO::OpCode>(opCode), flatSize, flatData);
+
+            if (nullptr == m_db)
+                { ctx.SetResultNull(); return; }
+
+            GeometryStreamIO::Reader reader(*m_db);
+            GeometricPrimitivePtr geomPrim;
+            if (!reader.Get(op, geomPrim))
+                { ctx.SetResultNull(); return; }
+
+            IGeometryPtr igeom;
+            switch (geomPrim->GetGeometryType())
+                {
+                case GeometricPrimitive::GeometryType::CurvePrimitive:
+                    igeom = IGeometry::Create(geomPrim->GetAsICurvePrimitive());
+                    break;
+                case GeometricPrimitive::GeometryType::CurveVector:
+                    igeom = IGeometry::Create(geomPrim->GetAsCurveVector());
+                    break;
+                case GeometricPrimitive::GeometryType::SolidPrimitive:
+                    igeom = IGeometry::Create(geomPrim->GetAsISolidPrimitive());
+                    break;
+                case GeometricPrimitive::GeometryType::BsplineSurface:
+                    igeom = IGeometry::Create(geomPrim->GetAsMSBsplineSurface());
+                    break;
+                case GeometricPrimitive::GeometryType::Polyface:
+                    igeom = IGeometry::Create(geomPrim->GetAsPolyfaceHeader());
+                    break;
+                default:
+                    break;
+                }
+
+            if (!igeom.IsValid())
+                { ctx.SetResultNull(); return; }
+
+            Utf8String jsonStr;
+            if (!BentleyGeometry::IModelJson::TryGeometryToIModelJsonString(jsonStr, *igeom))
+                { ctx.SetResultNull(); return; }
+
+            ctx.SetResultText(jsonStr.c_str(), (int)jsonStr.size(), Context::CopyData::Yes);
+            }
+        catch (...)
+            {
+            ctx.SetResultNull();
+            }
+        }
+    };
+
+//=======================================================================================
+//! imodel_geom_text(blob) — Extract all TextString content from a raw GeometryStream blob.
+//! Multiple text entries are joined with newline. Returns NULL if none found.
+// @bsiclass
+//=======================================================================================
+struct iModel_geom_text : ScalarFunction
+    {
+    DgnDbP m_db;
+    explicit iModel_geom_text(Utf8CP name, DgnDbP db) : ScalarFunction(name, 1, DbValueType::TextVal), m_db(db) {}
+
+    void _ComputeScalar(Context& ctx, int nArgs, DbValue* args) override
+        {
+        try
+            {
+            if (args[0].IsNull() || nullptr == m_db)
+                { ctx.SetResultNull(); return; }
+
+            bvector<uint8_t> decompressed;
+            if (!DecompressGeomStream(args[0].GetValueBlob(), args[0].GetValueBytes(), decompressed))
+                { ctx.SetResultNull(); return; }
+
+            Utf8String allText;
+            GeometryStreamIO::Reader reader(*m_db);
+
+            WalkOpcodes(decompressed.data(), decompressed.size(),
+                [&](uint32_t opCode, uint8_t const* payload, uint32_t paySize) -> bool
+                    {
+                    if (opCode != static_cast<uint32_t>(GeometryStreamIO::OpCode::TextString))
+                        return true;
+                    if (nullptr == payload || 0 == paySize)
+                        return true;
+                    GeometryStreamIO::Operation op(GeometryStreamIO::OpCode::TextString, paySize, payload);
+                    TextStringPtr text = TextString::Create(*m_db);
+                    if (reader.Get(op, *text))
+                        {
+                        if (!allText.empty())
+                            allText += '\n';
+                        allText += text->GetText();
+                        }
+                    return true;
+                    });
+
+            if (allText.empty())
+                ctx.SetResultNull();
+            else
+                ctx.SetResultText(allText.c_str(), (int)allText.size(), Context::CopyData::Yes);
+            }
+        catch (...)
+            {
+            ctx.SetResultNull();
+            }
+        }
+    };
+
+//=======================================================================================
+//! imodel_geom_entry_count(blob) — Count geometric entries (IsGeometry=1) in a raw
+//! GeometryStream blob without full geometry deserialization. Returns NULL on failure.
+// @bsiclass
+//=======================================================================================
+struct iModel_geom_entry_count : ScalarFunction
+    {
+    explicit iModel_geom_entry_count(Utf8CP name) : ScalarFunction(name, 1, DbValueType::IntegerVal) {}
+
+    void _ComputeScalar(Context& ctx, int nArgs, DbValue* args) override
+        {
+        try
+            {
+            if (args[0].IsNull())
+                { ctx.SetResultNull(); return; }
+
+            bvector<uint8_t> decompressed;
+            if (!DecompressGeomStream(args[0].GetValueBlob(), args[0].GetValueBytes(), decompressed))
+                { ctx.SetResultNull(); return; }
+
+            int count = 0;
+            WalkOpcodes(decompressed.data(), decompressed.size(),
+                [&](uint32_t opCode, uint8_t const* /*payload*/, uint32_t /*paySize*/) -> bool
+                    {
+                    GeometryStreamIO::Operation op(static_cast<GeometryStreamIO::OpCode>(opCode), 0, nullptr);
+                    if (op.IsGeometryOp())
+                        ++count;
+                    return true;
+                    });
+
+            ctx.SetResultInt(count);
+            }
+        catch (...)
+            {
+            ctx.SetResultNull();
+            }
+        }
+    };
+
+//=======================================================================================
+//! imodel_geom_part_ids(blob) — Return a JSON array of all GeometryPartId references
+//! (as hex strings) in a raw GeometryStream blob. Returns NULL if none found.
+// @bsiclass
+//=======================================================================================
+struct iModel_geom_part_ids : ScalarFunction
+    {
+    DgnDbP m_db;
+    explicit iModel_geom_part_ids(Utf8CP name, DgnDbP db) : ScalarFunction(name, 1, DbValueType::TextVal), m_db(db) {}
+
+    void _ComputeScalar(Context& ctx, int nArgs, DbValue* args) override
+        {
+        try
+            {
+            if (args[0].IsNull() || nullptr == m_db)
+                { ctx.SetResultNull(); return; }
+
+            bvector<uint8_t> decompressed;
+            if (!DecompressGeomStream(args[0].GetValueBlob(), args[0].GetValueBytes(), decompressed))
+                { ctx.SetResultNull(); return; }
+
+            GeometryStreamIO::Reader reader(*m_db);
+            bvector<DgnGeometryPartId> partIds;
+
+            WalkOpcodes(decompressed.data(), decompressed.size(),
+                [&](uint32_t opCode, uint8_t const* payload, uint32_t paySize) -> bool
+                    {
+                    if (opCode != static_cast<uint32_t>(GeometryStreamIO::OpCode::GeometryPartInstance))
+                        return true;
+                    if (nullptr == payload || 0 == paySize)
+                        return true;
+                    GeometryStreamIO::Operation op(GeometryStreamIO::OpCode::GeometryPartInstance, paySize, payload);
+                    DgnGeometryPartId partId;
+                    Transform xform;
+                    if (reader.Get(op, partId, xform) && partId.IsValid())
+                        partIds.push_back(partId);
+                    return true;
+                    });
+
+            if (partIds.empty())
+                { ctx.SetResultNull(); return; }
+
+            // Build JSON array: ["0x1a","0x3f",...]
+            Utf8String json = "[";
+            for (size_t i = 0; i < partIds.size(); ++i)
+                {
+                if (i > 0)
+                    json += ",";
+                json += "\"";
+                json += partIds[i].ToHexStr();
+                json += "\"";
+                }
+            json += "]";
+            ctx.SetResultText(json.c_str(), (int)json.size(), Context::CopyData::Yes);
+            }
+        catch (...)
+            {
+            ctx.SetResultNull();
+            }
+        }
+    };
+
+//=======================================================================================
+//! imodel_geom_has_brep(blob) — Return 1 if the GeometryStream contains any BRep
+//! (Parasolid) geometry, 0 otherwise. Returns NULL on failure.
+// @bsiclass
+//=======================================================================================
+struct iModel_geom_has_brep : ScalarFunction
+    {
+    explicit iModel_geom_has_brep(Utf8CP name) : ScalarFunction(name, 1, DbValueType::IntegerVal) {}
+
+    void _ComputeScalar(Context& ctx, int nArgs, DbValue* args) override
+        {
+        try
+            {
+            if (args[0].IsNull())
+                { ctx.SetResultNull(); return; }
+
+            bvector<uint8_t> decompressed;
+            if (!DecompressGeomStream(args[0].GetValueBlob(), args[0].GetValueBytes(), decompressed))
+                { ctx.SetResultNull(); return; }
+
+            bool hasBrep = false;
+            WalkOpcodes(decompressed.data(), decompressed.size(),
+                [&](uint32_t opCode, uint8_t const* /*payload*/, uint32_t /*paySize*/) -> bool
+                    {
+                    if (opCode == static_cast<uint32_t>(GeometryStreamIO::OpCode::ParasolidBRep))
+                        {
+                        hasBrep = true;
+                        return false; // stop early
+                        }
+                    return true;
+                    });
+
+            ctx.SetResultInt(hasBrep ? 1 : 0);
+            }
+        catch (...)
+            {
+            ctx.SetResultNull();
+            }
+        }
+    };
+
+//=======================================================================================
+//! @bsiclass
 //=======================================================================================
 #ifdef DOCUMENTATION_GENERATOR
 /**
@@ -850,6 +1179,13 @@ void BisCoreDomain::_OnDgnDbOpened(DgnDbR db) const
 
     for (RTreeMatchFunction* func : s_matchFuncs)
         db.AddRTreeMatchFunction(*func);
+
+    // Register imodel_geom_* scalar functions
+    db.AddFunction(*(new iModel_geom_json("imodel_geom_json", &db)));
+    db.AddFunction(*(new iModel_geom_text("imodel_geom_text", &db)));
+    db.AddFunction(*(new iModel_geom_entry_count("imodel_geom_entry_count")));
+    db.AddFunction(*(new iModel_geom_part_ids("imodel_geom_part_ids", &db)));
+    db.AddFunction(*(new iModel_geom_has_brep("imodel_geom_has_brep")));
 
     // Register GeometryStream virtual table module
     (new GeomStreamModule(db))->Register();

--- a/iModelCore/iModelPlatform/DgnCore/DgnSqlFuncs.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/DgnSqlFuncs.cpp
@@ -3,6 +3,7 @@
 * See LICENSE.md in the repository root for full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 #include "DgnPlatformInternal.h"
+#include "GeomStreamVTab.h"
 
 BEGIN_UNNAMED_NAMESPACE
 
@@ -849,6 +850,9 @@ void BisCoreDomain::_OnDgnDbOpened(DgnDbR db) const
 
     for (RTreeMatchFunction* func : s_matchFuncs)
         db.AddRTreeMatchFunction(*func);
+
+    // Register GeometryStream virtual table module
+    (new GeomStreamModule(db))->Register();
     }
 
 #ifdef DOCUMENTATION_GENERATOR  // -- NB: This closing @}  closes the @addtogroup iModelSqlFunctions @{  at the top of the file

--- a/iModelCore/iModelPlatform/DgnCore/GeomStreamVTab.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/GeomStreamVTab.cpp
@@ -364,6 +364,14 @@ DbResult GeomStreamModule::GeomStreamVirtualTable::GeomStreamCursor::Filter(int 
             return BE_SQLITE_OK;
             }
 
+        // Enforce the per-DgnDb size limit before decompressing
+        DgnDbP dgndb = GetDgnDb();
+        if (nullptr != dgndb && header.m_size > dgndb->GetMaxGeomStreamVTabBytes())
+            {
+            m_eof = true;
+            return BE_SQLITE_TOOBIG;
+            }
+
         // Decompress the opcode data
         m_decompressed.resize(header.m_size);
         if (ZIP_SUCCESS != snappy._Read(m_decompressed.data(), header.m_size, actuallyRead)

--- a/iModelCore/iModelPlatform/DgnCore/GeomStreamVTab.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/GeomStreamVTab.cpp
@@ -12,6 +12,22 @@ USING_NAMESPACE_BENTLEY_SQLITE_EC
 // Process-wide limit; default 50 MB
 size_t GeomStreamModule::s_maxGeomStreamVTabBytes = 50 * 1024 * 1024;
 
+/*---------------------------------------------------------------------------------**//**
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+size_t GeomStreamModule::GetMaxGeomStreamVTabBytes()
+    {
+    return s_maxGeomStreamVTabBytes;
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+void GeomStreamModule::SetMaxGeomStreamVTabBytes(size_t bytes)
+    {
+    s_maxGeomStreamVTabBytes = std::max(bytes, static_cast<size_t>(4096));
+    }
+
 // Geometry blob header — matches the format written by GeometryStream::WriteGeometryStream
 static constexpr uint32_t GEOM_BLOB_SIGNATURE = 0x0600;
 

--- a/iModelCore/iModelPlatform/DgnCore/GeomStreamVTab.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/GeomStreamVTab.cpp
@@ -1,0 +1,635 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the repository root for full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+#include "DgnPlatformInternal.h"
+#include "GeomStreamVTab.h"
+
+USING_NAMESPACE_BENTLEY_DGN
+USING_NAMESPACE_BENTLEY_SQLITE
+USING_NAMESPACE_BENTLEY_SQLITE_EC
+
+// Geometry blob header — matches the format written by GeometryStream::WriteGeometryStream
+static constexpr uint32_t GEOM_BLOB_SIGNATURE = 0x0600;
+
+//=======================================================================================
+// GeomStreamModule
+//=======================================================================================
+GeomStreamModule::GeomStreamModule(ECDbR ecdb)
+    : ECDbModule(ecdb, NAME, DECLARATION, ECSCHEMA_XML)
+    {}
+
+/*---------------------------------------------------------------------------------**//**
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+DbResult GeomStreamModule::Connect(DbVirtualTable*& out, Config& conf, int argc, const char* const* argv)
+    {
+    out = new GeomStreamVirtualTable(*this);
+    return BE_SQLITE_OK;
+    }
+
+//=======================================================================================
+// GeomStreamVirtualTable — BestIndex
+//=======================================================================================
+/*---------------------------------------------------------------------------------**//**
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+DbResult GeomStreamModule::GeomStreamVirtualTable::BestIndex(IndexInfo& indexInfo)
+    {
+    for (int i = 0; i < indexInfo.GetConstraintCount(); ++i)
+        {
+        auto constraint = indexInfo.GetConstraint(i);
+        if (constraint->GetColumn() == (int)GeomStreamCursor::Columns::GeomStreamBlob
+            && constraint->GetOp() == IndexInfo::Operator::EQ
+            && constraint->IsUsable())
+            {
+            auto usage = indexInfo.GetConstraintUsage(i);
+            usage->SetArgvIndex(1);
+            usage->SetOmit(true);
+            indexInfo.SetEstimatedCost(100);
+            indexInfo.SetEstimatedRows(10);
+            indexInfo.SetIdxNum(1);
+            return BE_SQLITE_OK;
+            }
+        }
+
+    // No blob input — return prohibitive cost
+    indexInfo.SetEstimatedCost(1e12);
+    indexInfo.SetEstimatedRows(0);
+    indexInfo.SetIdxNum(0);
+    return BE_SQLITE_OK;
+    }
+
+//=======================================================================================
+// GeomStreamCursor — helpers
+//=======================================================================================
+
+/*---------------------------------------------------------------------------------**//**
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+DgnDbP GeomStreamModule::GeomStreamVirtualTable::GeomStreamCursor::GetDgnDb()
+    {
+    auto& ecdb = static_cast<GeomStreamModule&>(GetTable().GetModule()).GetECDb();
+    return dynamic_cast<DgnDbP>(&ecdb);
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+void GeomStreamModule::GeomStreamVirtualTable::GeomStreamCursor::Reset()
+    {
+    m_decompressed.clear();
+    m_data = nullptr;
+    m_dataSize = 0;
+    m_dataOffset = 0;
+    m_entryIndex = -1;
+    m_eof = true;
+    m_currentOp = GeometryStreamIO::Operation();
+    m_geomParams = Render::GeometryParams();
+    m_symbologyValid = false;
+    m_subGraphicRange.Init();
+    m_hasSubGraphicRange = false;
+    m_geomPartId = DgnGeometryPartId();
+    m_partOrigin = DPoint3d::FromZero();
+    m_partYaw = 0;
+    m_partPitch = 0;
+    m_partRoll = 0;
+    m_partScale = 1.0;
+    m_hasPartData = false;
+    m_headerFlags = 0;
+    m_isHeaderEntry = false;
+    m_textContent.clear();
+    m_hasTextContent = false;
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* OpCode enum → string name
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+Utf8CP GeomStreamModule::GeomStreamVirtualTable::GeomStreamCursor::OpCodeToString(GeometryStreamIO::OpCode opCode)
+    {
+    switch (opCode)
+        {
+        case GeometryStreamIO::OpCode::Header:               return "Header";
+        case GeometryStreamIO::OpCode::SubGraphicRange:      return "SubGraphicRange";
+        case GeometryStreamIO::OpCode::GeometryPartInstance: return "GeometryPartInstance";
+        case GeometryStreamIO::OpCode::BasicSymbology:       return "BasicSymbology";
+        case GeometryStreamIO::OpCode::PointPrimitive:       return "PointPrimitive";
+        case GeometryStreamIO::OpCode::PointPrimitive2d:     return "PointPrimitive2d";
+        case GeometryStreamIO::OpCode::ArcPrimitive:         return "ArcPrimitive";
+        case GeometryStreamIO::OpCode::CurveVector:          return "CurveVector";
+        case GeometryStreamIO::OpCode::Polyface:             return "Polyface";
+        case GeometryStreamIO::OpCode::CurvePrimitive:       return "CurvePrimitive";
+        case GeometryStreamIO::OpCode::SolidPrimitive:       return "SolidPrimitive";
+        case GeometryStreamIO::OpCode::BsplineSurface:       return "BsplineSurface";
+        case GeometryStreamIO::OpCode::AreaFill:             return "AreaFill";
+        case GeometryStreamIO::OpCode::Pattern:              return "Pattern";
+        case GeometryStreamIO::OpCode::Material:             return "Material";
+        case GeometryStreamIO::OpCode::TextString:           return "TextString";
+        case GeometryStreamIO::OpCode::LineStyleModifiers:   return "LineStyleModifiers";
+        case GeometryStreamIO::OpCode::ParasolidBRep:        return "ParasolidBRep";
+        case GeometryStreamIO::OpCode::Image:                return "Image";
+        default:                                             return "Unknown";
+        }
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* OpCode → user-facing entry type name
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+Utf8CP GeomStreamModule::GeomStreamVirtualTable::GeomStreamCursor::OpCodeToEntryType(GeometryStreamIO::OpCode opCode)
+    {
+    switch (opCode)
+        {
+        case GeometryStreamIO::OpCode::Header:               return "Header";
+        case GeometryStreamIO::OpCode::SubGraphicRange:      return "SubGraphicRange";
+        case GeometryStreamIO::OpCode::GeometryPartInstance: return "GeometryPart";
+        case GeometryStreamIO::OpCode::BasicSymbology:       return "BasicSymbology";
+        case GeometryStreamIO::OpCode::PointPrimitive:       return "PointPrimitive";
+        case GeometryStreamIO::OpCode::PointPrimitive2d:     return "PointPrimitive";
+        case GeometryStreamIO::OpCode::ArcPrimitive:         return "ArcPrimitive";
+        case GeometryStreamIO::OpCode::CurveVector:          return "CurveVector";
+        case GeometryStreamIO::OpCode::Polyface:             return "Polyface";
+        case GeometryStreamIO::OpCode::CurvePrimitive:       return "CurvePrimitive";
+        case GeometryStreamIO::OpCode::SolidPrimitive:       return "SolidPrimitive";
+        case GeometryStreamIO::OpCode::BsplineSurface:       return "BsplineSurface";
+        case GeometryStreamIO::OpCode::AreaFill:             return "AreaFill";
+        case GeometryStreamIO::OpCode::Pattern:              return "Pattern";
+        case GeometryStreamIO::OpCode::Material:             return "Material";
+        case GeometryStreamIO::OpCode::TextString:           return "TextString";
+        case GeometryStreamIO::OpCode::LineStyleModifiers:   return "LineStyleModifiers";
+        case GeometryStreamIO::OpCode::ParasolidBRep:        return "BRepEntity";
+        case GeometryStreamIO::OpCode::Image:                return "Image";
+        default:                                             return "Unknown";
+        }
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* Process the current opcode — accumulate symbology, extract part/range/text data.
+* Called after each successful ReadNextEntry(). Extracts per-entry metadata from the
+* opcode payload using GeometryStreamIO::Reader when a DgnDb is available.
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+void GeomStreamModule::GeomStreamVirtualTable::GeomStreamCursor::ProcessCurrentOp()
+    {
+    // Reset per-entry state
+    m_hasPartData = false;
+    m_isHeaderEntry = false;
+    m_hasTextContent = false;
+    m_hasSubGraphicRange = false;
+
+    DgnDbP db = GetDgnDb();
+
+    switch (m_currentOp.m_opCode)
+        {
+        case GeometryStreamIO::OpCode::Header:
+            {
+            auto header = GeometryStreamIO::Reader::GetHeader(m_currentOp);
+            if (nullptr != header)
+                m_headerFlags = (uint32_t)header->m_flags;
+            m_isHeaderEntry = true;
+            break;
+            }
+
+        case GeometryStreamIO::OpCode::BasicSymbology:
+        case GeometryStreamIO::OpCode::AreaFill:
+        case GeometryStreamIO::OpCode::Pattern:
+        case GeometryStreamIO::OpCode::Material:
+        case GeometryStreamIO::OpCode::LineStyleModifiers:
+            {
+            if (nullptr != db)
+                {
+                GeometryStreamIO::Reader reader(*db);
+                reader.Get(m_currentOp, m_geomParams);
+                m_symbologyValid = true;
+                }
+            break;
+            }
+
+        case GeometryStreamIO::OpCode::SubGraphicRange:
+            {
+            if (nullptr != db)
+                {
+                GeometryStreamIO::Reader reader(*db);
+                m_hasSubGraphicRange = reader.Get(m_currentOp, m_subGraphicRange);
+                }
+            break;
+            }
+
+        case GeometryStreamIO::OpCode::GeometryPartInstance:
+            {
+            if (nullptr != db)
+                {
+                GeometryStreamIO::Reader reader(*db);
+                Transform geomToElem;
+                if (reader.Get(m_currentOp, m_geomPartId, geomToElem))
+                    {
+                    m_hasPartData = true;
+                    // Extract origin from transform
+                    geomToElem.GetTranslation(m_partOrigin);
+                    // Extract YPR from transform matrix
+                    RotMatrix matrix;
+                    geomToElem.GetMatrix(matrix);
+                    YawPitchRollAngles angles;
+                    if (YawPitchRollAngles::TryFromRotMatrix(angles, matrix))
+                        {
+                        m_partYaw = angles.GetYaw().Degrees();
+                        m_partPitch = angles.GetPitch().Degrees();
+                        m_partRoll = angles.GetRoll().Degrees();
+                        }
+                    else
+                        {
+                        m_partYaw = m_partPitch = m_partRoll = 0.0;
+                        }
+                    // Extract scale from matrix columns
+                    DVec3d col0, col1, col2;
+                    matrix.GetColumns(col0, col1, col2);
+                    m_partScale = col0.Magnitude();
+                    }
+                }
+            break;
+            }
+
+        case GeometryStreamIO::OpCode::TextString:
+            {
+            if (nullptr != db)
+                {
+                TextStringPtr text = TextString::Create(*db);
+                GeometryStreamIO::Reader reader(*db);
+                if (reader.Get(m_currentOp, *text))
+                    {
+                    m_textContent = text->GetText();
+                    m_hasTextContent = true;
+                    }
+                }
+            break;
+            }
+
+        default:
+            break;
+        }
+    }
+
+//=======================================================================================
+// GeomStreamCursor — ReadNextEntry (with bounds checking)
+//=======================================================================================
+
+/*---------------------------------------------------------------------------------**//**
+* Read the next opcode from the decompressed stream. Returns BE_SQLITE_OK on success
+* (sets m_eof=true when stream is exhausted). Performs strict bounds checking to
+* prevent buffer overreads on corrupt/truncated data.
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+DbResult GeomStreamModule::GeomStreamVirtualTable::GeomStreamCursor::ReadNextEntry()
+    {
+    // Check if we've consumed all data
+    if (m_dataOffset >= m_dataSize)
+        {
+        m_eof = true;
+        return BE_SQLITE_OK;
+        }
+
+    // Need at least 8 bytes for opcode header (4-byte opcode + 4-byte size)
+    if (m_dataOffset + 8 > m_dataSize)
+        {
+        m_eof = true;
+        return BE_SQLITE_OK;
+        }
+
+    uint8_t const* ptr = m_data + m_dataOffset;
+    uint32_t opCode  = *reinterpret_cast<uint32_t const*>(ptr);
+    uint32_t dataSize = *reinterpret_cast<uint32_t const*>(ptr + sizeof(uint32_t));
+
+    // Validate payload fits within remaining buffer
+    size_t totalOpSize = sizeof(uint32_t) + sizeof(uint32_t) + dataSize;
+    if (m_dataOffset + totalOpSize > m_dataSize)
+        {
+        m_eof = true;
+        return BE_SQLITE_OK;
+        }
+
+    uint8_t const* data = (0 != dataSize) ? (ptr + sizeof(uint32_t) + sizeof(uint32_t)) : nullptr;
+    m_currentOp = GeometryStreamIO::Operation(static_cast<GeometryStreamIO::OpCode>(opCode), dataSize, data);
+    m_dataOffset += totalOpSize;
+    m_entryIndex++;
+
+    ProcessCurrentOp();
+    m_eof = false;
+    return BE_SQLITE_OK;
+    }
+
+//=======================================================================================
+// GeomStreamCursor — Filter
+//=======================================================================================
+
+/*---------------------------------------------------------------------------------**//**
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+DbResult GeomStreamModule::GeomStreamVirtualTable::GeomStreamCursor::Filter(int idxNum, const char* idxStr, int argc, DbValue* argv)
+    {
+    Reset();
+    try
+        {
+        if (argc < 1 || argv[0].IsNull())
+            {
+            m_eof = true;
+            return BE_SQLITE_OK;
+            }
+
+        int blobSize = argv[0].GetValueBytes();
+        void const* blob = argv[0].GetValueBlob();
+        if (blobSize <= 0 || nullptr == blob)
+            {
+            m_eof = true;
+            return BE_SQLITE_OK;
+            }
+
+        // Decompress the blob: GeomBlobHeader (8 bytes) + Snappy-compressed opcode data
+        SnappyFromMemory& snappy = SnappyFromMemory::GetForThread();
+        snappy.Init(const_cast<void*>(blob), static_cast<uint32_t>(blobSize));
+
+        // Read the GeomBlobHeader (signature + uncompressed size)
+        struct { uint32_t m_signature; uint32_t m_size; } header;
+        uint32_t actuallyRead;
+        if (ZIP_SUCCESS != snappy._Read(reinterpret_cast<Byte*>(&header), sizeof(header), actuallyRead)
+            || actuallyRead != sizeof(header))
+            {
+            m_eof = true;
+            return BE_SQLITE_OK;
+            }
+
+        if (GEOM_BLOB_SIGNATURE != header.m_signature || 0 == header.m_size)
+            {
+            m_eof = true;
+            return BE_SQLITE_OK;
+            }
+
+        // Decompress the opcode data
+        m_decompressed.resize(header.m_size);
+        if (ZIP_SUCCESS != snappy._Read(m_decompressed.data(), header.m_size, actuallyRead)
+            || actuallyRead != header.m_size)
+            {
+            m_decompressed.clear();
+            m_eof = true;
+            return BE_SQLITE_OK;
+            }
+
+        m_data = m_decompressed.data();
+        m_dataSize = header.m_size;
+        m_dataOffset = 0;
+        m_entryIndex = -1;
+
+        // Read the first entry
+        return ReadNextEntry();
+        }
+    catch (...)
+        {
+        Reset();
+        m_eof = true;
+        return BE_SQLITE_OK;
+        }
+    }
+
+//=======================================================================================
+// GeomStreamCursor — Next
+//=======================================================================================
+
+/*---------------------------------------------------------------------------------**//**
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+DbResult GeomStreamModule::GeomStreamVirtualTable::GeomStreamCursor::Next()
+    {
+    try
+        {
+        return ReadNextEntry();
+        }
+    catch (...)
+        {
+        m_eof = true;
+        return BE_SQLITE_OK;
+        }
+    }
+
+//=======================================================================================
+// GeomStreamCursor — GetRowId
+//=======================================================================================
+
+/*---------------------------------------------------------------------------------**//**
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+DbResult GeomStreamModule::GeomStreamVirtualTable::GeomStreamCursor::GetRowId(int64_t& rowId)
+    {
+    rowId = m_entryIndex;
+    return BE_SQLITE_OK;
+    }
+
+//=======================================================================================
+// GeomStreamCursor — GetColumn
+//=======================================================================================
+
+/*---------------------------------------------------------------------------------**//**
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+DbResult GeomStreamModule::GeomStreamVirtualTable::GeomStreamCursor::GetColumn(int i, Context& ctx)
+    {
+    try
+        {
+        switch (static_cast<Columns>(i))
+            {
+            case Columns::GeomStreamBlob:
+                ctx.SetResultNull();
+                break;
+
+            case Columns::EntryIndex:
+                ctx.SetResultInt(m_entryIndex);
+                break;
+
+            case Columns::OpCode:
+                {
+                Utf8CP name = OpCodeToString(m_currentOp.m_opCode);
+                ctx.SetResultText(name, (int)strlen(name), Context::CopyData::No);
+                break;
+                }
+
+            case Columns::EntryType:
+                {
+                Utf8CP name = OpCodeToEntryType(m_currentOp.m_opCode);
+                ctx.SetResultText(name, (int)strlen(name), Context::CopyData::No);
+                break;
+                }
+
+            case Columns::IsGeometry:
+                ctx.SetResultInt(m_currentOp.IsGeometryOp() ? 1 : 0);
+                break;
+
+            // Symbology columns — return accumulated state
+            case Columns::SubCategoryId:
+                if (m_symbologyValid)
+                    ctx.SetResultInt64(m_geomParams.GetSubCategoryId().GetValueUnchecked());
+                else
+                    ctx.SetResultNull();
+                break;
+
+            case Columns::Color:
+                if (m_symbologyValid && !m_geomParams.IsLineColorFromSubCategoryAppearance())
+                    ctx.SetResultInt(static_cast<int>(m_geomParams.GetLineColor().GetValue()));
+                else
+                    ctx.SetResultNull();
+                break;
+
+            case Columns::Weight:
+                if (m_symbologyValid && !m_geomParams.IsWeightFromSubCategoryAppearance())
+                    ctx.SetResultInt(static_cast<int>(m_geomParams.GetWeight()));
+                else
+                    ctx.SetResultNull();
+                break;
+
+            case Columns::LineStyle:
+                if (m_symbologyValid && !m_geomParams.IsLineStyleFromSubCategoryAppearance() && m_geomParams.GetLineStyle() != nullptr)
+                    ctx.SetResultInt64(m_geomParams.GetLineStyle()->GetStyleId().GetValueUnchecked());
+                else
+                    ctx.SetResultNull();
+                break;
+
+            case Columns::Transparency:
+                if (m_symbologyValid)
+                    ctx.SetResultDouble(m_geomParams.GetTransparency());
+                else
+                    ctx.SetResultNull();
+                break;
+
+            case Columns::GeomClass:
+                if (m_symbologyValid)
+                    ctx.SetResultInt(static_cast<int>(m_geomParams.GetGeometryClass()));
+                else
+                    ctx.SetResultNull();
+                break;
+
+            case Columns::DisplayPriority:
+                if (m_symbologyValid)
+                    ctx.SetResultInt(m_geomParams.GetDisplayPriority());
+                else
+                    ctx.SetResultNull();
+                break;
+
+            case Columns::MaterialId:
+                if (m_symbologyValid && !m_geomParams.IsMaterialFromSubCategoryAppearance())
+                    {
+                    auto matId = m_geomParams.GetMaterialId();
+                    if (matId.IsValid())
+                        ctx.SetResultInt64(matId.GetValueUnchecked());
+                    else
+                        ctx.SetResultNull();
+                    }
+                else
+                    ctx.SetResultNull();
+                break;
+
+            // GeometryPart columns
+            case Columns::GeometryPartId:
+                if (m_hasPartData)
+                    ctx.SetResultInt64(m_geomPartId.GetValueUnchecked());
+                else
+                    ctx.SetResultNull();
+                break;
+
+            case Columns::PartOriginX:
+                if (m_hasPartData) ctx.SetResultDouble(m_partOrigin.x);
+                else ctx.SetResultNull();
+                break;
+
+            case Columns::PartOriginY:
+                if (m_hasPartData) ctx.SetResultDouble(m_partOrigin.y);
+                else ctx.SetResultNull();
+                break;
+
+            case Columns::PartOriginZ:
+                if (m_hasPartData) ctx.SetResultDouble(m_partOrigin.z);
+                else ctx.SetResultNull();
+                break;
+
+            case Columns::PartYaw:
+                if (m_hasPartData) ctx.SetResultDouble(m_partYaw);
+                else ctx.SetResultNull();
+                break;
+
+            case Columns::PartPitch:
+                if (m_hasPartData) ctx.SetResultDouble(m_partPitch);
+                else ctx.SetResultNull();
+                break;
+
+            case Columns::PartRoll:
+                if (m_hasPartData) ctx.SetResultDouble(m_partRoll);
+                else ctx.SetResultNull();
+                break;
+
+            case Columns::PartScale:
+                if (m_hasPartData) ctx.SetResultDouble(m_partScale);
+                else ctx.SetResultNull();
+                break;
+
+            // SubGraphicRange columns
+            case Columns::RangeLowX:
+                if (m_hasSubGraphicRange) ctx.SetResultDouble(m_subGraphicRange.low.x);
+                else ctx.SetResultNull();
+                break;
+
+            case Columns::RangeLowY:
+                if (m_hasSubGraphicRange) ctx.SetResultDouble(m_subGraphicRange.low.y);
+                else ctx.SetResultNull();
+                break;
+
+            case Columns::RangeLowZ:
+                if (m_hasSubGraphicRange) ctx.SetResultDouble(m_subGraphicRange.low.z);
+                else ctx.SetResultNull();
+                break;
+
+            case Columns::RangeHighX:
+                if (m_hasSubGraphicRange) ctx.SetResultDouble(m_subGraphicRange.high.x);
+                else ctx.SetResultNull();
+                break;
+
+            case Columns::RangeHighY:
+                if (m_hasSubGraphicRange) ctx.SetResultDouble(m_subGraphicRange.high.y);
+                else ctx.SetResultNull();
+                break;
+
+            case Columns::RangeHighZ:
+                if (m_hasSubGraphicRange) ctx.SetResultDouble(m_subGraphicRange.high.z);
+                else ctx.SetResultNull();
+                break;
+
+            // Header flags
+            case Columns::HeaderFlags:
+                if (m_isHeaderEntry) ctx.SetResultInt(static_cast<int>(m_headerFlags));
+                else ctx.SetResultNull();
+                break;
+
+            // TextString content
+            case Columns::TextContent:
+                if (m_hasTextContent)
+                    ctx.SetResultText(m_textContent.c_str(), (int)m_textContent.size(), Context::CopyData::Yes);
+                else
+                    ctx.SetResultNull();
+                break;
+
+            // Raw geometry payload — return data for any entry that has a non-null payload
+            case Columns::GeometryBlob:
+                if (nullptr != m_currentOp.m_data && m_currentOp.m_dataSize > 0)
+                    ctx.SetResultBlob(m_currentOp.m_data, m_currentOp.m_dataSize, Context::CopyData::No);
+                else
+                    ctx.SetResultNull();
+                break;
+
+            default:
+                ctx.SetResultNull();
+                break;
+            }
+        }
+    catch (...)
+        {
+        ctx.SetResultNull();
+        }
+
+    return BE_SQLITE_OK;
+    }

--- a/iModelCore/iModelPlatform/DgnCore/GeomStreamVTab.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/GeomStreamVTab.cpp
@@ -9,6 +9,9 @@ USING_NAMESPACE_BENTLEY_DGN
 USING_NAMESPACE_BENTLEY_SQLITE
 USING_NAMESPACE_BENTLEY_SQLITE_EC
 
+// Process-wide limit; default 50 MB
+size_t GeomStreamModule::s_maxGeomStreamVTabBytes = 50 * 1024 * 1024;
+
 // Geometry blob header — matches the format written by GeometryStream::WriteGeometryStream
 static constexpr uint32_t GEOM_BLOB_SIGNATURE = 0x0600;
 
@@ -364,12 +367,11 @@ DbResult GeomStreamModule::GeomStreamVirtualTable::GeomStreamCursor::Filter(int 
             return BE_SQLITE_OK;
             }
 
-        // Enforce the per-DgnDb size limit before decompressing
-        DgnDbP dgndb = GetDgnDb();
-        if (nullptr != dgndb && header.m_size > dgndb->GetMaxGeomStreamVTabBytes())
+        // Silently skip blobs that exceed the process-wide size limit
+        if (header.m_size > GeomStreamModule::GetMaxGeomStreamVTabBytes())
             {
             m_eof = true;
-            return BE_SQLITE_TOOBIG;
+            return BE_SQLITE_OK;
             }
 
         // Decompress the opcode data

--- a/iModelCore/iModelPlatform/DgnCore/GeomStreamVTab.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/GeomStreamVTab.cpp
@@ -103,6 +103,7 @@ void GeomStreamModule::GeomStreamVirtualTable::GeomStreamCursor::Reset()
     m_isHeaderEntry = false;
     m_textContent.clear();
     m_hasTextContent = false;
+    m_geometryBlob.clear();
     }
 
 /*---------------------------------------------------------------------------------**//**
@@ -317,6 +318,17 @@ DbResult GeomStreamModule::GeomStreamVirtualTable::GeomStreamCursor::ReadNextEnt
     m_entryIndex++;
 
     ProcessCurrentOp();
+
+    // Populate m_geometryBlob: [4 bytes opcode][flatbuffer data]
+    m_geometryBlob.clear();
+    if (nullptr != m_currentOp.m_data && m_currentOp.m_dataSize > 0)
+        {
+        uint32_t opcode = static_cast<uint32_t>(m_currentOp.m_opCode);
+        m_geometryBlob.resize(sizeof(uint32_t) + m_currentOp.m_dataSize);
+        memcpy(m_geometryBlob.data(), &opcode, sizeof(uint32_t));
+        memcpy(m_geometryBlob.data() + sizeof(uint32_t), m_currentOp.m_data, m_currentOp.m_dataSize);
+        }
+
     m_eof = false;
     return BE_SQLITE_OK;
     }
@@ -623,10 +635,10 @@ DbResult GeomStreamModule::GeomStreamVirtualTable::GeomStreamCursor::GetColumn(i
                     ctx.SetResultNull();
                 break;
 
-            // Raw geometry payload — return data for any entry that has a non-null payload
+            // GeometryBlob: [4-byte opcode][flatbuffer payload]
             case Columns::GeometryBlob:
-                if (nullptr != m_currentOp.m_data && m_currentOp.m_dataSize > 0)
-                    ctx.SetResultBlob(m_currentOp.m_data, m_currentOp.m_dataSize, Context::CopyData::No);
+                if (!m_geometryBlob.empty())
+                    ctx.SetResultBlob(m_geometryBlob.data(), (int)m_geometryBlob.size(), Context::CopyData::No);
                 else
                     ctx.SetResultNull();
                 break;

--- a/iModelCore/iModelPlatform/DgnCore/GeomStreamVTab.h
+++ b/iModelCore/iModelPlatform/DgnCore/GeomStreamVTab.h
@@ -135,6 +135,14 @@ struct GeomStreamModule : BeSQLite::EC::ECDbModule
         GeomStreamModule(BeSQLite::EC::ECDbR ecdb);
         DbResult Connect(DbVirtualTable*& out, Config& conf, int argc, const char* const* argv) final;
 
+        //! Process-wide maximum uncompressed GeometryStream size (bytes) the vtab will decompose.
+        //! Blobs exceeding this are silently skipped (zero rows). Default: 50 MB. Minimum enforced: 4 KB.
+        static size_t GetMaxGeomStreamVTabBytes() { return s_maxGeomStreamVTabBytes; }
+        static void SetMaxGeomStreamVTabBytes(size_t bytes) { s_maxGeomStreamVTabBytes = std::max(bytes, static_cast<size_t>(4096)); }
+
+    private:
+        static size_t s_maxGeomStreamVTabBytes;
+
         static constexpr Utf8CP ECSCHEMA_XML =
             R"xml(<?xml version="1.0" encoding="utf-8" ?>
             <ECSchema

--- a/iModelCore/iModelPlatform/DgnCore/GeomStreamVTab.h
+++ b/iModelCore/iModelPlatform/DgnCore/GeomStreamVTab.h
@@ -1,0 +1,197 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the repository root for full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+#pragma once
+#include <ECDb/ECDbVirtualTab.h>
+#include <DgnPlatform/ElementGeometry.h>
+#include <DgnPlatform/DgnDb.h>
+
+BEGIN_BENTLEY_DGN_NAMESPACE
+
+//=======================================================================================
+//! Virtual table module that decomposes a GeometryStream blob into one row per entry.
+//! Registered from iModelPlatform. Usage:
+//!   SELECT gs.* FROM BisCore.GeometricElement3d e, dgn_geom_stream(e.GeometryStream) gs
+// @bsiclass
+//=======================================================================================
+struct GeomStreamModule : BeSQLite::EC::ECDbModule
+    {
+    constexpr static Utf8CP NAME = "dgn_geom_stream";
+
+    //=================================================================================
+    struct GeomStreamVirtualTable : ECDbVirtualTable
+        {
+        //=============================================================================
+        struct GeomStreamCursor : ECDbCursor
+            {
+            enum class Columns : int
+                {
+                GeomStreamBlob = 0,     // hidden input
+                EntryIndex,
+                OpCode,
+                EntryType,
+                IsGeometry,
+                SubCategoryId,
+                Color,
+                Weight,
+                LineStyle,
+                Transparency,
+                GeomClass,
+                DisplayPriority,
+                MaterialId,
+                GeometryPartId,
+                PartOriginX,
+                PartOriginY,
+                PartOriginZ,
+                PartYaw,
+                PartPitch,
+                PartRoll,
+                PartScale,
+                RangeLowX,
+                RangeLowY,
+                RangeLowZ,
+                RangeHighX,
+                RangeHighY,
+                RangeHighZ,
+                HeaderFlags,
+                TextContent,
+                GeometryBlob,
+                COUNT
+                };
+
+            private:
+                // Decompressed geometry stream bytes
+                bvector<uint8_t> m_decompressed;
+
+                // Current entry state
+                uint8_t const*  m_data;
+                size_t          m_dataSize;
+                size_t          m_dataOffset;
+                int             m_entryIndex;
+                bool            m_eof;
+
+                // Current opcode
+                GeometryStreamIO::Operation m_currentOp;
+
+                // Accumulated symbology
+                Render::GeometryParams m_geomParams;
+                bool m_symbologyValid;
+
+                // SubGraphicRange from last SubGraphicRange opcode
+                DRange3d m_subGraphicRange;
+                bool     m_hasSubGraphicRange;
+
+                // GeometryPart instance data
+                DgnGeometryPartId m_geomPartId;
+                DPoint3d    m_partOrigin;
+                double      m_partYaw;
+                double      m_partPitch;
+                double      m_partRoll;
+                double      m_partScale;
+                bool        m_hasPartData;
+
+                // Header flags
+                uint32_t m_headerFlags;
+                bool     m_isHeaderEntry;
+
+                // TextString content
+                Utf8String m_textContent;
+                bool       m_hasTextContent;
+
+                DgnDbP GetDgnDb();
+                void Reset();
+                DbResult ReadNextEntry();
+                void ProcessCurrentOp();
+                static Utf8CP OpCodeToString(GeometryStreamIO::OpCode);
+                static Utf8CP OpCodeToEntryType(GeometryStreamIO::OpCode);
+
+            public:
+                GeomStreamCursor(GeomStreamVirtualTable& vt)
+                    : ECDbCursor(vt), m_data(nullptr), m_dataSize(0), m_dataOffset(0),
+                      m_entryIndex(-1), m_eof(true), m_symbologyValid(false),
+                      m_hasSubGraphicRange(false), m_hasPartData(false), m_headerFlags(0),
+                      m_isHeaderEntry(false), m_hasTextContent(false),
+                      m_partYaw(0), m_partPitch(0), m_partRoll(0), m_partScale(1.0)
+                    {
+                    m_subGraphicRange.Init();
+                    m_partOrigin = DPoint3d::FromZero();
+                    }
+
+                bool Eof() final { return m_eof; }
+                DbResult Next() final;
+                DbResult GetColumn(int i, Context& ctx) final;
+                DbResult GetRowId(int64_t& rowId) final;
+                DbResult Filter(int idxNum, const char* idxStr, int argc, DbValue* argv) final;
+            };
+
+        public:
+            GeomStreamVirtualTable(GeomStreamModule& module) : ECDbVirtualTable(module) {}
+            DbResult Open(DbCursor*& cur) override { cur = new GeomStreamCursor(*this); return BE_SQLITE_OK; }
+            DbResult BestIndex(IndexInfo& indexInfo) final;
+        };
+
+    public:
+        GeomStreamModule(BeSQLite::EC::ECDbR ecdb);
+        DbResult Connect(DbVirtualTable*& out, Config& conf, int argc, const char* const* argv) final;
+
+        static constexpr Utf8CP ECSCHEMA_XML =
+            R"xml(<?xml version="1.0" encoding="utf-8" ?>
+            <ECSchema
+                    schemaName="DgnVLib"
+                    alias="DgnVLib"
+                    version="1.0.0"
+                    xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+                <ECSchemaReference name="ECDbVirtual" version="01.00.00" alias="ecdbvir" />
+                <ECCustomAttributes>
+                    <VirtualSchema xmlns="ECDbVirtual.01.00.00"/>
+                </ECCustomAttributes>
+                <ECEntityClass typeName="dgn_geom_stream" modifier="Abstract">
+                    <ECCustomAttributes>
+                        <VirtualType xmlns="ECDbVirtual.01.00.00"/>
+                    </ECCustomAttributes>
+                    <ECProperty propertyName="EntryIndex"      typeName="int" />
+                    <ECProperty propertyName="OpCode"           typeName="string" />
+                    <ECProperty propertyName="EntryType"        typeName="string" />
+                    <ECProperty propertyName="IsGeometry"       typeName="int" />
+                    <ECProperty propertyName="SubCategoryId"    typeName="long" />
+                    <ECProperty propertyName="Color"            typeName="int" />
+                    <ECProperty propertyName="Weight"           typeName="int" />
+                    <ECProperty propertyName="LineStyle"        typeName="int" />
+                    <ECProperty propertyName="Transparency"     typeName="double" />
+                    <ECProperty propertyName="GeomClass"        typeName="int" />
+                    <ECProperty propertyName="DisplayPriority"  typeName="int" />
+                    <ECProperty propertyName="MaterialId"       typeName="long" />
+                    <ECProperty propertyName="GeometryPartId"   typeName="long" />
+                    <ECProperty propertyName="PartOriginX"      typeName="double" />
+                    <ECProperty propertyName="PartOriginY"      typeName="double" />
+                    <ECProperty propertyName="PartOriginZ"      typeName="double" />
+                    <ECProperty propertyName="PartYaw"          typeName="double" />
+                    <ECProperty propertyName="PartPitch"        typeName="double" />
+                    <ECProperty propertyName="PartRoll"         typeName="double" />
+                    <ECProperty propertyName="PartScale"        typeName="double" />
+                    <ECProperty propertyName="RangeLowX"        typeName="double" />
+                    <ECProperty propertyName="RangeLowY"        typeName="double" />
+                    <ECProperty propertyName="RangeLowZ"        typeName="double" />
+                    <ECProperty propertyName="RangeHighX"       typeName="double" />
+                    <ECProperty propertyName="RangeHighY"       typeName="double" />
+                    <ECProperty propertyName="RangeHighZ"       typeName="double" />
+                    <ECProperty propertyName="HeaderFlags"      typeName="int" />
+                    <ECProperty propertyName="TextContent"      typeName="string" />
+                    <ECProperty propertyName="GeometryBlob"     typeName="binary" />
+                </ECEntityClass>
+            </ECSchema>)xml";
+
+        static constexpr Utf8CP DECLARATION =
+            "CREATE TABLE x("
+            "geom_stream BLOB HIDDEN,"
+            "EntryIndex, OpCode, EntryType, IsGeometry,"
+            "SubCategoryId, Color, Weight, LineStyle, Transparency, GeomClass, DisplayPriority, MaterialId,"
+            "GeometryPartId, PartOriginX, PartOriginY, PartOriginZ, PartYaw, PartPitch, PartRoll, PartScale,"
+            "RangeLowX, RangeLowY, RangeLowZ, RangeHighX, RangeHighY, RangeHighZ,"
+            "HeaderFlags, TextContent,"
+            "GeometryBlob"
+            ")";
+    };
+
+END_BENTLEY_DGN_NAMESPACE

--- a/iModelCore/iModelPlatform/DgnCore/GeomStreamVTab.h
+++ b/iModelCore/iModelPlatform/DgnCore/GeomStreamVTab.h
@@ -12,12 +12,12 @@ BEGIN_BENTLEY_DGN_NAMESPACE
 //=======================================================================================
 //! Virtual table module that decomposes a GeometryStream blob into one row per entry.
 //! Registered from iModelPlatform. Usage:
-//!   SELECT gs.* FROM BisCore.GeometricElement3d e, dgn_geom_stream(e.GeometryStream) gs
+//!   SELECT gs.* FROM BisCore.GeometricElement3d e, imodel_geom_stream(e.GeometryStream) gs
 // @bsiclass
 //=======================================================================================
 struct GeomStreamModule : BeSQLite::EC::ECDbModule
     {
-    constexpr static Utf8CP NAME = "dgn_geom_stream";
+    constexpr static Utf8CP NAME = "imodel_geom_stream";
 
     //=================================================================================
     struct GeomStreamVirtualTable : ECDbVirtualTable
@@ -99,6 +99,9 @@ struct GeomStreamModule : BeSQLite::EC::ECDbModule
                 Utf8String m_textContent;
                 bool       m_hasTextContent;
 
+                // GeometryBlob: [4-byte opcode][flatbuffer payload]
+                bvector<uint8_t> m_geometryBlob;
+
                 DgnDbP GetDgnDb();
                 void Reset();
                 DbResult ReadNextEntry();
@@ -146,15 +149,15 @@ struct GeomStreamModule : BeSQLite::EC::ECDbModule
         static constexpr Utf8CP ECSCHEMA_XML =
             R"xml(<?xml version="1.0" encoding="utf-8" ?>
             <ECSchema
-                    schemaName="DgnVLib"
-                    alias="DgnVLib"
+                    schemaName="IModelVLib"
+                    alias="IModelVLib"
                     version="1.0.0"
                     xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
                 <ECSchemaReference name="ECDbVirtual" version="01.00.00" alias="ecdbvir" />
                 <ECCustomAttributes>
                     <VirtualSchema xmlns="ECDbVirtual.01.00.00"/>
                 </ECCustomAttributes>
-                <ECEntityClass typeName="dgn_geom_stream" modifier="Abstract">
+                <ECEntityClass typeName="imodel_geom_stream" modifier="Abstract">
                     <ECCustomAttributes>
                         <VirtualType xmlns="ECDbVirtual.01.00.00"/>
                     </ECCustomAttributes>

--- a/iModelCore/iModelPlatform/DgnCore/GeomStreamVTab.h
+++ b/iModelCore/iModelPlatform/DgnCore/GeomStreamVTab.h
@@ -168,7 +168,7 @@ struct GeomStreamModule : BeSQLite::EC::ECDbModule
                     <ECProperty propertyName="SubCategoryId"    typeName="long" />
                     <ECProperty propertyName="Color"            typeName="int" />
                     <ECProperty propertyName="Weight"           typeName="int" />
-                    <ECProperty propertyName="LineStyle"        typeName="int" />
+                    <ECProperty propertyName="LineStyle"        typeName="long" />
                     <ECProperty propertyName="Transparency"     typeName="double" />
                     <ECProperty propertyName="GeomClass"        typeName="int" />
                     <ECProperty propertyName="DisplayPriority"  typeName="int" />

--- a/iModelCore/iModelPlatform/DgnCore/GeomStreamVTab.h
+++ b/iModelCore/iModelPlatform/DgnCore/GeomStreamVTab.h
@@ -140,8 +140,8 @@ struct GeomStreamModule : BeSQLite::EC::ECDbModule
 
         //! Process-wide maximum uncompressed GeometryStream size (bytes) the vtab will decompose.
         //! Blobs exceeding this are silently skipped (zero rows). Default: 50 MB. Minimum enforced: 4 KB.
-        static size_t GetMaxGeomStreamVTabBytes() { return s_maxGeomStreamVTabBytes; }
-        static void SetMaxGeomStreamVTabBytes(size_t bytes) { s_maxGeomStreamVTabBytes = std::max(bytes, static_cast<size_t>(4096)); }
+        DGNPLATFORM_EXPORT static size_t GetMaxGeomStreamVTabBytes();
+        DGNPLATFORM_EXPORT static void SetMaxGeomStreamVTabBytes(size_t bytes);
 
     private:
         static size_t s_maxGeomStreamVTabBytes;

--- a/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/DgnDb.h
+++ b/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/DgnDb.h
@@ -210,7 +210,7 @@ struct DgnDb : RefCounted<BeSQLite::EC::ECDb>, BeSQLite::EC::ECDb::IECDbCacheCle
 private:
     BeSQLite::BeBriefcaseBasedIdSequence m_elementIdSequence;
     int m_purgeOperation = 0;
-    size_t m_maxGeomStreamVTabBytes = 50 * 1024 * 1024; // 50 MB default
+
 
     void Destroy();
     SchemaStatus PickSchemasToImport(bvector<ECN::ECSchemaCP>& importSchemas, bvector<ECN::ECSchemaCP> const& schemas, bool isImportingFromV8) const;
@@ -301,14 +301,6 @@ public:
 
     //! Get the profile version of an opened DgnDb.
     DGNPLATFORM_EXPORT DgnDbProfileVersion GetProfileVersion();
-
-    //! Get the maximum uncompressed GeometryStream size (in bytes) that the dgn_geom_stream virtual table will process.
-    //! Blobs larger than this limit are silently skipped (zero rows returned). Default is 50 MB.
-    size_t GetMaxGeomStreamVTabBytes() const { return m_maxGeomStreamVTabBytes; }
-
-    //! Set the maximum uncompressed GeometryStream size (in bytes) accessible via the dgn_geom_stream virtual table.
-    //! @param[in] bytes The new limit. Values below 4096 (4 KB) are clamped to 4096.
-    void SetMaxGeomStreamVTabBytes(size_t bytes) { m_maxGeomStreamVTabBytes = std::max(bytes, static_cast<size_t>(4096)); }
 
     //! Open an existing DgnDb file.
     //! @param[out] status BE_SQLITE_OK if the DgnDb file was successfully opened, error code otherwise. May be NULL.

--- a/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/DgnDb.h
+++ b/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/DgnDb.h
@@ -210,6 +210,7 @@ struct DgnDb : RefCounted<BeSQLite::EC::ECDb>, BeSQLite::EC::ECDb::IECDbCacheCle
 private:
     BeSQLite::BeBriefcaseBasedIdSequence m_elementIdSequence;
     int m_purgeOperation = 0;
+    size_t m_maxGeomStreamVTabBytes = 50 * 1024 * 1024; // 50 MB default
 
     void Destroy();
     SchemaStatus PickSchemasToImport(bvector<ECN::ECSchemaCP>& importSchemas, bvector<ECN::ECSchemaCP> const& schemas, bool isImportingFromV8) const;
@@ -300,6 +301,14 @@ public:
 
     //! Get the profile version of an opened DgnDb.
     DGNPLATFORM_EXPORT DgnDbProfileVersion GetProfileVersion();
+
+    //! Get the maximum uncompressed GeometryStream size (in bytes) that the dgn_geom_stream virtual table will process.
+    //! Blobs larger than this limit are silently skipped (zero rows returned). Default is 50 MB.
+    size_t GetMaxGeomStreamVTabBytes() const { return m_maxGeomStreamVTabBytes; }
+
+    //! Set the maximum uncompressed GeometryStream size (in bytes) accessible via the dgn_geom_stream virtual table.
+    //! @param[in] bytes The new limit. Values below 4096 (4 KB) are clamped to 4096.
+    void SetMaxGeomStreamVTabBytes(size_t bytes) { m_maxGeomStreamVTabBytes = std::max(bytes, static_cast<size_t>(4096)); }
 
     //! Open an existing DgnDb file.
     //! @param[out] status BE_SQLITE_OK if the DgnDb file was successfully opened, error code otherwise. May be NULL.

--- a/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/DgnDb.h
+++ b/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/DgnDb.h
@@ -211,7 +211,6 @@ private:
     BeSQLite::BeBriefcaseBasedIdSequence m_elementIdSequence;
     int m_purgeOperation = 0;
 
-
     void Destroy();
     SchemaStatus PickSchemasToImport(bvector<ECN::ECSchemaCP>& importSchemas, bvector<ECN::ECSchemaCP> const& schemas, bool isImportingFromV8) const;
     void OnBisCoreSchemaImported(CreateDgnDbParams const& params);

--- a/iModelCore/iModelPlatform/Tests/DgnProject/NonPublished/GeomStreamVTab_Test.cpp
+++ b/iModelCore/iModelPlatform/Tests/DgnProject/NonPublished/GeomStreamVTab_Test.cpp
@@ -1,0 +1,546 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the repository root for full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+#include "DgnHandlersTests.h"
+#include <DgnPlatform/PlatformLib.h>
+#include <DgnPlatform/GeomPart.h>
+#include "../TestFixture/GeomHelper.h"
+
+USING_NAMESPACE_BENTLEY_SQLITE
+USING_NAMESPACE_BENTLEY_SQLITE_EC
+
+//=======================================================================================
+// @bsiclass
+//=======================================================================================
+struct GeomStreamVTabTest : public DgnDbTestFixture
+{
+};
+
+/*---------------------------------------------------------------------------------**//**
+* Verify that dgn_geom_stream returns at least one row per element and that basic
+* columns (EntryIndex, OpCode, EntryType) are non-NULL.
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+TEST_F(GeomStreamVTabTest, BasicQuery)
+    {
+    SetupSeedProject();
+
+    // Insert a TestElement with geometry
+    auto el = InsertElement(Render::GeometryParams(m_defaultCategoryId));
+    ASSERT_TRUE(el.IsValid()) << "Failed to insert element with geometry";
+    DgnElementId elemId = el->GetElementId();
+    SaveDb();
+
+    // Query the geometry stream
+    ECSqlStatement stmt;
+    ASSERT_EQ(ECSqlStatus::Success, stmt.Prepare(*m_db,
+        "SELECT gs.EntryIndex, gs.OpCode, gs.EntryType, gs.IsGeometry "
+        "FROM bis.GeometricElement3d e, dgn_geom_stream(e.GeometryStream) gs "
+        "WHERE e.ECInstanceId = ?"));
+
+    stmt.BindId(1, elemId);
+
+    int rowCount = 0;
+    while (BE_SQLITE_ROW == stmt.Step())
+        {
+        // EntryIndex should be sequential starting from 0
+        EXPECT_EQ(rowCount, stmt.GetValueInt(0)) << "EntryIndex should be sequential";
+
+        // OpCode should be a non-empty string
+        Utf8CP opCode = stmt.GetValueText(1);
+        EXPECT_TRUE(opCode != nullptr && strlen(opCode) > 0) << "OpCode should not be empty";
+
+        // EntryType should be a non-empty string
+        Utf8CP entryType = stmt.GetValueText(2);
+        EXPECT_TRUE(entryType != nullptr && strlen(entryType) > 0) << "EntryType should not be empty";
+
+        rowCount++;
+        }
+
+    EXPECT_GT(rowCount, 0) << "Should have at least one geometry stream entry";
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* Verify that the first entry in a geometry stream is typically a Header opcode.
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+TEST_F(GeomStreamVTabTest, HeaderEntry)
+    {
+    SetupSeedProject();
+
+    auto el = InsertElement(Render::GeometryParams(m_defaultCategoryId));
+    ASSERT_TRUE(el.IsValid());
+    DgnElementId elemId = el->GetElementId();
+    SaveDb();
+
+    ECSqlStatement stmt;
+    ASSERT_EQ(ECSqlStatus::Success, stmt.Prepare(*m_db,
+        "SELECT gs.OpCode, gs.HeaderFlags "
+        "FROM bis.GeometricElement3d e, dgn_geom_stream(e.GeometryStream) gs "
+        "WHERE e.ECInstanceId = ? AND gs.EntryIndex = 0"));
+
+    stmt.BindId(1, elemId);
+
+    ASSERT_EQ(BE_SQLITE_ROW, stmt.Step());
+    Utf8CP firstOpCode = stmt.GetValueText(0);
+    ASSERT_TRUE(firstOpCode != nullptr);
+    EXPECT_STREQ("Header", firstOpCode) << "First opcode should be Header";
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* Verify that geometry entries have IsGeometry = 1 and non-geometry entries have 0.
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+TEST_F(GeomStreamVTabTest, IsGeometryFlag)
+    {
+    SetupSeedProject();
+
+    auto el = InsertElement(Render::GeometryParams(m_defaultCategoryId));
+    ASSERT_TRUE(el.IsValid());
+    DgnElementId elemId = el->GetElementId();
+    SaveDb();
+
+    ECSqlStatement stmt;
+    ASSERT_EQ(ECSqlStatus::Success, stmt.Prepare(*m_db,
+        "SELECT gs.OpCode, gs.IsGeometry "
+        "FROM bis.GeometricElement3d e, dgn_geom_stream(e.GeometryStream) gs "
+        "WHERE e.ECInstanceId = ?"));
+
+    stmt.BindId(1, elemId);
+
+    bool foundGeomEntry = false;
+    bool foundNonGeomEntry = false;
+    while (BE_SQLITE_ROW == stmt.Step())
+        {
+        Utf8CP opCode = stmt.GetValueText(0);
+        int isGeom = stmt.GetValueInt(1);
+
+        if (isGeom == 1)
+            foundGeomEntry = true;
+        else
+            foundNonGeomEntry = true;
+
+        // Header should never be geometry
+        if (opCode != nullptr && strcmp(opCode, "Header") == 0)
+            EXPECT_EQ(0, isGeom) << "Header should not be a geometry entry";
+        }
+
+    EXPECT_TRUE(foundGeomEntry) << "TestElement should have at least one geometry entry";
+    EXPECT_TRUE(foundNonGeomEntry) << "TestElement should have non-geometry entries (Header, BasicSymbology)";
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* Verify SubCategoryId is returned for geometry entries.
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+TEST_F(GeomStreamVTabTest, SubCategoryId)
+    {
+    SetupSeedProject();
+
+    auto el = InsertElement(Render::GeometryParams(m_defaultCategoryId));
+    ASSERT_TRUE(el.IsValid());
+    DgnElementId elemId = el->GetElementId();
+    SaveDb();
+
+    ECSqlStatement stmt;
+    ASSERT_EQ(ECSqlStatus::Success, stmt.Prepare(*m_db,
+        "SELECT gs.SubCategoryId "
+        "FROM bis.GeometricElement3d e, dgn_geom_stream(e.GeometryStream) gs "
+        "WHERE e.ECInstanceId = ? AND gs.IsGeometry = 1"));
+
+    stmt.BindId(1, elemId);
+
+    while (BE_SQLITE_ROW == stmt.Step())
+        {
+        // After BasicSymbology, geometry entries should have a valid SubCategoryId
+        int64_t subCatId = stmt.GetValueInt64(0);
+        if (!stmt.IsValueNull(0))
+            EXPECT_NE(0, subCatId) << "SubCategoryId should be non-zero when set";
+        }
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* Verify that multiple elements each produce their own set of rows.
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+TEST_F(GeomStreamVTabTest, MultipleElements)
+    {
+    SetupSeedProject();
+
+    auto el1 = InsertElement(Render::GeometryParams(m_defaultCategoryId));
+    auto el2 = InsertElement(Render::GeometryParams(m_defaultCategoryId));
+    auto el3 = InsertElement(Render::GeometryParams(m_defaultCategoryId));
+    ASSERT_TRUE(el1.IsValid() && el2.IsValid() && el3.IsValid());
+    SaveDb();
+
+    // Count total entries across all elements
+    ECSqlStatement stmt;
+    ASSERT_EQ(ECSqlStatus::Success, stmt.Prepare(*m_db,
+        "SELECT COUNT(*) FROM bis.GeometricElement3d e, dgn_geom_stream(e.GeometryStream) gs"));
+
+    ASSERT_EQ(BE_SQLITE_ROW, stmt.Step());
+    int totalCount = stmt.GetValueInt(0);
+    EXPECT_GT(totalCount, 0) << "Should have entries across all elements";
+
+    // Count entries per element — each element should produce the same number
+    stmt.Finalize();
+    ASSERT_EQ(ECSqlStatus::Success, stmt.Prepare(*m_db,
+        "SELECT e.ECInstanceId, COUNT(*) "
+        "FROM bis.GeometricElement3d e, dgn_geom_stream(e.GeometryStream) gs "
+        "GROUP BY e.ECInstanceId"));
+
+    int elementCount = 0;
+    int lastEntryCount = -1;
+    while (BE_SQLITE_ROW == stmt.Step())
+        {
+        elementCount++;
+        int entryCount = stmt.GetValueInt(1);
+        EXPECT_GT(entryCount, 0);
+
+        // Since all TestElements have the same geometry, entry counts should be equal
+        if (lastEntryCount >= 0)
+            EXPECT_EQ(lastEntryCount, entryCount) << "Identical elements should have same entry count";
+        lastEntryCount = entryCount;
+        }
+
+    EXPECT_GE(elementCount, 3) << "Should have at least 3 elements (the 3 we inserted)";
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* Verify that GeometryBlob column returns non-NULL data for geometry entries.
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+TEST_F(GeomStreamVTabTest, GeometryBlobColumn)
+    {
+    SetupSeedProject();
+
+    auto el = InsertElement(Render::GeometryParams(m_defaultCategoryId));
+    ASSERT_TRUE(el.IsValid());
+    DgnElementId elemId = el->GetElementId();
+    SaveDb();
+
+    ECSqlStatement stmt;
+    ASSERT_EQ(ECSqlStatus::Success, stmt.Prepare(*m_db,
+        "SELECT gs.GeometryBlob, gs.OpCode "
+        "FROM bis.GeometricElement3d e, dgn_geom_stream(e.GeometryStream) gs "
+        "WHERE e.ECInstanceId = ?"));
+
+    stmt.BindId(1, elemId);
+
+    while (BE_SQLITE_ROW == stmt.Step())
+        {
+        Utf8CP opCode = stmt.GetValueText(1);
+        if (opCode != nullptr && strcmp(opCode, "Header") != 0)
+            {
+            // Non-header entries should have a GeometryBlob with the raw opcode payload
+            int blobSize = 0;
+            const void* blobData = stmt.GetValueBlob(0, &blobSize);
+            EXPECT_TRUE(blobData != nullptr && blobSize > 0) << "GeometryBlob should contain opcode payload for " << opCode;
+            }
+        }
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* Verify that SELECT * works (all columns expand correctly).
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+TEST_F(GeomStreamVTabTest, SelectStar)
+    {
+    SetupSeedProject();
+
+    auto el = InsertElement(Render::GeometryParams(m_defaultCategoryId));
+    ASSERT_TRUE(el.IsValid());
+    DgnElementId elemId = el->GetElementId();
+    SaveDb();
+
+    ECSqlStatement stmt;
+    ASSERT_EQ(ECSqlStatus::Success, stmt.Prepare(*m_db,
+        "SELECT * FROM bis.GeometricElement3d e, dgn_geom_stream(e.GeometryStream) gs "
+        "WHERE e.ECInstanceId = ?"));
+
+    stmt.BindId(1, elemId);
+    ASSERT_EQ(BE_SQLITE_ROW, stmt.Step()) << "SELECT * should return at least one row";
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* Verify filtering: querying with IsGeometry = 1 should only return geometry opcodes.
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+TEST_F(GeomStreamVTabTest, FilterGeometryEntries)
+    {
+    SetupSeedProject();
+
+    auto el = InsertElement(Render::GeometryParams(m_defaultCategoryId));
+    ASSERT_TRUE(el.IsValid());
+    DgnElementId elemId = el->GetElementId();
+    SaveDb();
+
+    ECSqlStatement stmt;
+    ASSERT_EQ(ECSqlStatus::Success, stmt.Prepare(*m_db,
+        "SELECT gs.OpCode, gs.IsGeometry "
+        "FROM bis.GeometricElement3d e, dgn_geom_stream(e.GeometryStream) gs "
+        "WHERE e.ECInstanceId = ? AND gs.IsGeometry = 1"));
+
+    stmt.BindId(1, elemId);
+
+    int geomRows = 0;
+    while (BE_SQLITE_ROW == stmt.Step())
+        {
+        EXPECT_EQ(1, stmt.GetValueInt(1)) << "Filtered rows should all have IsGeometry=1";
+        geomRows++;
+        }
+
+    EXPECT_GT(geomRows, 0) << "Should find at least one geometry entry";
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* Verify that an element with geometry using display params has Color/Weight populated.
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+TEST_F(GeomStreamVTabTest, DisplayParams)
+    {
+    SetupSeedProject();
+
+    // Insert element with explicit display properties
+    Render::GeometryParams geomParams(m_defaultCategoryId);
+    geomParams.SetLineColor(ColorDef::Green());
+    geomParams.SetWeight(3);
+
+    auto el = InsertElement(geomParams);
+    ASSERT_TRUE(el.IsValid());
+    DgnElementId elemId = el->GetElementId();
+    SaveDb();
+
+    ECSqlStatement stmt;
+    ASSERT_EQ(ECSqlStatus::Success, stmt.Prepare(*m_db,
+        "SELECT gs.Color, gs.Weight "
+        "FROM bis.GeometricElement3d e, dgn_geom_stream(e.GeometryStream) gs "
+        "WHERE e.ECInstanceId = ? AND gs.IsGeometry = 1"));
+
+    stmt.BindId(1, elemId);
+
+    bool foundColorWeight = false;
+    while (BE_SQLITE_ROW == stmt.Step())
+        {
+        if (!stmt.IsValueNull(0))
+            {
+            foundColorWeight = true;
+            // Color should be set (we set Green)
+            int color = stmt.GetValueInt(0);
+            EXPECT_NE(0, color) << "Color should be non-zero when explicitly set";
+            }
+        if (!stmt.IsValueNull(1))
+            {
+            int weight = stmt.GetValueInt(1);
+            EXPECT_EQ(3, weight) << "Weight should match the value we set";
+            }
+        }
+
+    EXPECT_TRUE(foundColorWeight) << "Should find Color/Weight in symbology entries";
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* Verify that 2d elements also work.
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+TEST_F(GeomStreamVTabTest, Element2d)
+    {
+    SetupSeedProject();
+
+    // Create a drawing model to hold the 2D element (TestElement2d requires a 2D model)
+    DgnCategoryId drawingCategoryId = DgnDbTestUtils::InsertDrawingCategory(*m_db, "GeomStreamTestDrawingCategory");
+    DocumentListModelPtr drawingListModel = DgnDbTestUtils::InsertDocumentListModel(*m_db, "GeomStreamTestDrawingList");
+    DrawingPtr drawing = DgnDbTestUtils::InsertDrawing(*drawingListModel, "GeomStreamTestDrawing");
+    DrawingModelPtr drawingModel = DgnDbTestUtils::InsertDrawingModel(*drawing);
+    ASSERT_TRUE(drawingModel.IsValid()) << "Failed to create drawing model";
+
+    DgnElementId elem2dId = InsertElement2d(drawingModel->GetModelId(), drawingCategoryId);
+    ASSERT_TRUE(elem2dId.IsValid());
+    SaveDb();
+
+    ECSqlStatement stmt;
+    ASSERT_EQ(ECSqlStatus::Success, stmt.Prepare(*m_db,
+        "SELECT gs.EntryIndex, gs.OpCode "
+        "FROM bis.GeometricElement2d e, dgn_geom_stream(e.GeometryStream) gs "
+        "WHERE e.ECInstanceId = ?"));
+
+    stmt.BindId(1, elem2dId);
+
+    int rowCount = 0;
+    while (BE_SQLITE_ROW == stmt.Step())
+        rowCount++;
+
+    EXPECT_GT(rowCount, 0) << "2d element should have geometry stream entries";
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* Verify that an element with a geometry part reference populates the Part columns.
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+TEST_F(GeomStreamVTabTest, GeometryPartReference)
+    {
+    SetupSeedProject();
+
+    // Create a geometry part using the dictionary model (a DefinitionModel)
+    DgnGeometryPartPtr part = DgnGeometryPart::Create(m_db->GetDictionaryModel(), "TestPart");
+    ASSERT_TRUE(part.IsValid());
+
+    GeometricPrimitivePtr geomPrim = GeometricPrimitive::Create(*GeomHelper::computeShape());
+    GeometryBuilderPtr partBuilder = GeometryBuilder::CreateGeometryPart(*m_db, true);
+    partBuilder->Append(*geomPrim);
+    ASSERT_EQ(SUCCESS, partBuilder->Finish(*part));
+
+    DgnGeometryPartCPtr insertedPart = m_db->Elements().Insert<DgnGeometryPart>(*part);
+    ASSERT_TRUE(insertedPart.IsValid()) << "Failed to insert geometry part";
+
+    // Create element referencing the part
+    DgnElementId elemId = InsertElementUsingGeometryPart(insertedPart->GetId());
+    ASSERT_TRUE(elemId.IsValid());
+    SaveDb();
+
+    ECSqlStatement stmt;
+    ASSERT_EQ(ECSqlStatus::Success, stmt.Prepare(*m_db,
+        "SELECT gs.GeometryPartId, gs.PartOriginX, gs.PartOriginY, gs.PartOriginZ, gs.PartScale, gs.OpCode "
+        "FROM bis.GeometricElement3d e, dgn_geom_stream(e.GeometryStream) gs "
+        "WHERE e.ECInstanceId = ? AND gs.GeometryPartId IS NOT NULL"));
+
+    stmt.BindId(1, elemId);
+
+    bool foundPart = false;
+    while (BE_SQLITE_ROW == stmt.Step())
+        {
+        foundPart = true;
+        int64_t partId = stmt.GetValueInt64(0);
+        EXPECT_NE(0, partId) << "GeometryPartId should be valid";
+
+        // PartScale defaults to 1.0 for non-scaled parts
+        if (!stmt.IsValueNull(4))
+            {
+            double scale = stmt.GetValueDouble(4);
+            EXPECT_GT(scale, 0.0) << "PartScale should be positive";
+            }
+
+        Utf8CP opCode = stmt.GetValueText(5);
+        EXPECT_STREQ("GeometryPartInstance", opCode) << "Part entries should have GeometryPartInstance opcode";
+        }
+
+    EXPECT_TRUE(foundPart) << "Should find the geometry part reference";
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* Verify that dgn_geom_stream produces no rows (not an error) when GeometryStream is NULL.
+* This tests resilience against elements that exist but have no geometry.
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+TEST_F(GeomStreamVTabTest, NullGeometryStream)
+    {
+    SetupSeedProject();
+
+    // Insert an element without geometry — use CreateWithoutGeometry if available,
+    // or query an element class that may not have geometry.
+    // We'll test by trying to join with a non-geometric element class.
+    // If there are no null geometry streams, this test simply passes with 0 rows.
+    ECSqlStatement stmt;
+    auto status = stmt.Prepare(*m_db,
+        "SELECT COUNT(*) FROM bis.GeometricElement3d e, dgn_geom_stream(e.GeometryStream) gs "
+        "WHERE e.GeometryStream IS NULL");
+
+    // If the ECSQL prepares, it should return 0 rows, not an error
+    if (ECSqlStatus::Success == status)
+        {
+        ASSERT_EQ(BE_SQLITE_ROW, stmt.Step());
+        int count = stmt.GetValueInt(0);
+        EXPECT_EQ(0, count) << "NULL GeometryStream should produce 0 vtab rows";
+        }
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* Verify that querying with schema-qualified name also works: DgnVLib.dgn_geom_stream
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+TEST_F(GeomStreamVTabTest, SchemaQualifiedName)
+    {
+    SetupSeedProject();
+
+    auto el = InsertElement(Render::GeometryParams(m_defaultCategoryId));
+    ASSERT_TRUE(el.IsValid());
+    DgnElementId elemId = el->GetElementId();
+    SaveDb();
+
+    ECSqlStatement stmt;
+    ASSERT_EQ(ECSqlStatus::Success, stmt.Prepare(*m_db,
+        "SELECT gs.EntryIndex, gs.OpCode "
+        "FROM bis.GeometricElement3d e, DgnVLib.dgn_geom_stream(e.GeometryStream) gs "
+        "WHERE e.ECInstanceId = ?"));
+
+    stmt.BindId(1, elemId);
+
+    int rowCount = 0;
+    while (BE_SQLITE_ROW == stmt.Step())
+        rowCount++;
+
+    EXPECT_GT(rowCount, 0) << "Schema-qualified name should also work";
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* Verify we can count geometry-type entries per element using GROUP BY.
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+TEST_F(GeomStreamVTabTest, CountGeometryEntriesPerElement)
+    {
+    SetupSeedProject();
+
+    auto el1 = InsertElement(Render::GeometryParams(m_defaultCategoryId));
+    auto el2 = InsertElement(Render::GeometryParams(m_defaultCategoryId));
+    ASSERT_TRUE(el1.IsValid() && el2.IsValid());
+    SaveDb();
+
+    ECSqlStatement stmt;
+    ASSERT_EQ(ECSqlStatus::Success, stmt.Prepare(*m_db,
+        "SELECT e.ECInstanceId, SUM(gs.IsGeometry) AS geomCount "
+        "FROM bis.GeometricElement3d e, dgn_geom_stream(e.GeometryStream) gs "
+        "GROUP BY e.ECInstanceId"));
+
+    int elementCount = 0;
+    while (BE_SQLITE_ROW == stmt.Step())
+        {
+        elementCount++;
+        int geomCount = stmt.GetValueInt(1);
+        EXPECT_GT(geomCount, 0) << "Each element should have at least one geometry entry";
+        }
+
+    EXPECT_GE(elementCount, 2) << "Should have at least 2 elements";
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* Verify that EntryIndex is unique and monotonically increasing per element.
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+TEST_F(GeomStreamVTabTest, EntryIndexMonotonic)
+    {
+    SetupSeedProject();
+
+    auto el = InsertElement(Render::GeometryParams(m_defaultCategoryId));
+    ASSERT_TRUE(el.IsValid());
+    DgnElementId elemId = el->GetElementId();
+    SaveDb();
+
+    ECSqlStatement stmt;
+    ASSERT_EQ(ECSqlStatus::Success, stmt.Prepare(*m_db,
+        "SELECT gs.EntryIndex "
+        "FROM bis.GeometricElement3d e, dgn_geom_stream(e.GeometryStream) gs "
+        "WHERE e.ECInstanceId = ?"));
+
+    stmt.BindId(1, elemId);
+
+    int lastIndex = -1;
+    while (BE_SQLITE_ROW == stmt.Step())
+        {
+        int index = stmt.GetValueInt(0);
+        EXPECT_EQ(lastIndex + 1, index) << "EntryIndex should be monotonically increasing";
+        lastIndex = index;
+        }
+
+    EXPECT_GE(lastIndex, 0) << "Should have visited at least one entry";
+    }

--- a/iModelCore/iModelPlatform/Tests/DgnProject/NonPublished/GeomStreamVTab_Test.cpp
+++ b/iModelCore/iModelPlatform/Tests/DgnProject/NonPublished/GeomStreamVTab_Test.cpp
@@ -18,7 +18,7 @@ struct GeomStreamVTabTest : public DgnDbTestFixture
 };
 
 /*---------------------------------------------------------------------------------**//**
-* Verify that dgn_geom_stream returns at least one row per element and that basic
+* Verify that imodel_geom_stream returns at least one row per element and that basic
 * columns (EntryIndex, OpCode, EntryType) are non-NULL.
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/
@@ -36,7 +36,7 @@ TEST_F(GeomStreamVTabTest, BasicQuery)
     ECSqlStatement stmt;
     ASSERT_EQ(ECSqlStatus::Success, stmt.Prepare(*m_db,
         "SELECT gs.EntryIndex, gs.OpCode, gs.EntryType, gs.IsGeometry "
-        "FROM bis.GeometricElement3d e, dgn_geom_stream(e.GeometryStream) gs "
+        "FROM bis.GeometricElement3d e, imodel_geom_stream(e.GeometryStream) gs "
         "WHERE e.ECInstanceId = ?"));
 
     stmt.BindId(1, elemId);
@@ -77,7 +77,7 @@ TEST_F(GeomStreamVTabTest, HeaderEntry)
     ECSqlStatement stmt;
     ASSERT_EQ(ECSqlStatus::Success, stmt.Prepare(*m_db,
         "SELECT gs.OpCode, gs.HeaderFlags "
-        "FROM bis.GeometricElement3d e, dgn_geom_stream(e.GeometryStream) gs "
+        "FROM bis.GeometricElement3d e, imodel_geom_stream(e.GeometryStream) gs "
         "WHERE e.ECInstanceId = ? AND gs.EntryIndex = 0"));
 
     stmt.BindId(1, elemId);
@@ -104,7 +104,7 @@ TEST_F(GeomStreamVTabTest, IsGeometryFlag)
     ECSqlStatement stmt;
     ASSERT_EQ(ECSqlStatus::Success, stmt.Prepare(*m_db,
         "SELECT gs.OpCode, gs.IsGeometry "
-        "FROM bis.GeometricElement3d e, dgn_geom_stream(e.GeometryStream) gs "
+        "FROM bis.GeometricElement3d e, imodel_geom_stream(e.GeometryStream) gs "
         "WHERE e.ECInstanceId = ?"));
 
     stmt.BindId(1, elemId);
@@ -146,7 +146,7 @@ TEST_F(GeomStreamVTabTest, SubCategoryId)
     ECSqlStatement stmt;
     ASSERT_EQ(ECSqlStatus::Success, stmt.Prepare(*m_db,
         "SELECT gs.SubCategoryId "
-        "FROM bis.GeometricElement3d e, dgn_geom_stream(e.GeometryStream) gs "
+        "FROM bis.GeometricElement3d e, imodel_geom_stream(e.GeometryStream) gs "
         "WHERE e.ECInstanceId = ? AND gs.IsGeometry = 1"));
 
     stmt.BindId(1, elemId);
@@ -177,7 +177,7 @@ TEST_F(GeomStreamVTabTest, MultipleElements)
     // Count total entries across all elements
     ECSqlStatement stmt;
     ASSERT_EQ(ECSqlStatus::Success, stmt.Prepare(*m_db,
-        "SELECT COUNT(*) FROM bis.GeometricElement3d e, dgn_geom_stream(e.GeometryStream) gs"));
+        "SELECT COUNT(*) FROM bis.GeometricElement3d e, imodel_geom_stream(e.GeometryStream) gs"));
 
     ASSERT_EQ(BE_SQLITE_ROW, stmt.Step());
     int totalCount = stmt.GetValueInt(0);
@@ -187,7 +187,7 @@ TEST_F(GeomStreamVTabTest, MultipleElements)
     stmt.Finalize();
     ASSERT_EQ(ECSqlStatus::Success, stmt.Prepare(*m_db,
         "SELECT e.ECInstanceId, COUNT(*) "
-        "FROM bis.GeometricElement3d e, dgn_geom_stream(e.GeometryStream) gs "
+        "FROM bis.GeometricElement3d e, imodel_geom_stream(e.GeometryStream) gs "
         "GROUP BY e.ECInstanceId"));
 
     int elementCount = 0;
@@ -223,7 +223,7 @@ TEST_F(GeomStreamVTabTest, GeometryBlobColumn)
     ECSqlStatement stmt;
     ASSERT_EQ(ECSqlStatus::Success, stmt.Prepare(*m_db,
         "SELECT gs.GeometryBlob, gs.OpCode "
-        "FROM bis.GeometricElement3d e, dgn_geom_stream(e.GeometryStream) gs "
+        "FROM bis.GeometricElement3d e, imodel_geom_stream(e.GeometryStream) gs "
         "WHERE e.ECInstanceId = ?"));
 
     stmt.BindId(1, elemId);
@@ -256,7 +256,7 @@ TEST_F(GeomStreamVTabTest, SelectStar)
 
     ECSqlStatement stmt;
     ASSERT_EQ(ECSqlStatus::Success, stmt.Prepare(*m_db,
-        "SELECT * FROM bis.GeometricElement3d e, dgn_geom_stream(e.GeometryStream) gs "
+        "SELECT * FROM bis.GeometricElement3d e, imodel_geom_stream(e.GeometryStream) gs "
         "WHERE e.ECInstanceId = ?"));
 
     stmt.BindId(1, elemId);
@@ -279,7 +279,7 @@ TEST_F(GeomStreamVTabTest, FilterGeometryEntries)
     ECSqlStatement stmt;
     ASSERT_EQ(ECSqlStatus::Success, stmt.Prepare(*m_db,
         "SELECT gs.OpCode, gs.IsGeometry "
-        "FROM bis.GeometricElement3d e, dgn_geom_stream(e.GeometryStream) gs "
+        "FROM bis.GeometricElement3d e, imodel_geom_stream(e.GeometryStream) gs "
         "WHERE e.ECInstanceId = ? AND gs.IsGeometry = 1"));
 
     stmt.BindId(1, elemId);
@@ -315,7 +315,7 @@ TEST_F(GeomStreamVTabTest, DisplayParams)
     ECSqlStatement stmt;
     ASSERT_EQ(ECSqlStatus::Success, stmt.Prepare(*m_db,
         "SELECT gs.Color, gs.Weight "
-        "FROM bis.GeometricElement3d e, dgn_geom_stream(e.GeometryStream) gs "
+        "FROM bis.GeometricElement3d e, imodel_geom_stream(e.GeometryStream) gs "
         "WHERE e.ECInstanceId = ? AND gs.IsGeometry = 1"));
 
     stmt.BindId(1, elemId);
@@ -362,7 +362,7 @@ TEST_F(GeomStreamVTabTest, Element2d)
     ECSqlStatement stmt;
     ASSERT_EQ(ECSqlStatus::Success, stmt.Prepare(*m_db,
         "SELECT gs.EntryIndex, gs.OpCode "
-        "FROM bis.GeometricElement2d e, dgn_geom_stream(e.GeometryStream) gs "
+        "FROM bis.GeometricElement2d e, imodel_geom_stream(e.GeometryStream) gs "
         "WHERE e.ECInstanceId = ?"));
 
     stmt.BindId(1, elem2dId);
@@ -402,7 +402,7 @@ TEST_F(GeomStreamVTabTest, GeometryPartReference)
     ECSqlStatement stmt;
     ASSERT_EQ(ECSqlStatus::Success, stmt.Prepare(*m_db,
         "SELECT gs.GeometryPartId, gs.PartOriginX, gs.PartOriginY, gs.PartOriginZ, gs.PartScale, gs.OpCode "
-        "FROM bis.GeometricElement3d e, dgn_geom_stream(e.GeometryStream) gs "
+        "FROM bis.GeometricElement3d e, imodel_geom_stream(e.GeometryStream) gs "
         "WHERE e.ECInstanceId = ? AND gs.GeometryPartId IS NOT NULL"));
 
     stmt.BindId(1, elemId);
@@ -429,7 +429,7 @@ TEST_F(GeomStreamVTabTest, GeometryPartReference)
     }
 
 /*---------------------------------------------------------------------------------**//**
-* Verify that dgn_geom_stream produces no rows (not an error) when GeometryStream is NULL.
+* Verify that imodel_geom_stream produces no rows (not an error) when GeometryStream is NULL.
 * This tests resilience against elements that exist but have no geometry.
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/
@@ -443,7 +443,7 @@ TEST_F(GeomStreamVTabTest, NullGeometryStream)
     // If there are no null geometry streams, this test simply passes with 0 rows.
     ECSqlStatement stmt;
     auto status = stmt.Prepare(*m_db,
-        "SELECT COUNT(*) FROM bis.GeometricElement3d e, dgn_geom_stream(e.GeometryStream) gs "
+        "SELECT COUNT(*) FROM bis.GeometricElement3d e, imodel_geom_stream(e.GeometryStream) gs "
         "WHERE e.GeometryStream IS NULL");
 
     // If the ECSQL prepares, it should return 0 rows, not an error
@@ -456,7 +456,7 @@ TEST_F(GeomStreamVTabTest, NullGeometryStream)
     }
 
 /*---------------------------------------------------------------------------------**//**
-* Verify that querying with schema-qualified name also works: DgnVLib.dgn_geom_stream
+* Verify that querying with schema-qualified name also works: IModelVLib.imodel_geom_stream
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/
 TEST_F(GeomStreamVTabTest, SchemaQualifiedName)
@@ -471,7 +471,7 @@ TEST_F(GeomStreamVTabTest, SchemaQualifiedName)
     ECSqlStatement stmt;
     ASSERT_EQ(ECSqlStatus::Success, stmt.Prepare(*m_db,
         "SELECT gs.EntryIndex, gs.OpCode "
-        "FROM bis.GeometricElement3d e, DgnVLib.dgn_geom_stream(e.GeometryStream) gs "
+        "FROM bis.GeometricElement3d e, IModelVLib.imodel_geom_stream(e.GeometryStream) gs "
         "WHERE e.ECInstanceId = ?"));
 
     stmt.BindId(1, elemId);
@@ -499,7 +499,7 @@ TEST_F(GeomStreamVTabTest, CountGeometryEntriesPerElement)
     ECSqlStatement stmt;
     ASSERT_EQ(ECSqlStatus::Success, stmt.Prepare(*m_db,
         "SELECT e.ECInstanceId, SUM(gs.IsGeometry) AS geomCount "
-        "FROM bis.GeometricElement3d e, dgn_geom_stream(e.GeometryStream) gs "
+        "FROM bis.GeometricElement3d e, imodel_geom_stream(e.GeometryStream) gs "
         "GROUP BY e.ECInstanceId"));
 
     int elementCount = 0;
@@ -529,7 +529,7 @@ TEST_F(GeomStreamVTabTest, EntryIndexMonotonic)
     ECSqlStatement stmt;
     ASSERT_EQ(ECSqlStatus::Success, stmt.Prepare(*m_db,
         "SELECT gs.EntryIndex "
-        "FROM bis.GeometricElement3d e, dgn_geom_stream(e.GeometryStream) gs "
+        "FROM bis.GeometricElement3d e, imodel_geom_stream(e.GeometryStream) gs "
         "WHERE e.ECInstanceId = ?"));
 
     stmt.BindId(1, elemId);
@@ -543,4 +543,94 @@ TEST_F(GeomStreamVTabTest, EntryIndexMonotonic)
         }
 
     EXPECT_GE(lastIndex, 0) << "Should have visited at least one entry";
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* Verify that imodel_geom_json returns valid JSON for a geometry entry.
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+TEST_F(GeomStreamVTabTest, GeomJsonScalarFunction)
+    {
+    SetupSeedProject();
+
+    auto el = InsertElement(Render::GeometryParams(m_defaultCategoryId));
+    ASSERT_TRUE(el.IsValid());
+    DgnElementId elemId = el->GetElementId();
+    SaveDb();
+
+    ECSqlStatement stmt;
+    ASSERT_EQ(ECSqlStatus::Success, stmt.Prepare(*m_db,
+        "SELECT imodel_geom_json(gs.GeometryBlob), gs.EntryType "
+        "FROM bis.GeometricElement3d e, imodel_geom_stream(e.GeometryStream) gs "
+        "WHERE e.ECInstanceId = ? AND gs.IsGeometry = 1"));
+
+    stmt.BindId(1, elemId);
+
+    bool foundJson = false;
+    while (BE_SQLITE_ROW == stmt.Step())
+        {
+        Utf8CP entryType = stmt.GetValueText(1);
+        // BRepEntity returns NULL — skip
+        if (entryType != nullptr && strcmp(entryType, "BRepEntity") == 0)
+            continue;
+
+        if (!stmt.IsValueNull(0))
+            {
+            Utf8CP json = stmt.GetValueText(0);
+            EXPECT_TRUE(json != nullptr && strlen(json) > 0) << "imodel_geom_json should return non-empty JSON";
+            foundJson = true;
+            }
+        }
+
+    EXPECT_TRUE(foundJson) << "Should find at least one geometry entry with JSON";
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* Verify that imodel_geom_entry_count returns the geometry entry count.
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+TEST_F(GeomStreamVTabTest, GeomEntryCountFunction)
+    {
+    SetupSeedProject();
+
+    auto el = InsertElement(Render::GeometryParams(m_defaultCategoryId));
+    ASSERT_TRUE(el.IsValid());
+    DgnElementId elemId = el->GetElementId();
+    SaveDb();
+
+    ECSqlStatement stmt;
+    ASSERT_EQ(ECSqlStatus::Success, stmt.Prepare(*m_db,
+        "SELECT imodel_geom_entry_count(e.GeometryStream) "
+        "FROM bis.GeometricElement3d e WHERE e.ECInstanceId = ?"));
+
+    stmt.BindId(1, elemId);
+    ASSERT_EQ(BE_SQLITE_ROW, stmt.Step());
+    EXPECT_FALSE(stmt.IsValueNull(0)) << "imodel_geom_entry_count should not be NULL";
+    int count = stmt.GetValueInt(0);
+    EXPECT_GT(count, 0) << "Should have at least one geometry entry";
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* Verify that imodel_geom_has_brep returns 0 or 1 (not NULL).
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+TEST_F(GeomStreamVTabTest, GeomHasBrepFunction)
+    {
+    SetupSeedProject();
+
+    auto el = InsertElement(Render::GeometryParams(m_defaultCategoryId));
+    ASSERT_TRUE(el.IsValid());
+    DgnElementId elemId = el->GetElementId();
+    SaveDb();
+
+    ECSqlStatement stmt;
+    ASSERT_EQ(ECSqlStatus::Success, stmt.Prepare(*m_db,
+        "SELECT imodel_geom_has_brep(e.GeometryStream) "
+        "FROM bis.GeometricElement3d e WHERE e.ECInstanceId = ?"));
+
+    stmt.BindId(1, elemId);
+    ASSERT_EQ(BE_SQLITE_ROW, stmt.Step());
+    EXPECT_FALSE(stmt.IsValueNull(0)) << "imodel_geom_has_brep should return 0 or 1";
+    int val = stmt.GetValueInt(0);
+    EXPECT_TRUE(val == 0 || val == 1) << "imodel_geom_has_brep should be 0 or 1";
     }

--- a/iModelCore/iModelPlatform/Tests/DgnProject/TestFixture/DgnDbTestFixtures.cpp
+++ b/iModelCore/iModelPlatform/Tests/DgnProject/TestFixture/DgnDbTestFixtures.cpp
@@ -172,7 +172,8 @@ DgnElementId DgnDbTestFixture::InsertElement2d(DgnModelId modelId, DgnCategoryId
         categoryId = m_defaultCategoryId;
 
     DgnElementPtr el = TestElement2d::Create(*m_db, modelId, categoryId, elementCode, 100);
-    return m_db->Elements().Insert(*el)->GetElementId();
+    DgnElementCPtr inserted = m_db->Elements().Insert(*el);
+    return inserted.IsValid() ? inserted->GetElementId() : DgnElementId();
     }
 
 /*---------------------------------------------------------------------------------**//**
@@ -202,7 +203,8 @@ DgnElementId DgnDbTestFixture::InsertElementUsingGeometryPart2d(DgnCodeCR gpCode
     if (SUCCESS != builder->Finish(*geomElem))
         return DgnElementId();
 
-    return m_db->Elements().Insert(*el)->GetElementId();
+    DgnElementCPtr inserted2d = m_db->Elements().Insert(*el);
+    return inserted2d.IsValid() ? inserted2d->GetElementId() : DgnElementId();
     }
 
 /*---------------------------------------------------------------------------------**//**

--- a/iModelCore/iModelPlatform/iModelPlatform.mke
+++ b/iModelCore/iModelPlatform/iModelPlatform.mke
@@ -231,6 +231,8 @@ $(CoreObjs)DgnDbSchema$(oext) :                     $(DgnCoreDir)DgnDbSchema.cpp
 
 $(CoreObjs)DgnSqlFuncs$(oext) :                     $(DgnCoreDir)DgnSqlFuncs.cpp ${MultiCompileDepends}
 
+$(CoreObjs)GeomStreamVTab$(oext) :                  $(DgnCoreDir)GeomStreamVTab.cpp $(DgnCoreDir)GeomStreamVTab.h ${MultiCompileDepends}
+
 $(CoreObjs)DgnUnits$(oext) :                        $(DgnCoreDir)DgnUnits.cpp $(iModelPlatformAPISrc)DgnDb.h $(iModelPlatformAPISrc)DgnDbTables.h ${MultiCompileDepends}
 
 $(CoreObjs)DgnCategory$(oext) :                     $(DgnCoreDir)DgnCategory.cpp $(iModelPlatformAPISrc)DgnDb.h $(iModelPlatformAPISrc)DgnCategory.h ${MultiCompileDepends}

--- a/iModelJsNodeAddon/IModelJsNative.cpp
+++ b/iModelJsNodeAddon/IModelJsNative.cpp
@@ -2636,17 +2636,6 @@ struct NativeDgnDb : BeObjectWrap<NativeDgnDb>, SQLiteOps<DgnDb>
         GetOpenedDb(info).m_codeValueBehavior = newBehavior;
     }
 
-    Napi::Value GetMaxGeomStreamVTabBytes(NapiInfoCR info) {
-        return Napi::Number::New(info.Env(), static_cast<double>(GetOpenedDb(info).GetMaxGeomStreamVTabBytes()));
-    }
-
-    void SetMaxGeomStreamVTabBytes(NapiInfoCR info) {
-        REQUIRE_ARGUMENT_NUMBER(0, bytes);
-        if (bytes < 1)
-            THROW_JS_IMODEL_NATIVE_EXCEPTION(info.Env(), "maxGeomStreamVTabBytes must be a positive number", IModelJsNativeErrorKey::BadArg);
-        GetOpenedDb(info).SetMaxGeomStreamVTabBytes(static_cast<size_t>(bytes));
-    }
-
     Napi::Value ComputeProjectExtents(NapiInfoCR info)
         {
         REQUIRE_ARGUMENT_BOOL(0, wantFullExtents);
@@ -3283,8 +3272,6 @@ struct NativeDgnDb : BeObjectWrap<NativeDgnDb>, SQLiteOps<DgnDb>
             InstanceMethod("saveLocalValue", &NativeDgnDb::SaveLocalValue),
             InstanceMethod("schemaToXmlString", &NativeDgnDb::SchemaToXmlString),
             InstanceMethod("setCodeValueBehavior", &NativeDgnDb::SetCodeValueBehavior),
-            InstanceMethod("getMaxGeomStreamVTabBytes", &NativeDgnDb::GetMaxGeomStreamVTabBytes),
-            InstanceMethod("setMaxGeomStreamVTabBytes", &NativeDgnDb::SetMaxGeomStreamVTabBytes),
             InstanceMethod("setGeometricModelTrackingEnabled", &NativeDgnDb::SetGeometricModelTrackingEnabled),
             InstanceMethod("setIModelDb", &NativeDgnDb::SetIModelDb),
             InstanceMethod("setIModelId", &NativeDgnDb::SetIModelId),
@@ -7157,6 +7144,21 @@ static void setMaxTileCacheSize(NapiInfoCR info) {
   JsInterop::GetNativeLogger().error("Invalid argument for setMaxTileCacheSize: expected an unsigned integer");
 }
 
+static Napi::Value getMaxGeomStreamVTabBytes(NapiInfoCR info) {
+  return Napi::Number::New(info.Env(), static_cast<double>(JsInterop::GetMaxGeomStreamVTabBytes()));
+}
+
+static void setMaxGeomStreamVTabBytes(NapiInfoCR info) {
+  if (info.Length() == 1 && info[0].IsNumber()) {
+    auto bytes = info[0].As<Napi::Number>().DoubleValue();
+    if (bytes >= 1) {
+      JsInterop::SetMaxGeomStreamVTabBytes(static_cast<size_t>(bytes));
+      return;
+    }
+  }
+  JsInterop::GetNativeLogger().error("Invalid argument for setMaxGeomStreamVTabBytes: expected a positive number");
+}
+
 static Napi::Value getLogger(NapiInfoCR info) {
   return s_jsLogger.GetJsLogger();
 }
@@ -7519,6 +7521,8 @@ static Napi::Object registerModule(Napi::Env env, Napi::Object exports) {
         Napi::PropertyDescriptor::Function(env, exports, "setCrashReporting", &setCrashReporting),
         Napi::PropertyDescriptor::Function(env, exports, "setCrashReportProperty", &setCrashReportProperty),
         Napi::PropertyDescriptor::Function(env, exports, "setMaxTileCacheSize", &setMaxTileCacheSize),
+        Napi::PropertyDescriptor::Function(env, exports, "getMaxGeomStreamVTabBytes", &getMaxGeomStreamVTabBytes),
+        Napi::PropertyDescriptor::Function(env, exports, "setMaxGeomStreamVTabBytes", &setMaxGeomStreamVTabBytes),
         Napi::PropertyDescriptor::Function(env, exports, "getTrueTypeFontMetadata", &getTrueTypeFontMetadata),
         Napi::PropertyDescriptor::Function(env, exports, "isRscFontData", &isRscFontData),
         Napi::PropertyDescriptor::Function(env, exports, "imageBufferFromImageSource", &imageBufferFromImageSource),

--- a/iModelJsNodeAddon/IModelJsNative.cpp
+++ b/iModelJsNodeAddon/IModelJsNative.cpp
@@ -2636,6 +2636,17 @@ struct NativeDgnDb : BeObjectWrap<NativeDgnDb>, SQLiteOps<DgnDb>
         GetOpenedDb(info).m_codeValueBehavior = newBehavior;
     }
 
+    Napi::Value GetMaxGeomStreamVTabBytes(NapiInfoCR info) {
+        return Napi::Number::New(info.Env(), static_cast<double>(GetOpenedDb(info).GetMaxGeomStreamVTabBytes()));
+    }
+
+    void SetMaxGeomStreamVTabBytes(NapiInfoCR info) {
+        REQUIRE_ARGUMENT_NUMBER(0, bytes);
+        if (bytes < 1)
+            THROW_JS_IMODEL_NATIVE_EXCEPTION(info.Env(), "maxGeomStreamVTabBytes must be a positive number", IModelJsNativeErrorKey::BadArg);
+        GetOpenedDb(info).SetMaxGeomStreamVTabBytes(static_cast<size_t>(bytes));
+    }
+
     Napi::Value ComputeProjectExtents(NapiInfoCR info)
         {
         REQUIRE_ARGUMENT_BOOL(0, wantFullExtents);
@@ -3272,6 +3283,8 @@ struct NativeDgnDb : BeObjectWrap<NativeDgnDb>, SQLiteOps<DgnDb>
             InstanceMethod("saveLocalValue", &NativeDgnDb::SaveLocalValue),
             InstanceMethod("schemaToXmlString", &NativeDgnDb::SchemaToXmlString),
             InstanceMethod("setCodeValueBehavior", &NativeDgnDb::SetCodeValueBehavior),
+            InstanceMethod("getMaxGeomStreamVTabBytes", &NativeDgnDb::GetMaxGeomStreamVTabBytes),
+            InstanceMethod("setMaxGeomStreamVTabBytes", &NativeDgnDb::SetMaxGeomStreamVTabBytes),
             InstanceMethod("setGeometricModelTrackingEnabled", &NativeDgnDb::SetGeometricModelTrackingEnabled),
             InstanceMethod("setIModelDb", &NativeDgnDb::SetIModelDb),
             InstanceMethod("setIModelId", &NativeDgnDb::SetIModelId),

--- a/iModelJsNodeAddon/IModelJsNative.cpp
+++ b/iModelJsNodeAddon/IModelJsNative.cpp
@@ -7151,12 +7151,12 @@ static Napi::Value getMaxGeomStreamVTabBytes(NapiInfoCR info) {
 static void setMaxGeomStreamVTabBytes(NapiInfoCR info) {
   if (info.Length() == 1 && info[0].IsNumber()) {
     auto bytes = info[0].As<Napi::Number>().DoubleValue();
-    if (bytes >= 1) {
+    if (std::isfinite(bytes) && bytes >= 1 && bytes <= static_cast<double>(std::numeric_limits<size_t>::max())) {
       JsInterop::SetMaxGeomStreamVTabBytes(static_cast<size_t>(bytes));
       return;
     }
   }
-  JsInterop::GetNativeLogger().error("Invalid argument for setMaxGeomStreamVTabBytes: expected a positive number");
+  JsInterop::GetNativeLogger().error("Invalid argument for setMaxGeomStreamVTabBytes: expected a positive finite number");
 }
 
 static Napi::Value getLogger(NapiInfoCR info) {

--- a/iModelJsNodeAddon/IModelJsNative.h
+++ b/iModelJsNodeAddon/IModelJsNative.h
@@ -581,6 +581,8 @@ public:
     static void GetTileTree(ICancellableP, DgnDbR db, Utf8StringCR id, Napi::Function& callback);
     static void GetTileContent(ICancellableP, DgnDbR db, Utf8StringCR treeId, Utf8StringCR tileId, Napi::Function& callback);
     static void SetMaxTileCacheSize(uint64_t maxBytes);
+    static size_t GetMaxGeomStreamVTabBytes();
+    static void SetMaxGeomStreamVTabBytes(size_t bytes);
 
     [[noreturn]] static void ThrowJsException(Utf8CP msg);
     static Json::Value ExecuteTest(DgnDbR, Utf8StringCR testName, Utf8StringCR params);

--- a/iModelJsNodeAddon/JsInterop.cpp
+++ b/iModelJsNodeAddon/JsInterop.cpp
@@ -15,6 +15,7 @@
     #include <Visualization/Visualization.h>
 #endif
 #include <DgnPlatform/EntityIdsChangeGroup.h>
+#include "../iModelCore/iModelPlatform/DgnCore/GeomStreamVTab.h"
 #include <chrono>
 #include <tuple>
 
@@ -1294,6 +1295,20 @@ ECInstanceId JsInterop::GetInstanceIdFromInstance(ECDbCR ecdb, BeJsConst jsonIns
 +---------------+---------------+---------------+---------------+---------------+------*/
 void JsInterop::SetMaxTileCacheSize(uint64_t maxBytes) {
   T_HOST.Visualization().SetMaxTileCacheSize(maxBytes);
+}
+
+/*---------------------------------------------------------------------------------**//**
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+size_t JsInterop::GetMaxGeomStreamVTabBytes() {
+    return GeomStreamModule::GetMaxGeomStreamVTabBytes();
+}
+
+/*---------------------------------------------------------------------------------**//**
+* @bsimethod
++---------------+---------------+---------------+---------------+---------------+------*/
+void JsInterop::SetMaxGeomStreamVTabBytes(size_t bytes) {
+    GeomStreamModule::SetMaxGeomStreamVTabBytes(bytes);
 }
 
 //---------------------------------------------------------------------------------------

--- a/iModelJsNodeAddon/api_package/ts/src/NativeLibrary.ts
+++ b/iModelJsNodeAddon/api_package/ts/src/NativeLibrary.ts
@@ -190,9 +190,9 @@ export declare namespace IModelJsNative {
 
   let logger: NativeLogger;
   function setMaxTileCacheSize(maxBytes: number): void;
-  /** Get the process-wide maximum uncompressed GeometryStream size (bytes) the dgn_geom_stream virtual table will decompose. Default: 50 MB. */
+  /** Get the process-wide maximum uncompressed GeometryStream size (bytes) the imodel_geom_stream virtual table will decompose. Default: 50 MB. */
   function getMaxGeomStreamVTabBytes(): number;
-  /** Set the process-wide maximum uncompressed GeometryStream size (bytes) the dgn_geom_stream virtual table will decompose. Minimum enforced: 4 KB. Blobs exceeding this are silently skipped. */
+  /** Set the process-wide maximum uncompressed GeometryStream size (bytes) the imodel_geom_stream virtual table will decompose. Minimum enforced: 4 KB. Blobs exceeding this are silently skipped. */
   function setMaxGeomStreamVTabBytes(bytes: number): void;
   function getTileVersionInfo(): TileVersionInfo;
   function setCrashReporting(cfg: NativeCrashReportingConfig): void;

--- a/iModelJsNodeAddon/api_package/ts/src/NativeLibrary.ts
+++ b/iModelJsNodeAddon/api_package/ts/src/NativeLibrary.ts
@@ -190,6 +190,10 @@ export declare namespace IModelJsNative {
 
   let logger: NativeLogger;
   function setMaxTileCacheSize(maxBytes: number): void;
+  /** Get the process-wide maximum uncompressed GeometryStream size (bytes) the dgn_geom_stream virtual table will decompose. Default: 50 MB. */
+  function getMaxGeomStreamVTabBytes(): number;
+  /** Set the process-wide maximum uncompressed GeometryStream size (bytes) the dgn_geom_stream virtual table will decompose. Minimum enforced: 4 KB. Blobs exceeding this are silently skipped. */
+  function setMaxGeomStreamVTabBytes(bytes: number): void;
   function getTileVersionInfo(): TileVersionInfo;
   function setCrashReporting(cfg: NativeCrashReportingConfig): void;
   function setCrashReportProperty(name: string, value: string | undefined): void;
@@ -771,10 +775,6 @@ export declare namespace IModelJsNative {
     public setITwinId(guid: GuidString): DbResult;
     public setBusyTimeout(ms: number): void;
     public setCodeValueBehavior(newBehavior: "exact" | "trim-unicode-whitespace"): void;
-    /** Get the maximum uncompressed GeometryStream size (bytes) the dgn_geom_stream virtual table will process. Default: 50 MB. */
-    public getMaxGeomStreamVTabBytes(): number;
-    /** Set the maximum uncompressed GeometryStream size (bytes) the dgn_geom_stream virtual table will process. Minimum enforced: 4096 bytes. */
-    public setMaxGeomStreamVTabBytes(bytes: number): void;
     public simplifyElementGeometry(simplifyArgs: any): IModelStatus;
     public startCreateChangeset(): ChangesetFileProps;
     public startProfiler(scopeName?: string, scenarioName?: string, overrideFile?: boolean, computeExecutionPlan?: boolean): DbResult;

--- a/iModelJsNodeAddon/api_package/ts/src/NativeLibrary.ts
+++ b/iModelJsNodeAddon/api_package/ts/src/NativeLibrary.ts
@@ -771,6 +771,10 @@ export declare namespace IModelJsNative {
     public setITwinId(guid: GuidString): DbResult;
     public setBusyTimeout(ms: number): void;
     public setCodeValueBehavior(newBehavior: "exact" | "trim-unicode-whitespace"): void;
+    /** Get the maximum uncompressed GeometryStream size (bytes) the dgn_geom_stream virtual table will process. Default: 50 MB. */
+    public getMaxGeomStreamVTabBytes(): number;
+    /** Set the maximum uncompressed GeometryStream size (bytes) the dgn_geom_stream virtual table will process. Minimum enforced: 4096 bytes. */
+    public setMaxGeomStreamVTabBytes(bytes: number): void;
     public simplifyElementGeometry(simplifyArgs: any): IModelStatus;
     public startCreateChangeset(): ChangesetFileProps;
     public startProfiler(scopeName?: string, scenarioName?: string, overrideFile?: boolean, computeExecutionPlan?: boolean): DbResult;


### PR DESCRIPTION
itwinjs-core: https://github.com/iTwin/itwinjs-core/pull/9239

## Summary

Introduces the `imodel_geom_stream` ECSQL virtual table and five companion scalar functions that expose GeometryStream blobs to pure-SQL queries, enabling inspection and analytics over element geometry without any native C++ code.

Closes https://github.com/iTwin/itwinjs-backlog/issues/2036

## Changes

- **GeomStreamVTab.h/cpp** — New ECDb virtual table module (`imodel_geom_stream`) that decomposes a GeometryStream blob into one row per geometry entry, exposing symbology, bounding-box, part-instance, text, and raw GeometryBlob columns
- **DgnSqlFuncs.cpp** — Implements and registers five new scalar functions (`imodel_geom_json`, `imodel_geom_text`, `imodel_geom_entry_count`, `imodel_geom_part_ids`, `imodel_geom_has_brep`) alongside `imodel_geom_stream`
- **SchemaManagerDispatcher.cpp** — Fix inverted boolean logic in virtual schema validation
- **GeomStreamVTab_Test.cpp** — Tests covering basic iteration, BRep filtering, GeometryPart lookup, symbology extraction, and NULL/empty blob handling
- **iModelPlatform.mke** — Build system updated to include new source files
- **IModelJsNative / JsInterop / NativeLibrary.ts** — Expose `SetMaxGeomStreamVTabBytes` to TypeScript for controlling the per-process size limit

---

## New Virtual Table

### `imodel_geom_stream(GeometryStream)`

Decomposes a raw GeometryStream blob into one row per geometry entry.

| Column | Type | Description |
|---|---|---|
| `EntryIndex` | int | Zero-based position of the entry in the stream |
| `OpCode` | string | Raw opcode name (e.g. `PointPrimitive`, `ParasolidBRep`) |
| `EntryType` | string | Friendly type name (e.g. `PointPrimitive`, `BRepEntity`, `Arc3d`, `Header`, `GeometryPart`) |
| `IsGeometry` | int | 1 if this entry is a renderable geometry primitive |
| `SubCategoryId` | long | Active sub-category ID from accumulated symbology |
| `Color` | int | Override color (TBGR) |
| `Weight` | int | Line weight override |
| `LineStyle` | int | Line style override |
| `Transparency` | double | Transparency override (0–1) |
| `GeomClass` | int | Geometry class |
| `DisplayPriority` | int | Display priority override |
| `MaterialId` | long | Material ID override |
| `GeometryPartId` | long | ID of the referenced GeometryPart element (part instances only) |
| `PartOriginX/Y/Z` | double | Part instance origin |
| `PartYaw/Pitch/Roll` | double | Part instance orientation (degrees) |
| `PartScale` | double | Uniform part instance scale |
| `RangeLowX/Y/Z` | double | Sub-graphic range low corner |
| `RangeHighX/Y/Z` | double | Sub-graphic range high corner |
| `HeaderFlags` | int | Geometry stream header flags |
| `TextContent` | string | Text string content (TextString entries only) |
| `GeometryBlob` | blob | Raw `[4-byte opcode][flatbuffer payload]` — pass to `imodel_geom_json()` |

**Example queries:**

```sql
-- Iterate every geometry entry in a specific element
SELECT gs.EntryIndex, gs.EntryType, gs.IsGeometry
FROM BisCore.GeometricElement3d e, imodel_geom_stream(e.GeometryStream) gs
WHERE e.ECInstanceId = ?

-- Count geometry primitives per element
SELECT e.ECInstanceId, COUNT(*) AS GeomCount
FROM BisCore.GeometricElement3d e, imodel_geom_stream(e.GeometryStream) gs
WHERE gs.IsGeometry = 1
GROUP BY e.ECInstanceId

-- Find all elements with BRep geometry using the virtual table
SELECT DISTINCT e.ECInstanceId
FROM BisCore.GeometricElement3d e, imodel_geom_stream(e.GeometryStream) gs
WHERE gs.EntryType = 'BRepEntity'

-- Extract per-entry bounding boxes
SELECT e.ECInstanceId, gs.EntryIndex,
       gs.RangeLowX, gs.RangeLowY, gs.RangeLowZ,
       gs.RangeHighX, gs.RangeHighY, gs.RangeHighZ
FROM BisCore.GeometricElement3d e, imodel_geom_stream(e.GeometryStream) gs
WHERE gs.IsGeometry = 1

-- List all GeometryPart references with placement
SELECT e.ECInstanceId, gs.GeometryPartId, gs.PartOriginX, gs.PartOriginY, gs.PartOriginZ, gs.PartScale
FROM BisCore.GeometricElement3d e, imodel_geom_stream(e.GeometryStream) gs
WHERE gs.EntryType = 'GeometryPart'

-- Read text annotations from geometry streams
SELECT e.ECInstanceId, gs.TextContent
FROM BisCore.GeometricElement3d e, imodel_geom_stream(e.GeometryStream) gs
WHERE gs.EntryType = 'TextString'
  AND gs.TextContent IS NOT NULL
```

---

## New Scalar Functions

### `imodel_geom_json(GeometryBlob) → TEXT`

Decodes a `GeometryBlob` column value (produced by `imodel_geom_stream`) into an iModel.js-compatible geometry JSON string. BRep entries return `NULL`.

```sql
-- Convert each geometry entry to iModel.js geometry JSON
SELECT gs.EntryIndex, gs.EntryType, imodel_geom_json(gs.GeometryBlob) AS GeomJSON
FROM BisCore.GeometricElement3d e, imodel_geom_stream(e.GeometryStream) gs
WHERE e.ECInstanceId = ?
  AND gs.IsGeometry = 1
  AND gs.EntryType != 'BRepEntity'
```

---

### `imodel_geom_text(GeometryStream) → TEXT`

Extracts all `TextString` content from a raw GeometryStream blob. Multiple text entries are joined with newlines. Returns `NULL` if none found.

```sql
-- Find all elements containing specific text in their geometry
SELECT e.ECInstanceId, imodel_geom_text(e.GeometryStream) AS TextContent
FROM BisCore.GeometricElement3d e
WHERE imodel_geom_text(e.GeometryStream) LIKE '%valve%'
```

---

### `imodel_geom_entry_count(GeometryStream) → INTEGER`

Counts renderable geometry primitives (`IsGeometry = 1`) in a raw GeometryStream blob without full geometry deserialization. Returns `NULL` on failure.

```sql
-- Find elements with more than 10 geometry entries
SELECT e.ECInstanceId, imodel_geom_entry_count(e.GeometryStream) AS GeomCount
FROM BisCore.GeometricElement3d e
WHERE imodel_geom_entry_count(e.GeometryStream) > 10
ORDER BY GeomCount DESC
```

---

### `imodel_geom_part_ids(GeometryStream) → TEXT`

Returns a JSON array of all `GeometryPartId` references (as hex strings) in a raw GeometryStream blob. Returns `NULL` if none found.

```sql
-- List elements and the GeometryPart IDs they reference
SELECT e.ECInstanceId, imodel_geom_part_ids(e.GeometryStream) AS PartIds
FROM BisCore.GeometricElement3d e
WHERE imodel_geom_part_ids(e.GeometryStream) IS NOT NULL

-- Find all elements that reference a specific GeometryPart (by hex id)
SELECT e.ECInstanceId
FROM BisCore.GeometricElement3d e
WHERE imodel_geom_part_ids(e.GeometryStream) LIKE '%0x1a3%'
```

---

### `imodel_geom_has_brep(GeometryStream) → INTEGER`

Returns `1` if the GeometryStream contains any Parasolid BRep geometry, `0` otherwise. Returns `NULL` on failure.

```sql
-- Find all elements that contain BRep geometry
SELECT e.ECInstanceId
FROM BisCore.GeometricElement3d e
WHERE imodel_geom_has_brep(e.GeometryStream) = 1

-- Count BRep vs non-BRep elements in a model
SELECT imodel_geom_has_brep(e.GeometryStream) AS HasBRep, COUNT(*) AS ElementCount
FROM BisCore.GeometricElement3d e
GROUP BY HasBRep
```
