### PR TITLE
Marked cascading changes as indirect

### DIFF
--- a/iModelCore/iModelPlatform/DgnCore/DgnElements.cpp
+++ b/iModelCore/iModelPlatform/DgnCore/DgnElements.cpp
@@ -1100,6 +1100,10 @@ DbResult BulkElementDeletion::ExecuteDeletion()
     {
     // Explicitly execute ON DELETE CASCADE and ON DELETE SET NULL FK actions for all tables that reference bis_Element.
     {
+    const auto changeMode = m_dgndb.Txns().GetMode();
+
+    m_dgndb.Txns().SetMode(ChangeTracker::Mode::Indirect);  // The cascade changes should be tracked as indirect changes
+
     Statement onDeleteStmt;
     onDeleteStmt.Prepare(m_dgndb, "SELECT name FROM main.sqlite_master WHERE type='table' AND sql LIKE '%REFERENCES%bis_Element%ON DELETE%' AND name != '" BIS_TABLE(BIS_CLASS_Element) "' ORDER BY name");
     while (BE_SQLITE_ROW == onDeleteStmt.Step())
@@ -1134,6 +1138,7 @@ DbResult BulkElementDeletion::ExecuteDeletion()
                 }
             }
         }
+    m_dgndb.Txns().SetMode(changeMode); // restore original transaction mode
     }
 
     auto reset = [&]() {


### PR DESCRIPTION
In the bulk delete api implementation, to avoid per row cascade delete triggers which caused a drop in performance, the api was deferring foreign keys and bulk deleting the cascading rows before the element deletion.
As a result, the cascade deletes were also being tracked as direct changes, whereas sqlite tracks these cascades as indirect changes.
This caused a problem on OS+ which needs the changes to be marked as direct/indirect.

This PR sets the ChangeTracker's mode to indirect for the scope of the cascade delete changes and resets the mode to the previous value at the end.

Verified the fix locally on OS+.

