### PR TITLE
Revert "bump @itwin/* dev dependencies to next minor version"

### DIFF
--- a/iModelJsNodeAddon/api_package/ts/package.json
+++ b/iModelJsNodeAddon/api_package/ts/package.json
@@ -17,10 +17,10 @@
     "test": "node ./lib/test/index.js"
   },
   "devDependencies": {
-    "@itwin/build-tools": "^5.11.0-dev",
-    "@itwin/core-bentley": "^5.11.0-dev",
-    "@itwin/core-common": "^5.11.0-dev",
-    "@itwin/core-geometry": "^5.11.0-dev",
+    "@itwin/build-tools": "^5.10.0-dev",
+    "@itwin/core-bentley": "^5.10.0-dev",
+    "@itwin/core-common": "^5.10.0-dev",
+    "@itwin/core-geometry": "^5.10.0-dev",
     "@itwin/eslint-plugin": "^5.0.0-dev.2",
     "@types/chai": "^4.3.6",
     "@types/chai-as-promised": "^7.1.6",


### PR DESCRIPTION
## TL;DR

The branch-cut flow moved `imodel-native/main` to `^5.11.0-dev` before that dev line existed on npm, while the 5.10 patch lane was still active. That left native `main` pointing at packages it could not install.

This PR rolls the TypeScript API dev dependencies back to `^5.10.0-dev` so native `main` is usable again while the release automation fixes land.

## What

| Asset | Why it exists |
|---|---|
| `iModelJsNodeAddon/api_package/ts/package.json` | `main` was pointed at unpublished `5.11.0-dev` packages and started failing installs, so this restores the `5.10.0-dev` line that actually exists while `release/5.10.x` owns the active patch lane. |

---
*Nambot 🤖*
