### PR TITLE
Revert "bump @itwin/* dev dependencies to next minor version"

### DIFF
--- a/iModelJsNodeAddon/api_package/ts/package.json
+++ b/iModelJsNodeAddon/api_package/ts/package.json
@@ -17,10 +17,10 @@
     "test": "node ./lib/test/index.js"
   },
   "devDependencies": {
-    "@itwin/build-tools": "^5.11.0-dev",
-    "@itwin/core-bentley": "^5.11.0-dev",
-    "@itwin/core-common": "^5.11.0-dev",
-    "@itwin/core-geometry": "^5.11.0-dev",
+    "@itwin/build-tools": "^5.10.0-dev",
+    "@itwin/core-bentley": "^5.10.0-dev",
+    "@itwin/core-common": "^5.10.0-dev",
+    "@itwin/core-geometry": "^5.10.0-dev",
     "@itwin/eslint-plugin": "^5.0.0-dev.2",
     "@types/chai": "^4.3.6",
     "@types/chai-as-promised": "^7.1.6",


### PR DESCRIPTION
This reverts commit 20e56630d3420e724df848e63286f0df27e49756.

This commit updated itwinjs version too early. Undoing for now