### PR TITLE
WIP Helper function to maintain percision from jsoncpp in RapidJson

### DIFF
--- a/.github/skills/bentley-build/SKILL.md
+++ b/.github/skills/bentley-build/SKILL.md
@@ -145,6 +145,64 @@ bb -s "imodel-native-internal:build/strategies/iModelJsNodeAddon" \
 
 ---
 
+## Running Unit Tests
+
+Unit tests use Google Test (gtest). Each module has test parts with `DeferType="BuildUnitTests"` or `DeferType="RunUnitTests"` — these are NOT built by default strategies.
+
+### Build and run tests for a module
+
+```bash
+# Full form: build and run
+bb -r <repo> -f <PartFile> -p RunGtest build
+
+# Examples:
+bb -r imodel-native -f iModelCore/iModelPlatform/iModelPlatform -p RunGtest build
+bb -r imodel-native-internal -f iModelCore/Visualization/Visualization -p RunGtest build
+bb -r imodel-native -f iModelCore/ECDb/ECDb -p RunGtest build
+bb -r imodel-native -f iModelCore/GeoCoord/GeoCoord -p RunGtest build
+```
+
+### Shorthand: `bb re`
+
+The `re` (rebuild) action supports a `partfile:partname` shorthand:
+
+```bash
+# Rebuild just the test binary (no SubParts)
+bb re dgnplatform:unittests-nonpublished
+
+# Rebuild and package the gtest runner
+bb re dgnplatform:gtest
+```
+
+### Filtering tests
+
+Set `GTEST_FILTER` before running, or pass `--gtest_filter` to the test executable directly:
+
+```bash
+# Via environment variable (affects bb RunGtest)
+set GTEST_FILTER=ContentIdQualifierTests.ProducesConsistentProjectExtentsHash
+
+# Or run the test executable directly after building
+dgnplatformtest --gtest_filter=GeometryClipper*
+VisualizationTest --gtest_filter=ContentIdQualifier*
+```
+
+Test executables are output to the gtest product directory under `$(OutRoot)`.
+
+### Common test part names
+
+| Module | PartFile | Build Part | Run Part |
+|--------|----------|------------|----------|
+| DgnPlatform | `iModelCore/iModelPlatform/iModelPlatform` | `Gtest` | `RunGtest` |
+| ECDb | `iModelCore/ECDb/ECDb` | `Gtest` | `RunGtest` |
+| GeoCoord | `iModelCore/GeoCoord/GeoCoord` | `Gtest` | `RunGtest` |
+| Visualization | `iModelCore/Visualization/Visualization` (internal) | `Gtest` | `RunGtest` |
+
+> **Tip:** To find test part names for any module, grep the PartFile:
+> `grep -i "gtest\|unittest" <path>.PartFile.xml`
+
+---
+
 ## Part Files (.PartFile.xml)
 
 ### Key PartFile locations (relative to `src/imodel-native/`)

--- a/iModelCore/Bentley/BeRapidJson/PublicAPI/BeRapidJson/BeJsValue.h
+++ b/iModelCore/Bentley/BeRapidJson/PublicAPI/BeRapidJson/BeJsValue.h
@@ -1012,8 +1012,10 @@ public:
         m_val = new BeRapidJsonValue(&m_doc, m_doc.GetAllocator());
         return *this;
         }
-    // replace the content of this document with the parsed value of stringified JSON
-    void Parse(Utf8CP jsonString) { m_doc.Parse(jsonString); }
+    // replace the content of this document with the parsed value of stringified JSON.
+    // kParseFullPrecisionFlag ensures doubles are parsed with correctly-rounded (strtod-equivalent)
+    // precision, matching jsoncpp's parser behavior. Without it, some doubles may differ by 1 ULP.
+    void Parse(Utf8CP jsonString) { m_doc.Parse<rapidjson::kParseFullPrecisionFlag>(jsonString); }
     // replace the content of this document with the parsed value of stringified JSON
     void Parse(std::string const& jsonString) { Parse(jsonString.c_str()); }
 

