### PR TITLE
Presentation: Fix "actual source classes" not being set of nested content fields

### DIFF
--- a/iModelCore/ECPresentation/PublicAPI/ECPresentation/Content.h
+++ b/iModelCore/ECPresentation/PublicAPI/ECPresentation/Content.h
@@ -1162,7 +1162,12 @@ struct EXPORT_VTABLE_ATTRIBUTE ContentDescriptor : RefCountedBase
         RelatedClassPath const& GetPathFromSelectToContentClass() const {return m_pathFromSelectClassToContentClass;}
         void SetPathFromSelectToContentClass(RelatedClassPath path) {m_pathFromSelectClassToContentClass = path;}
 
-        //! Actual source subclasses of source in 'path from select to content class'
+        //! Actual source classes of the primary class that leads to this field.
+        //! 
+        //! The same relationship can be represented in two ways:
+        //! 1. A -> Related content field [A -> B] -> Related content field [B -> C].
+        //! 2. A -> Related content field [A -> B -> C].
+        //! `GetActualSourceClasses` of all three related content fields would return the same result - class A or its subclasses.
         std::unordered_set<ECClassCP> const* GetActualSourceClasses() const {return m_actualSourceClasses.get();}
         std::unordered_set<ECClassCP>* GetActualSourceClasses() {return m_actualSourceClasses.get();}
         void SetActualSourceClasses(std::unique_ptr<std::unordered_set<ECClassCP>> classes) {m_actualSourceClasses = std::move(classes);}

--- a/iModelCore/ECPresentation/Source/Content/ContentDescriptorBuilder.cpp
+++ b/iModelCore/ECPresentation/Source/Content/ContentDescriptorBuilder.cpp
@@ -1212,10 +1212,7 @@ public:
 
         relatedContentField->SetSpecificationIdentifier(relatedPropertySpecsStack.back()->GetHash());
         relatedContentField->SetRelationshipMeaning(relatedPropertySpecsStack.back()->GetRelationshipMeaning());
-
-        // only set actual source classes if the field is not nested - they're pointing to nesting field's source otherwise
-        if (!mergeResult.nestingField)
-            relatedContentField->SetActualSourceClasses(std::make_unique<std::unordered_set<ECClassCP>>(actualSourceClasses));
+        relatedContentField->SetActualSourceClasses(std::make_unique<std::unordered_set<ECClassCP>>(actualSourceClasses));
 
         if (fieldAttributes.GetRenderer())
             relatedContentField->SetRenderer(new ContentFieldRenderer(*fieldAttributes.GetRenderer()));
@@ -1628,7 +1625,14 @@ public:
         {
         for (ContentDescriptor::Field const* field : contentField.GetFields())
             {
-            m_descriptor->AddRootField(*field->Clone());
+            auto clone = field->Clone();
+            if (clone->GetParent() && clone->AsNestedContentField() && clone->AsNestedContentField()->AsRelatedContentField())
+                {
+                // if the field has a parent and we place it into descriptor as the root field, the "Actual source classes" become
+                // invalid in the context of the descriptor
+                clone->AsNestedContentField()->AsRelatedContentField()->SetActualSourceClasses(nullptr);
+                }
+            m_descriptor->AddRootField(*clone);
             DIAGNOSTICS_DEV_LOG(DiagnosticsCategory::Content, LOG_TRACE, Utf8PrintfString("Cloned nested field `%s` into descriptor.", field->GetUniqueName().c_str()));
             }
         DIAGNOSTICS_DEV_LOG(DiagnosticsCategory::Content, LOG_TRACE, Utf8PrintfString("Total fields: %" PRIu64, (uint64_t)m_descriptor->GetAllFields().size()));

--- a/iModelCore/ECPresentation/Tests/NonPublished/Integration/Content/Content_RelatedPropertiesTests.cpp
+++ b/iModelCore/ECPresentation/Tests/NonPublished/Integration/Content/Content_RelatedPropertiesTests.cpp
@@ -6287,6 +6287,8 @@ TEST_F(RulesDrivenECPresentationManagerContentTests, SetsActualSourceClassesOnRe
     EXPECT_STREQ("PropB", descriptor->GetVisibleFields()[fieldIndex]->AsNestedContentField()->GetFields()[0]->GetLabel().c_str());
     EXPECT_TRUE(descriptor->GetVisibleFields()[fieldIndex]->AsNestedContentField()->GetFields()[1]->IsNestedContentField());
     EXPECT_TRUE(descriptor->GetVisibleFields()[fieldIndex]->AsNestedContentField()->GetFields()[1]->AsNestedContentField()->AsRelatedContentField());
+    EXPECT_EQ(classC, &descriptor->GetVisibleFields()[fieldIndex]->AsNestedContentField()->GetFields()[1]->AsNestedContentField()->GetContentClass());
+    EXPECT_TRUE(ContainsAll(*descriptor->GetVisibleFields()[fieldIndex]->AsNestedContentField()->GetFields()[1]->AsNestedContentField()->AsRelatedContentField()->GetActualSourceClasses(), bvector<ECClassCP>{ classA3 }, true));
     EXPECT_EQ(1, descriptor->GetVisibleFields()[fieldIndex]->AsNestedContentField()->GetFields()[1]->AsNestedContentField()->GetFields().size());
     EXPECT_STREQ("PropC", descriptor->GetVisibleFields()[fieldIndex]->AsNestedContentField()->GetFields()[1]->AsNestedContentField()->GetFields()[0]->GetLabel().c_str());
 
@@ -6388,6 +6390,7 @@ TEST_F(RulesDrivenECPresentationManagerContentTests, CreatesValidDescriptorWhenD
     EXPECT_TRUE(descriptor->GetVisibleFields()[fieldIndex]->AsNestedContentField()->GetFields()[1]->IsNestedContentField());
     EXPECT_TRUE(descriptor->GetVisibleFields()[fieldIndex]->AsNestedContentField()->GetFields()[1]->AsNestedContentField()->AsRelatedContentField());
     EXPECT_EQ(classS, &descriptor->GetVisibleFields()[fieldIndex]->AsNestedContentField()->GetFields()[1]->AsNestedContentField()->AsRelatedContentField()->GetContentClass());
+    EXPECT_TRUE(ContainsAll(*descriptor->GetVisibleFields()[fieldIndex]->AsNestedContentField()->GetFields()[1]->AsNestedContentField()->AsRelatedContentField()->GetActualSourceClasses(), bvector<ECClassCP>{ classB, classC }, true));
     EXPECT_EQ(1, descriptor->GetVisibleFields()[fieldIndex]->AsNestedContentField()->GetFields()[1]->AsNestedContentField()->GetFields().size());
     EXPECT_STREQ("PropS", descriptor->GetVisibleFields()[fieldIndex]->AsNestedContentField()->GetFields()[1]->AsNestedContentField()->GetFields()[0]->GetLabel().c_str());
     }


### PR DESCRIPTION
https://github.com/iTwin/imodel-native/pull/788 made `GetActualSourceClasses` return a nullable set and only set the classes on direct related content fields, saying that the set is invalid for nested related content fields. 

That's not totally correct - with the fields structure `F1[A -> B] -> F2[B -> C]`, the "actual source classes" for both fields should be either A or its subclasses. That attribute is only invalid for F2 in a special context, where we create a descriptor from F1, and F2 becomes the root field. So instead of never setting "actual source classes" for F2, we should not set it only in that context.