### PR TITLE
Remove nullptr assertion in CreateContext method

### DIFF
--- a/iModelCore/ecobjects/src/ECcontext.cpp
+++ b/iModelCore/ecobjects/src/ECcontext.cpp
@@ -413,11 +413,6 @@ public:
 +---------------+---------------+---------------+---------------+---------------+------*/
 ECInstanceReadContextPtr ECInstanceReadContext::CreateContext(ECSchemaReadContextR context, ECSchemaCR fallBackSchema, ECSchemaPtr* foundSchema)
     {
-    // Callers historically passed *nullptr through this overload when they had no fallback to
-    // provide (relying on the reference never being dereferenced). That pattern is undefined
-    // behaviour; assert it loudly in debug builds and steer callers to the no-fallback
-    // overload below.
-    BeAssert(&fallBackSchema != nullptr && "Use CreateContext(ECSchemaReadContextR, ECSchemaPtr*) when no fallback schema is available");
     return new ECSchemaReadContextBackedInstanceReadContext (context, &fallBackSchema, foundSchema);
     }
 


### PR DESCRIPTION
In my earlier PR https://github.com/iTwin/imodel-native/pull/1433 I had added a defensive check because some callers were providing nullptr references and I wanted to defend against it.

Turns out xcode in mac really doesn't like comparing the address of a reference to something. Even though the check did work, I'm taking it back with this PR.

```cpp
BeAssert(&fallBackSchema != nullptr && "Use CreateContext(ECSchemaReadContextR, ECSchemaPtr*) when no fallback schema is available");
```