--- a/iModelCore/Bentley/BeRapidJson/PublicAPI/BeRapidJson/BeJsValue.h
+++ b/iModelCore/Bentley/BeRapidJson/PublicAPI/BeRapidJson/BeJsValue.h
@@ -1012,12 +1012,15 @@ public:
         m_val = new BeRapidJsonValue(&m_doc, m_doc.GetAllocator());
         return *this;
         }
-    // replace the content of this document with the parsed value of stringified JSON.
-    // kParseFullPrecisionFlag ensures doubles are parsed with correctly-rounded (strtod-equivalent)
-    // precision, matching jsoncpp's parser behavior. Without it, some doubles may differ by 1 ULP.
-    void Parse(Utf8CP jsonString) { m_doc.Parse<rapidjson::kParseFullPrecisionFlag>(jsonString); }
+    // replace the content of this document with the parsed value of stringified JSON
+    void Parse(Utf8CP jsonString) { m_doc.Parse(jsonString); }
     // replace the content of this document with the parsed value of stringified JSON
     void Parse(std::string const& jsonString) { Parse(jsonString.c_str()); }
+    // Parse with full-precision (strtod-equivalent) double conversion. Slower than Parse() but
+    // guarantees correctly-rounded IEEE 754 doubles, matching jsoncpp's parser. Use when parsed
+    // double values must be bit-identical to jsoncpp-parsed results (e.g. for hashing raw bytes).
+    void ParseFullPrecision(Utf8CP jsonString) { m_doc.Parse<rapidjson::kParseFullPrecisionFlag>(jsonString); }
+    void ParseFullPrecision(std::string const& jsonString) { ParseFullPrecision(jsonString.c_str()); }
 
     bool hasParseError() { return m_doc.HasParseError(); }
     void PurgeNulls() { PurgeNulls(m_doc); }

--- a/iModelCore/Bentley/BeRapidJson/PublicAPI/BeRapidJson/BeJsValue.h
+++ b/iModelCore/Bentley/BeRapidJson/PublicAPI/BeRapidJson/BeJsValue.h
@@ -62,11 +62,7 @@ public:
         }
 
         char buffer[40];
-#if defined(_MSC_VER) && defined(__STDC_SECURE_LIB__)
-        sprintf_s(buffer, sizeof(buffer), "%#.17g", d);
-#else
-        sprintf(buffer, "%#.17g", d);
-#endif
+        snprintf(buffer, sizeof(buffer), "%#.17g", d);
 
         // Trailing zero cleanup matching jsoncpp behavior exactly:
         char* ch = buffer + strlen(buffer) - 1;

