### PR TITLE
Adjust code to build successfully with Clang 22

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ ipch
 # So we'll ignore specific files we know we don't want tracked.
 .vscode/c_cpp_properties.json
 .vscode/settings.json
+.vscode/browse.vc.db*
 
 # local backup files
 *.orig

--- a/iModelCore/libsrc/csmap/Source/CS_hlApi.c
+++ b/iModelCore/libsrc/csmap/Source/CS_hlApi.c
@@ -125,7 +125,7 @@ error:
 	if (csDiagnostic != 0)
 	{
 		CS_errmsg (msgBufr,sizeof (msgBufr));
-		fprintf (csDiagnostic,"Error detected in %s: %s\n",modl_name,msgBufr);
+		CS_fprintf (csDiagnostic,"Error detected in %s: %s\n",modl_name,msgBufr);
 	}
 	return (-cs_Error);
 }
@@ -199,7 +199,7 @@ error:
 	if (csDiagnostic != 0)
 	{
 		CS_errmsg (msgBufr,sizeof (msgBufr));
-		fprintf (csDiagnostic,"Error detected in %s: %s\n",modl_name,msgBufr);
+		CS_fprintf (csDiagnostic,"Error detected in %s: %s\n",modl_name,msgBufr);
 	}
 	return (-cs_Error);
 }

--- a/iModelCore/libsrc/csmap/Source/CS_supprt.c
+++ b/iModelCore/libsrc/csmap/Source/CS_supprt.c
@@ -201,7 +201,7 @@ int EXP_LVL7 CS_bins (csFILE *strm,long32_t start,long32_t eofPos,int rs,Const v
 		rd_cnt = CS_fread (buff,1,(unsigned)rs,strm);
 		if (rd_cnt != (size_t)rs)
 		{
-			if (ferror (strm)) CS_erpt (cs_IOERR);
+			if (CS_ferror (strm)) CS_erpt (cs_IOERR);
 			else			   CS_erpt (cs_INV_FILE);
 			goto error;
 		}
@@ -263,7 +263,7 @@ int EXP_LVL7 CS_bins (csFILE *strm,long32_t start,long32_t eofPos,int rs,Const v
 				rd_cnt = CS_fread (buff,1,(unsigned)rs,strm);
 				if (rd_cnt != (size_t)rs)
 				{
-					if (ferror (strm)) CS_erpt (cs_IOERR);
+					if (CS_ferror (strm)) CS_erpt (cs_IOERR);
 					else               CS_erpt (cs_INV_FILE);
 					goto error;
 				}
@@ -894,7 +894,7 @@ int EXP_LVL7 CS_ips (csFILE *strm,short rs,long32_t eofPos,int (*comp)(Const voi
 	rd_cnt = CS_fread (buff,1,buf_siz,strm);
 	if (rd_cnt != buf_siz)
 	{
-		if (ferror (strm)) CS_erpt (cs_IOERR);
+		if (CS_ferror (strm)) CS_erpt (cs_IOERR);
 		else               CS_erpt (cs_INV_FILE);
 		goto error;
 	}
@@ -912,7 +912,7 @@ int EXP_LVL7 CS_ips (csFILE *strm,short rs,long32_t eofPos,int (*comp)(Const voi
 	wr_cnt = CS_fwrite (buff,1,buf_siz,strm);
 	if (wr_cnt != buf_siz)
 	{
-		if (ferror (strm)) CS_erpt (cs_IOERR);
+		if (CS_ferror (strm)) CS_erpt (cs_IOERR);
 		else               CS_erpt (cs_DISK_FULL);
 		goto error;
 	}

--- a/iModelCore/libsrc/csmap/Source/CSdatumCatalog.c
+++ b/iModelCore/libsrc/csmap/Source/CSdatumCatalog.c
@@ -586,7 +586,7 @@ int CSwriteDatumCatalog (struct csDatumCatalog_ *__This,Const char *path)
 	extern char csErrnam [];
 
 	char *cp;
-	FILE *catFstr;
+	csFILE *catFstr;
 	struct csDatumCatalogEntry_* entryPtr;
 	char newDir [csMAXPATH];
 	char baseDir [csMAXPATH];
@@ -622,7 +622,7 @@ int CSwriteDatumCatalog (struct csDatumCatalog_ *__This,Const char *path)
 	for (entryPtr = __This->listHead;entryPtr != NULL;entryPtr = entryPtr->next)
 	{
 		CSwriteDatumCatalogEntry (entryPtr,catFstr,baseDir);
-		if (ferror (catFstr))
+		if (CS_ferror (catFstr))
 		{
 			CS_stncp (csErrnam,newDir,MAXPATH);
 			CS_erpt (cs_IOERR);


### PR DESCRIPTION
Summary
Clang 22 promotes -Wincompatible-pointer-types to a hard error by default. This surfaced a handful of long-standing call sites in our vendored CS-MAP (OSGeo CS-MAP 14.06, SVN rev 2778) that bypass Bentley's csFILE / CS_* stdio wrappers and pass csFILE * directly to libc fprintf / ferror, or declare a local as FILE * while assigning CS_fopen's csFILE * return.

The wrappers (CS_fprintf, CS_ferror, ...) are already used dozens of times in these same files under the GEOCOORD_ENHANCEMENT build, where csFILE is a distinct type (struct _csFile) - the failing sites were simply missed when the wrappers were introduced. The wrappers reduce to plain libc when GEOCOORD_ENHANCEMENT is not defined, so the change is a no-op in that build mode.

Upstream CS-MAP is effectively frozen at 14.06 (~3 years, no new releases), so an upstream bump is not an option; in-place patches are the established pattern in this tree (cf. prior compiler-bump commits like "Fix Xcode 15.4 errors", "C++20 Support").

.gitignore - ignore .vscode/browse.vc.db* (Microsoft C/C++ extension's per-user IntelliSense Tag Parser cache, ~150 MB; placed in the existing per-file vscode ignore section since launch.json is intentionally tracked)