### PR TITLE
Fix SchemaMerger handling of new incoming schemas

### DIFF
--- a/iModelCore/ecobjects/src/SchemaMerger.cpp
+++ b/iModelCore/ecobjects/src/SchemaMerger.cpp
@@ -310,10 +310,6 @@ ECObjectsStatus SchemaMerger::MergeSchemas(SchemaMergeResult& result, bvector<EC
     if (rawRight.empty())
         return ECObjectsStatus::Success;
 
-    status = fillSchemasToResult("right", right);
-    if (status != ECObjectsStatus::Success)
-        return status;
-
     SchemaComparer comparer;
     SchemaComparer::Options comparerOptions = SchemaComparer::Options(SchemaComparer::DetailLevel::NoSchemaElements, SchemaComparer::DetailLevel::NoSchemaElements);
     SchemaDiff diff;
@@ -327,6 +323,40 @@ ECObjectsStatus SchemaMerger::MergeSchemas(SchemaMergeResult& result, bvector<EC
         return ECObjectsStatus::Error;
         }
 
+    // First pass: copy any incoming-only (New) schemas into the result. This must happen
+    // before merging the Modified schemas below, because a Modified schema may add a new
+    // reference to one of these New schemas and would otherwise fail to resolve it.
+    for (auto schemaChange : diff.Changes())
+        {
+        if (!schemaChange->IsChanged() || schemaChange->GetOpCode() != ECChange::OpCode::New)
+            continue;
+
+        if (result.ContainsSchema(schemaChange->GetChangeName()))
+            continue; // already brought in as a referenced schema while copying an earlier new schema
+
+        ECSchemaCP rawRightSchema = FindSchemaByName(right, schemaChange->GetChangeName());
+        if (rawRightSchema == nullptr)
+            {
+            result.Issues().ReportV(IssueSeverity::Error, IssueCategory::BusinessProperties, IssueType::ECSchema, ECIssueId::EC_0024,
+                "Failed to find new schema %s in the right schemas list. This usually indicates a dirty schema graph where multiple memory references of the same schema with different contents are provided.", schemaChange->GetChangeName());
+            return ECObjectsStatus::Error;
+            }
+
+        ECSchemaPtr copiedSchema;
+        auto copyStatus = rawRightSchema->CopySchema(copiedSchema, !doNotMergeReferences ? result.GetSchemaReadContext().get() : nullptr, options.GetSkipValidation());
+        if (copyStatus != ECObjectsStatus::Success)
+            {
+            result.Issues().ReportV(IssueSeverity::Error, IssueCategory::BusinessProperties, IssueType::ECSchema, ECIssueId::EC_0025,
+                "Schema '%s' from right side failed to be copied.", rawRightSchema->GetFullSchemaName().c_str());
+            return copyStatus;
+            }
+        if (copiedSchema.IsValid())
+            {
+            copiedSchema->SetOriginalECXmlVersion(rawRightSchema->GetOriginalECXmlVersionMajor(), rawRightSchema->GetOriginalECXmlVersionMinor());
+            result.GetSchemaCache().AddSchema(*copiedSchema);
+            }
+        }
+
     for (auto schemaChange : diff.Changes())
         {
         if (!schemaChange->IsChanged())
@@ -334,7 +364,7 @@ ECObjectsStatus SchemaMerger::MergeSchemas(SchemaMergeResult& result, bvector<EC
 
         auto opCode = schemaChange->GetOpCode();
         if (opCode == ECChange::OpCode::Deleted || opCode == ECChange::OpCode::New)
-            continue; // skip schemas missing on one side as this was already handled above
+            continue; // Deleted: left-only, already in the result so kept as-is. New: copied in the first pass above.
 
         Utf8CP schemaName = schemaChange->GetChangeName(); // naming not intuitive, but the most reliable way to extract the schema name
         ECSchemaP leftSchema = result.GetSchema(schemaName);

--- a/iModelCore/ecobjects/test/NonPublished/SchemaMergerTests.cpp
+++ b/iModelCore/ecobjects/test/NonPublished/SchemaMergerTests.cpp
@@ -3066,6 +3066,84 @@ TEST_F(SchemaMergerTests, AddReferenceToNewSchema)
 
 /*---------------------------------------------------------------------------------**//**
 * @bsitest
+* Two brand-new (right-only) schemas where one references the other. This exercises the
+* ECChange::OpCode::New path in MergeSchemas and ensures a new schema and its new
+* referenced schema are both copied into the result with the cross-schema reference
+* intact, regardless of dependency ordering.
++---------------+---------------+---------------+---------------+---------------+------*/
+TEST_F(SchemaMergerTests, AddNewSchemaReferencingAnotherNewSchema)
+    {
+    // The left side only contains an unrelated, pre-existing schema.
+    bvector<Utf8CP> leftSchemasXml {
+      R"schema(<?xml version='1.0' encoding='utf-8' ?>
+        <ECSchema schemaName="ExistingSchema" alias="ex" version="01.00.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+          <ECEntityClass typeName="ExistingEntity">
+            <ECProperty propertyName="A" typeName="string"/>
+          </ECEntityClass>
+        </ECSchema>
+        )schema"
+    };
+    ECSchemaReadContextPtr leftContext = InitializeReadContextWithAllSchemas(leftSchemasXml);
+    bvector<ECN::ECSchemaCP> leftSchemas = leftContext->GetCache().GetSchemas();
+
+    // The right side introduces two new schemas: NewDerivedSchema references and derives from NewBaseSchema.
+    bvector<Utf8CP> rightSchemasXml {
+      R"schema(<?xml version='1.0' encoding='utf-8' ?>
+        <ECSchema schemaName="NewBaseSchema" alias="nbs" version="01.00.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+          <ECEntityClass typeName="BaseEntity">
+            <ECProperty propertyName="A" typeName="string"/>
+          </ECEntityClass>
+        </ECSchema>
+        )schema",
+      R"schema(<?xml version='1.0' encoding='utf-8' ?>
+        <ECSchema schemaName="NewDerivedSchema" alias="nds" version="01.00.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+          <ECSchemaReference name="NewBaseSchema" version="01.00.00" alias="nbs"/>
+          <ECEntityClass typeName="DerivedEntity">
+            <BaseClass>nbs:BaseEntity</BaseClass>
+            <ECProperty propertyName="B" typeName="int"/>
+          </ECEntityClass>
+        </ECSchema>
+        )schema"
+    };
+    ECSchemaReadContextPtr rightContext = InitializeReadContextWithAllSchemas(rightSchemasXml);
+    bvector<ECN::ECSchemaCP> rightSchemas = rightContext->GetCache().GetSchemas();
+
+    //merge the schemas
+    SchemaMergeResult result;
+    EXPECT_EQ(ECObjectsStatus::Success, SchemaMerger::MergeSchemas(result, leftSchemas, rightSchemas));
+
+    // The existing schema is kept and both new schemas are added with the reference intact.
+    bvector<Utf8CP> expectedSchemasXml {
+      R"schema(<?xml version='1.0' encoding='utf-8' ?>
+        <ECSchema schemaName="ExistingSchema" alias="ex" version="01.00.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+          <ECEntityClass typeName="ExistingEntity">
+            <ECProperty propertyName="A" typeName="string"/>
+          </ECEntityClass>
+        </ECSchema>
+        )schema",
+      R"schema(<?xml version='1.0' encoding='utf-8' ?>
+        <ECSchema schemaName="NewBaseSchema" alias="nbs" version="01.00.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+          <ECEntityClass typeName="BaseEntity">
+            <ECProperty propertyName="A" typeName="string"/>
+          </ECEntityClass>
+        </ECSchema>
+        )schema",
+      R"schema(<?xml version='1.0' encoding='utf-8' ?>
+        <ECSchema schemaName="NewDerivedSchema" alias="nds" version="01.00.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+          <ECSchemaReference name="NewBaseSchema" version="01.00.00" alias="nbs"/>
+          <ECEntityClass typeName="DerivedEntity">
+            <BaseClass>nbs:BaseEntity</BaseClass>
+            <ECProperty propertyName="B" typeName="int"/>
+          </ECEntityClass>
+        </ECSchema>
+        )schema"
+    };
+
+    CompareResults(expectedSchemasXml, result);
+    }
+
+/*---------------------------------------------------------------------------------**//**
+* @bsitest
 +---------------+---------------+---------------+---------------+---------------+------*/
 TEST_F(SchemaMergerTests, AddReferenceToExistingSchema)
     {


### PR DESCRIPTION

Fixes #1449

## What

`SchemaMerger::MergeSchemas` previously pre-filled both the existing (left) and incoming
(right) schemas into the result, then compared that union against right. Because the union
already contained every incoming schema, the comparer never reported a schema as `New`, and
the merge loop's `New` branch was unreachable. This also produced a dirty schema graph when
left and right disagreed on a referenced schema's version, causing the compare to fail.

## Changes

- Stop pre-filling the right schemas into the result, so `Compare(left, right)` is a real
  old/new diff.
- Copy incoming-only (`New`) schemas into the result in a dedicated first pass, before
  merging `Modified` schemas. The first pass is required because a `Modified` schema may add
  a new reference to a `New` schema and must be able to resolve it.
- `Deleted` (left-only) schemas continue to be kept as-is.

## Tests

- `AddNewSchemaReferencingAnotherNewSchema` (new): two incoming-only schemas where one
  references and derives from the other - covers the `New`-references-`New` ordering case.
- `CustomAttributesAddedFromReferencedSchema` (existing): exercises the
  `Modified`-references-`New` ordering case and caught the regression in the single-pass
  version of the fix.