--- a/iModelCore/Bentley/BeRapidJson/PublicAPI/BeRapidJson/BeJsValue.h
+++ b/iModelCore/Bentley/BeRapidJson/PublicAPI/BeRapidJson/BeJsValue.h
@@ -34,6 +34,68 @@ struct BeJsConst;
 enum StringifyFormat {
     Default,
     Indented,
+    Precision17, //!< Format doubles with sprintf "%#.17g" (same as jsoncpp). Use when output string must be byte-identical to legacy jsoncpp serialization.
+};
+
+//=======================================================================================
+//! A custom RapidJSON writer that formats doubles using sprintf "%#.17g" with trailing
+//! zero cleanup, producing output byte-identical to jsoncpp's valueToString(double).
+//! This is necessary for backward compatibility where JSON string hashes must not change.
+// @bsiclass
+//=======================================================================================
+template<typename OutputStream>
+class JsonCppCompatWriter : public rapidjson::Writer<OutputStream> {
+    using Base = rapidjson::Writer<OutputStream>;
+public:
+    explicit JsonCppCompatWriter(OutputStream& os) : Base(os) {}
+
+    bool Double(double d) {
+        this->Prefix(rapidjson::kNumberType);
+        if (std::isnan(d) || std::isinf(d)) {
+            // Match jsoncpp: NaN/Inf → "null"
+            rapidjson::PutReserve(*this->os_, 4);
+            rapidjson::PutUnsafe(*this->os_, 'n');
+            rapidjson::PutUnsafe(*this->os_, 'u');
+            rapidjson::PutUnsafe(*this->os_, 'l');
+            rapidjson::PutUnsafe(*this->os_, 'l');
+            return this->EndValue(true);
+        }
+
+        char buffer[40];
+#if defined(_MSC_VER) && defined(__STDC_SECURE_LIB__)
+        sprintf_s(buffer, sizeof(buffer), "%#.17g", d);
+#else
+        sprintf(buffer, "%#.17g", d);
+#endif
+
+        // Trailing zero cleanup matching jsoncpp behavior exactly:
+        char* ch = buffer + strlen(buffer) - 1;
+        // If last char is '.', append '0' (e.g. "1." → "1.0")
+        if (*ch == '.') {
+            *(ch + 1) = '0';
+            *(ch + 2) = '\0';
+        } else if (*ch == '0') {
+            // Truncate trailing zeros after decimal point, keeping at least one
+            while (ch > buffer && *ch == '0')
+                --ch;
+            char* last_nonzero = ch;
+            while (ch >= buffer) {
+                if (*ch == '.') {
+                    *(last_nonzero + 2) = '\0';
+                    break;
+                } else if (*ch >= '0' && *ch <= '9') {
+                    --ch;
+                } else {
+                    break;
+                }
+            }
+        }
+
+        rapidjson::PutReserve(*this->os_, 40);
+        for (char* p = buffer; *p; ++p)
+            rapidjson::PutUnsafe(*this->os_, static_cast<typename OutputStream::Ch>(*p));
+        return this->EndValue(true);
+    }
 };
 //=======================================================================================
 // @internal
@@ -901,6 +963,9 @@ private:
         if (format == StringifyFormat::Indented) {
             rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(buffer);
             writer.SetIndent(' ', 3);
+            m_value->Accept(writer);
+        } else if (format == StringifyFormat::Precision17) {
+            JsonCppCompatWriter<rapidjson::StringBuffer> writer(buffer);
             m_value->Accept(writer);
         } else {
             rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);

--- a/iModelCore/GeoCoord/Tests/NonPublished/BaseEllipsoidUnitTests.cpp
+++ b/iModelCore/GeoCoord/Tests/NonPublished/BaseEllipsoidUnitTests.cpp
@@ -106,9 +106,10 @@ TEST_F(BaseEllipsoidUnitTests, CreateAFullySelfContainedEllipsoid_Test1)
     GeoCoordinates::EllipsoidP theEllipsoid = const_cast<GeoCoordinates::EllipsoidP>(GeoCoordinates::Ellipsoid::CreateEllipsoid());
 
     Utf8String errorMessage;
-    // DO NOT CHANGE TO BeJsDocument — RapidJSON's number parser may produce slightly different doubles than
-    // strtod() for values exceeding double precision, causing exact equality comparisons against C++ literals to fail.
-    ASSERT_TRUE(SUCCESS == theEllipsoid->FromJson(Json::Value::From(customEllipsoid1), errorMessage));
+    // ParseFullPrecision uses strtod-equivalent parsing to match jsoncpp behavior for exact double equality.
+    BeJsDocument parsedEllipsoid;
+    parsedEllipsoid.ParseFullPrecision(customEllipsoid1);
+    ASSERT_TRUE(SUCCESS == theEllipsoid->FromJson(parsedEllipsoid, errorMessage));
     Utf8String source;
     EXPECT_TRUE(Utf8String(theEllipsoid->GetName()) == "CustomEllipsoid");
     EXPECT_TRUE(Utf8String(theEllipsoid->GetDescription()) == "Custom ellipsoid description");

--- a/iModelCore/GeoCoord/Tests/NonPublished/BaseGCSUnitTests.cpp
+++ b/iModelCore/GeoCoord/Tests/NonPublished/BaseGCSUnitTests.cpp
@@ -3041,9 +3041,10 @@ TEST_F(BaseGCSUnitTests, CreateAFullySelfContainedDatumWithCustomEllipsoid_Test)
     GeoCoordinates::DatumP theDatum = const_cast<GeoCoordinates::DatumP>(GeoCoordinates::Datum::CreateDatum());
 
     Utf8String errorMessage;
-    // DO NOT CHANGE TO BeJsDocument — RapidJSON's number parser may produce slightly different doubles than
-    // strtod() for values exceeding double precision, causing exact equality comparisons against C++ literals to fail.
-    ASSERT_TRUE(SUCCESS == theDatum->FromJson(Json::Value::From(customDatum3), errorMessage));
+    // ParseFullPrecision uses strtod-equivalent parsing to match jsoncpp behavior for exact double equality.
+    BeJsDocument parsedDatum;
+    parsedDatum.ParseFullPrecision(customDatum3);
+    ASSERT_TRUE(SUCCESS == theDatum->FromJson(parsedDatum, errorMessage));
     Utf8String source;
 
     EXPECT_TRUE(Utf8String(theDatum->GetName()) == "CustomDatum3");
@@ -3132,8 +3133,10 @@ TEST_F(BaseGCSUnitTests, CreateAFullySelfContainedDatumWithCustomEllipsoidButFil
     GeoCoordinates::DatumP theDatum = const_cast<GeoCoordinates::DatumP>(GeoCoordinates::Datum::CreateDatum());
 
     Utf8String errorMessage;
-    // DO NOT CHANGE TO BeJsDocument — see comment in CreateAFullySelfContainedDatumWithCustomEllipsoid_Test
-    ASSERT_TRUE(SUCCESS == theDatum->FromJson(Json::Value::From(customDatum4), errorMessage));
+    // ParseFullPrecision uses strtod-equivalent parsing to match jsoncpp behavior for exact double equality.
+    BeJsDocument parsedDatum;
+    parsedDatum.ParseFullPrecision(customDatum4);
+    ASSERT_TRUE(SUCCESS == theDatum->FromJson(parsedDatum, errorMessage));
     Utf8String source;
 
 
@@ -3225,8 +3228,10 @@ TEST_F(BaseGCSUnitTests, CreateAFullySelfContainedDatumWithCustomEllipsoidButFil
     GeoCoordinates::DatumP theDatum = const_cast<GeoCoordinates::DatumP>(GeoCoordinates::Datum::CreateDatum());
 
     Utf8String errorMessage;
-    // DO NOT CHANGE TO BeJsDocument — see comment in CreateAFullySelfContainedDatumWithCustomEllipsoid_Test
-    ASSERT_TRUE(SUCCESS == theDatum->FromJson(Json::Value::From(customDatum4), errorMessage));
+    // ParseFullPrecision uses strtod-equivalent parsing to match jsoncpp behavior for exact double equality.
+    BeJsDocument parsedDatum;
+    parsedDatum.ParseFullPrecision(customDatum4);
+    ASSERT_TRUE(SUCCESS == theDatum->FromJson(parsedDatum, errorMessage));
     Utf8String source;
 
 
@@ -3318,8 +3323,10 @@ TEST_F(BaseGCSUnitTests, CreateAFullySelfContainedDatumWithCustomEllipsoidButFil
     GeoCoordinates::DatumP theDatum = const_cast<GeoCoordinates::DatumP>(GeoCoordinates::Datum::CreateDatum());
 
     Utf8String errorMessage;
-    // DO NOT CHANGE TO BeJsDocument — see comment in CreateAFullySelfContainedDatumWithCustomEllipsoid_Test
-    ASSERT_TRUE(SUCCESS == theDatum->FromJson(Json::Value::From(customDatum5), errorMessage));
+    // ParseFullPrecision uses strtod-equivalent parsing to match jsoncpp behavior for exact double equality.
+    BeJsDocument parsedDatum;
+    parsedDatum.ParseFullPrecision(customDatum5);
+    ASSERT_TRUE(SUCCESS == theDatum->FromJson(parsedDatum, errorMessage));
     Utf8String source;
 
     EXPECT_TRUE(Utf8String(theDatum->GetName()) == "CustomDatum5");

--- a/iModelCore/GeoCoord/Tests/NonPublished/GCSUnitTests.cpp
+++ b/iModelCore/GeoCoord/Tests/NonPublished/GCSUnitTests.cpp
@@ -3677,9 +3677,7 @@ TEST_F (GCSUnitTests, GCSTransformFromJsonSpecific)
 
         GeoCoordinates::BaseGCSPtr currentGCS = GeoCoordinates::BaseGCS::CreateGCS();
 
-        // ParseFullPrecision uses strtod-equivalent parsing to match jsoncpp behavior for exact double equality.
-        BeJsDocument result;
-        result.ParseFullPrecision(theJson);
+        BeJsDocument result(theJson);
         EXPECT_FALSE(result.hasParseError());
 
         Utf8String errMessage;
@@ -3702,9 +3700,7 @@ TEST_F (GCSUnitTests, GCSTransformFromJsonError1)
 
     GeoCoordinates::BaseGCSPtr currentGCS = GeoCoordinates::BaseGCS::CreateGCS();
 
-    // ParseFullPrecision uses strtod-equivalent parsing to match jsoncpp behavior for exact double equality.
-    BeJsDocument result;
-    result.ParseFullPrecision(theJson);
+    BeJsDocument result(theJson);
     EXPECT_FALSE(result.hasParseError());
 
     // Sabotage the id to make sure we do not use pre-defined
@@ -3747,9 +3743,7 @@ TEST_F(GCSUnitTests, EllipsoidTransformFromJsonSpecific)
         GeoCoordinates::Ellipsoid* currentEllipsoid1 = GeoCoordinates::Ellipsoid::CreateEllipsoid();
         GeoCoordinates::Ellipsoid* currentEllipsoid2 = GeoCoordinates::Ellipsoid::CreateEllipsoid();
 
-        // ParseFullPrecision uses strtod-equivalent parsing to match jsoncpp behavior for exact double equality.
-        BeJsDocument result;
-        result.ParseFullPrecision(theJson);
+        BeJsDocument result(theJson);
         EXPECT_FALSE(result.hasParseError());
 
         Utf8String errorMessage;
@@ -3780,9 +3774,7 @@ TEST_F(GCSUnitTests, DatumTransformFromJsonSpecific)
         GeoCoordinates::Datum* currentDatum1 = GeoCoordinates::Datum::CreateDatum();
         GeoCoordinates::Datum* currentDatum2 = GeoCoordinates::Datum::CreateDatum();
 
-        // ParseFullPrecision uses strtod-equivalent parsing to match jsoncpp behavior for exact double equality.
-        BeJsDocument result;
-        result.ParseFullPrecision(theJson);
+        BeJsDocument result(theJson);
         EXPECT_FALSE(result.hasParseError());
 
         Utf8String errorMessage;
@@ -3814,9 +3806,7 @@ TEST_F(GCSUnitTests, GeodeticTransformTransformFromJsonSpecific)
         GeoCoordinates::GeodeticTransform* currentTransform1 = GeoCoordinates::GeodeticTransform::CreateGeodeticTransform();
         GeoCoordinates::GeodeticTransform* currentTransform2 = GeoCoordinates::GeodeticTransform::CreateGeodeticTransform();
 
-        // ParseFullPrecision uses strtod-equivalent parsing to match jsoncpp behavior for exact double equality.
-        BeJsDocument result;
-        result.ParseFullPrecision(theJson);
+        BeJsDocument result(theJson);
         EXPECT_FALSE(result.hasParseError());
 
         Utf8String errorMessage;

--- a/iModelCore/GeoCoord/Tests/NonPublished/GCSUnitTests.cpp
+++ b/iModelCore/GeoCoord/Tests/NonPublished/GCSUnitTests.cpp
@@ -3677,10 +3677,10 @@ TEST_F (GCSUnitTests, GCSTransformFromJsonSpecific)
 
         GeoCoordinates::BaseGCSPtr currentGCS = GeoCoordinates::BaseGCS::CreateGCS();
 
-        // DO NOT CHANGE TO BeJsDocument — RapidJSON's number parser may produce slightly different doubles than
-        // strtod() for values exceeding double precision, causing exact equality comparisons against C++ literals to fail.
-        Json::Value result;
-        EXPECT_TRUE(Json::Reader::Parse(theJson, result));
+        // ParseFullPrecision uses strtod-equivalent parsing to match jsoncpp behavior for exact double equality.
+        BeJsDocument result;
+        result.ParseFullPrecision(theJson);
+        EXPECT_FALSE(result.hasParseError());
 
         Utf8String errMessage;
         EXPECT_EQ(SUCCESS, currentGCS->FromHorizontalJson(result, errMessage)) << errMessage.c_str();
@@ -3702,15 +3702,16 @@ TEST_F (GCSUnitTests, GCSTransformFromJsonError1)
 
     GeoCoordinates::BaseGCSPtr currentGCS = GeoCoordinates::BaseGCS::CreateGCS();
 
-    // DO NOT CHANGE TO BeJsDocument — see comment in GCSTransformFromJsonSpecific
-    Json::Value result;
-    EXPECT_TRUE(Json::Reader::Parse(theJson, result));
+    // ParseFullPrecision uses strtod-equivalent parsing to match jsoncpp behavior for exact double equality.
+    BeJsDocument result;
+    result.ParseFullPrecision(theJson);
+    EXPECT_FALSE(result.hasParseError());
 
     // Sabotage the id to make sure we do not use pre-defined
     result["id"] = "XYZ";
 
     // Sabotage EPSG code
-    result["epsg"] = -12;
+    result["epsg"] = (int32_t)-12;
 
     // TODO put specific error
     Utf8String errMessage;
@@ -3746,12 +3747,13 @@ TEST_F(GCSUnitTests, EllipsoidTransformFromJsonSpecific)
         GeoCoordinates::Ellipsoid* currentEllipsoid1 = GeoCoordinates::Ellipsoid::CreateEllipsoid();
         GeoCoordinates::Ellipsoid* currentEllipsoid2 = GeoCoordinates::Ellipsoid::CreateEllipsoid();
 
-        // DO NOT CHANGE TO BeJsDocument — see comment in GCSTransformFromJsonSpecific
-        Json::Value result;
-        EXPECT_TRUE(Json::Reader::Parse(theJson, result));
+        // ParseFullPrecision uses strtod-equivalent parsing to match jsoncpp behavior for exact double equality.
+        BeJsDocument result;
+        result.ParseFullPrecision(theJson);
+        EXPECT_FALSE(result.hasParseError());
 
         Utf8String errorMessage;
-        EXPECT_EQ(SUCCESS, currentEllipsoid1->FromJson(Json::Value::From(theJson), errorMessage)) << errorMessage.c_str();
+        EXPECT_EQ(SUCCESS, currentEllipsoid1->FromJson(result, errorMessage)) << errorMessage.c_str();
 
         // Sabotage the id to reparse
         result["id"] = "XYZ";
@@ -3778,12 +3780,13 @@ TEST_F(GCSUnitTests, DatumTransformFromJsonSpecific)
         GeoCoordinates::Datum* currentDatum1 = GeoCoordinates::Datum::CreateDatum();
         GeoCoordinates::Datum* currentDatum2 = GeoCoordinates::Datum::CreateDatum();
 
-        // DO NOT CHANGE TO BeJsDocument — see comment in GCSTransformFromJsonSpecific
-        Json::Value result;
-        EXPECT_TRUE(Json::Reader::Parse(theJson, result));
+        // ParseFullPrecision uses strtod-equivalent parsing to match jsoncpp behavior for exact double equality.
+        BeJsDocument result;
+        result.ParseFullPrecision(theJson);
+        EXPECT_FALSE(result.hasParseError());
 
         Utf8String errorMessage;
-        EXPECT_EQ(SUCCESS, currentDatum1->FromJson(Json::Value::From(theJson), errorMessage)) << errorMessage.c_str();
+        EXPECT_EQ(SUCCESS, currentDatum1->FromJson(result, errorMessage)) << errorMessage.c_str();
 
         // Sabotage the id to reparse
         result["id"] = "XYZ";
@@ -3811,14 +3814,15 @@ TEST_F(GCSUnitTests, GeodeticTransformTransformFromJsonSpecific)
         GeoCoordinates::GeodeticTransform* currentTransform1 = GeoCoordinates::GeodeticTransform::CreateGeodeticTransform();
         GeoCoordinates::GeodeticTransform* currentTransform2 = GeoCoordinates::GeodeticTransform::CreateGeodeticTransform();
 
-        // DO NOT CHANGE TO BeJsDocument — see comment in GCSTransformFromJsonSpecific
-        Json::Value result;
-        EXPECT_TRUE(Json::Reader::Parse(theJson, result));
+        // ParseFullPrecision uses strtod-equivalent parsing to match jsoncpp behavior for exact double equality.
+        BeJsDocument result;
+        result.ParseFullPrecision(theJson);
+        EXPECT_FALSE(result.hasParseError());
 
         Utf8String errorMessage;
-        EXPECT_EQ(SUCCESS, currentTransform1->FromJson(Json::Value::From(theJson), errorMessage)) << errorMessage.c_str();
+        EXPECT_EQ(SUCCESS, currentTransform1->FromJson(result, errorMessage)) << errorMessage.c_str();
 
-        Json::Value returnedResult;
+        BeJsDocument returnedResult;
         EXPECT_TRUE(SUCCESS == currentTransform1->ToJson(returnedResult));
 
         EXPECT_EQ(SUCCESS, currentTransform2->FromJson(result, errorMessage)) << errorMessage.c_str();

--- a/iModelCore/iModelPlatform/DgnCore/DgnUnits.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/DgnUnits.cpp
@@ -472,13 +472,12 @@ void DgnGeoLocation::SetProjectExtents(AxisAlignedBox3dCR newExtents)
 
     m_extent = newExtents;
 
-    // DO NOT CHANGE TO RAPID JSON.
-    // JsonCpp and RapidJson differ slightly in precision of floating point numbers.
-    // Tile content Ids include a hash of the project extents.
-    // Differing precision => different content Ids => invalidate every cached tile in existence.
-    Json::Value jsonObj;
+    // Precision17 produces output byte-identical to the former jsoncpp serialization (sprintf "%#.17g").
+    // Tile content IDs include a hash of the project extents string, so changing the serialized
+    // precision would invalidate every cached tile in existence.
+    BeJsDocument jsonObj;
     BeJsGeomUtils::DRange3dToJson(jsonObj, m_extent);
-    m_dgndb.SavePropertyString(DgnProjectProperty::Extents(), jsonObj.ToString());
+    m_dgndb.SavePropertyString(DgnProjectProperty::Extents(), jsonObj.Stringify(StringifyFormat::Precision17));
 
     if (!m_ecefLocation.m_isValid)
         {
@@ -549,15 +548,14 @@ AxisAlignedBox3d DgnGeoLocation::ComputeProjectExtents(DRange3dP rangeWithOutlie
 +---------------+---------------+---------------+---------------+---------------+------*/
 void DgnGeoLocation::LoadProjectExtents() const
     {
-    // DO NOT CHANGE TO RAPID JSON.
-    // JsonCpp and RapidJson differ slightly in precision of floating point numbers.
-    // Tile content Ids include a hash of the project extents.
-    // Differing precision => different content Ids => invalidate every cached tile in existence.
-    Json::Value jsonObj;
     Utf8String value;
     AxisAlignedBox3d extentsBeforeReadingFromDb = AxisAlignedBox3d(m_extent);
-    if (BE_SQLITE_ROW == m_dgndb.QueryProperty(value, DgnProjectProperty::Extents()) && Json::Reader::Parse(value, jsonObj))
-        BeJsGeomUtils::DRange3dFromJson(m_extent, jsonObj);
+    if (BE_SQLITE_ROW == m_dgndb.QueryProperty(value, DgnProjectProperty::Extents()))
+        {
+        BeJsDocument jsonObj(value);
+        if (!jsonObj.hasParseError())
+            BeJsGeomUtils::DRange3dFromJson(m_extent, jsonObj);
+        }
 
     if (!extentsBeforeReadingFromDb.IsEqual(m_extent, DoubleOps::SmallMetricDistance()))
         NotifyProjectExtentsChanged(m_extent);

--- a/iModelCore/iModelPlatform/DgnCore/DgnUnits.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/DgnUnits.cpp
@@ -554,7 +554,8 @@ void DgnGeoLocation::LoadProjectExtents() const
     AxisAlignedBox3d extentsBeforeReadingFromDb = AxisAlignedBox3d(m_extent);
     if (BE_SQLITE_ROW == m_dgndb.QueryProperty(value, DgnProjectProperty::Extents()))
         {
-        BeJsDocument jsonObj(value);
+        BeJsDocument jsonObj;
+        jsonObj.ParseFullPrecision(value);
         if (!jsonObj.hasParseError())
             BeJsGeomUtils::DRange3dFromJson(m_extent, jsonObj);
         }

--- a/iModelCore/iModelPlatform/DgnCore/DgnUnits.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/DgnUnits.cpp
@@ -472,11 +472,13 @@ void DgnGeoLocation::SetProjectExtents(AxisAlignedBox3dCR newExtents)
 
     m_extent = newExtents;
 
-    // Precision17 produces output byte-identical to the former jsoncpp serialization (sprintf "%#.17g").
-    // Tile content IDs include a hash of the project extents string, so changing the serialized
-    // precision would invalidate every cached tile in existence.
+    // Tile content IDs include a hash of the project extents string. The serialized format must be
+    // byte-identical to the former jsoncpp output to avoid invalidating every cached tile in existence.
+    // jsoncpp sorts object keys alphabetically ("high" before "low") and uses sprintf "%#.17g" for doubles.
+    // We replicate both behaviors here: alphabetical key insertion + Precision17 formatting.
     BeJsDocument jsonObj;
-    BeJsGeomUtils::DRange3dToJson(jsonObj, m_extent);
+    BeJsGeomUtils::DPoint3dToJson(jsonObj["high"], m_extent.high);
+    BeJsGeomUtils::DPoint3dToJson(jsonObj["low"], m_extent.low);
     m_dgndb.SavePropertyString(DgnProjectProperty::Extents(), jsonObj.Stringify(StringifyFormat::Precision17));
 
     if (!m_ecefLocation.m_isValid)


### PR DESCRIPTION
Don't think this pr is needed as [Paul pointed out here ](https://github.com/iTwin/itwinjs-backlog/issues/444#issuecomment-4415501546)so this may no longer be a problem. Wanted to keep the branch up for reference though just in case anyone is curious, or thinks it may be of value for other areas. some GCS tests also fail, and it may be due to precision too.