### PR TITLE
Proposal - No-Remap POC

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -90,8 +90,7 @@
             "request": "launch",
             "program": "${env:OutRoot}Winx64/Product/ECDb-Gtest/ECDbTest.exe",
             "args": [
-                "--gtest_break_on_failure",
-                "--gtest_filter=InstanceRepositoryFixture.basic"
+                "--gtest_filter=SchemaRemapTestFixture.*"
             ],
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}",

--- a/iModelCore/ECDb/ECDb/ClassMap.cpp
+++ b/iModelCore/ECDb/ECDb/ClassMap.cpp
@@ -459,7 +459,55 @@ BentleyStatus ClassMap::_Load(ClassMapLoadContext& ctx, DbClassMapLoadContext co
     if (m_propertyMaps.Insert(ecClassIdPropertyMap, 1) != SUCCESS)
         return ERROR;
 
-    return LoadPropertyMaps(ctx, dbLoadCtx);
+    if (SUCCESS != LoadPropertyMaps(ctx, dbLoadCtx))
+        return ERROR;
+
+    /*
+     * POC-No-Remap
+     * Apply per-class column overrides from ec_PropertyMap_Overrides when a property is promoted to a base class without physically moving data.
+     * The canonical ec_PropertyMap now points to a fresh base-class column, but instances of this class still have their data at the original column.
+     * Remapping each property map to the override column makes the in-memory ClassMap reflect the actual storage layout, so HasDivergentColumnAssignments can detect the divergence at query time.
+     */
+    if (m_ecdb.TableExists(TABLE_PropertyMap_Overrides))
+        {
+        const ECClassId classId = GetSchemaManager().GetClassId(m_ecClass);
+        CachedStatementPtr overrideStmt = m_ecdb.GetCachedStatement(
+            "SELECT o.AccessString, col.Name, tab.Name "
+            "FROM " TABLE_PropertyMap_Overrides " o "
+            "JOIN ec_Column col ON col.Id = o.ColumnId "
+            "JOIN ec_Table  tab ON tab.Id = col.TableId "
+            "WHERE o.ClassId = ?");
+
+        if (overrideStmt != nullptr && overrideStmt->BindId(1, classId) == BE_SQLITE_OK)
+            {
+            std::map<Utf8String, DbColumn*, CompareIUtf8Ascii> overrides;
+            while (overrideStmt->Step() == BE_SQLITE_ROW)
+                {
+                Utf8CP accessString = overrideStmt->GetValueText(0);
+                Utf8CP colName      = overrideStmt->GetValueText(1);
+                Utf8CP tableName    = overrideStmt->GetValueText(2);
+                if (const DbTable* table = GetSchemaManager().GetDbSchema().FindTable(tableName))
+                    {
+                    if (DbColumn* col = table->FindColumnP(colName))
+                        overrides.emplace(Utf8String(accessString), col);
+                    }
+                }
+
+            if (!overrides.empty())
+                {
+                SearchPropertyMapVisitor visitor(PropertyMap::Type::SingleColumnData);
+                m_propertyMaps.AcceptVisitor(visitor);
+                for (const PropertyMap* pm : visitor.Results())
+                    {
+                    auto it = overrides.find(pm->GetAccessString().c_str());
+                    if (it != overrides.end())
+                        pm->GetAs<SingleColumnDataPropertyMap>().Remap(*it->second);
+                    }
+                }
+            }
+        }
+
+    return SUCCESS;
     }
 
 //---------------------------------------------------------------------------------------
@@ -482,22 +530,74 @@ BentleyStatus ClassMap::LoadPropertyMaps(ClassMapLoadContext& ctx, DbClassMapLoa
             }
         }
 
+    /*
+     * POC-No-Remap
+     * First pass: Load all properties that the class has into m_propertyMaps while skipping the inherited properties.
+     */
     for (ECPropertyCP property : m_ecClass.GetProperties(true))
         {
         if (dbCtx.IsPropertyIgnored(property->GetName()) && m_ecClass.GetSchema().OriginalECXmlVersionGreaterThan(ECVersion::Latest))
             continue;
 
-        DataPropertyMap const*  tphBaseClassPropMap = nullptr;
-        if (&property->GetClass() != &m_ecClass && inheritanceMode == DbMappingManager::Classes::PropertyMapInheritanceMode::Clone)
+        if (&property->GetClass() != &m_ecClass)
+            continue; // skip inherited properties for now
+
+        if (DbMappingManager::Classes::LoadPropertyMap(dbCtx, *this, *property) == nullptr)
+            m_failedToLoadProperties.push_back(property);
+        }
+
+    /*
+     * POC-No-Remap
+     * Second pass: Load every INHERITED property from ec_PropertyMap for this class which already have a row in the table.
+     * Use case: SchemaRemapTestFixture.RevitStoryScenario
+     * When a class's base changes (e.g. Story: CompositeElement -> FacilityPart), the derived concrete class (Level) inherits a new property
+     *  (Description) whose canonical shared column (ps2) was already assigned in an earlier schema version, to a mixin property (RevitId) of the same concrete class.
+     * GetProperties(true) may return Description before RevitId, so the Pass 3 conflict check would not yet see RevitId -> ps2 in m_propertyMaps, allowing Description to be cloned onto ps2 and creating a conflict
+     * By pre-loading all canonically-mapped inherited properties in Pass 2, we ensure that the complete set of occupied columns is visible to the conflict check in Pass 3.
+     */
+    for (ECPropertyCP property : m_ecClass.GetProperties(true))
+        {
+        if (dbCtx.IsPropertyIgnored(property->GetName()) && m_ecClass.GetSchema().OriginalECXmlVersionGreaterThan(ECVersion::Latest))
+            continue;
+
+        if (&property->GetClass() == &m_ecClass)
+            continue; // own property which is already handled in Pass 1
+
+        DbMappingManager::Classes::LoadPropertyMap(dbCtx, *this, *property);
+        }
+
+    /*
+     * POC-No-Remap
+     * Third pass: Process inherited properties not yet in m_propertyMaps.
+     * At this point m_propertyMaps contains ALL own-class columns (Pass 1) plus ALL canonically-mapped inherited columns (Pass 2), giving the conflict check a complete view of occupied columns.
+     */
+    for (ECPropertyCP property : m_ecClass.GetProperties(true))
+        {
+        if (dbCtx.IsPropertyIgnored(property->GetName()) && m_ecClass.GetSchema().OriginalECXmlVersionGreaterThan(ECVersion::Latest))
+            continue;
+
+        if (&property->GetClass() == &m_ecClass)
+            continue; // already handled in Pass 1
+
+        // Skip properties already inserted into m_propertyMaps during Pass 2.
+        if (m_propertyMaps.Find(property->GetName().c_str()) != nullptr)
+            continue;
+
+        if (inheritanceMode != DbMappingManager::Classes::PropertyMapInheritanceMode::Clone)
             {
-            for (ClassMap const* baseClassMap : tphBaseClassMaps)
+            if (DbMappingManager::Classes::LoadPropertyMap(dbCtx, *this, *property) == nullptr)
+                m_failedToLoadProperties.push_back(property);
+            continue;
+            }
+
+        DataPropertyMap const* tphBaseClassPropMap = nullptr;
+        for (ClassMap const* baseClassMap : tphBaseClassMaps)
+            {
+            PropertyMap const* propMap = baseClassMap->GetPropertyMaps().Find(property->GetName().c_str());
+            if (propMap != nullptr && propMap->IsData())
                 {
-                PropertyMap const* propMap = baseClassMap->GetPropertyMaps().Find(property->GetName().c_str());
-                if (propMap != nullptr && propMap->IsData())
-                    {
-                    tphBaseClassPropMap = &propMap->GetAs<DataPropertyMap>();
-                    break;
-                    }
+                tphBaseClassPropMap = &propMap->GetAs<DataPropertyMap>();
+                break;
                 }
             }
 
@@ -505,7 +605,59 @@ BentleyStatus ClassMap::LoadPropertyMaps(ClassMapLoadContext& ctx, DbClassMapLoa
             {
             if (DbMappingManager::Classes::LoadPropertyMap(dbCtx, *this, *property) == nullptr)
                 m_failedToLoadProperties.push_back(property);
+            continue;
+            }
 
+        /*
+         * POC-No-Remap
+         * Unlikely but Defensive early-out: if this property somehow has an ec_PropertyMap entry that Pass 2 missed, load it now and skip the conflict check. 
+         */
+        if (DbMappingManager::Classes::LoadPropertyMap(dbCtx, *this, *property) != nullptr)
+            continue;
+
+        /*
+         * POC-No-Remap
+         * Column Conflict check
+         * 
+         * Before cloning the inherited property's column assignment, check whether any column it uses is already occupied by any property already in m_propertyMaps.
+         * Own properties from Pass 1 OR canonically-mapped inherited properties from Pass 2 such as mixin properties.
+         *
+         * Encountered in tests:
+         * 1. SchemaRemapTestFixture.PutSiblingsIntoHierarchy / SchemaRemapTestFixture.InjectBaseClassInBaseSchema: 
+         *     The class's direct base changes to a former sibling that already owns a property mapped to the same shared column as an OWN property of this class.
+         *
+         * 2. SchemaRemapTestFixture.RevitStoryScenario / SchemaRemapTestFixture.RevitStoryScenarioWithSiblingAndMixins:
+         *     A mixin property (e.g. RevitId) was mapped in a previous schema version to a shared column (ps2) that is now also the canonical column for a newly-inherited base-class property (e.g. Description).
+         *     Because RevitId and Description belong to different class branches that were unrelated in the previous hierarchy, their ps2 assignments were both valid then; but after the base-class change they now collide.
+         *
+         * In both cases CleanModifiedMappings would normally resolve the conflict using remapping.
+         * We now defer resolution to ClassMap::Update (which allocates a fresh column), which is safe because the conflicting property retains its original ec_PropertyMap entry, while the inherited property gets a new canonical column.
+         */
+        bool inheritedColumnConflicts = false;
+        {
+        SearchPropertyMapVisitor baseColumnVisitor(PropertyMap::Type::SingleColumnData);
+        tphBaseClassPropMap->AcceptVisitor(baseColumnVisitor);
+        for (const PropertyMap* basePm : baseColumnVisitor.Results())
+            {
+            const DbColumn& baseCol = basePm->GetAs<SingleColumnDataPropertyMap>().GetColumn();
+            SearchPropertyMapVisitor ownVisitor(PropertyMap::Type::SingleColumnData);
+            m_propertyMaps.AcceptVisitor(ownVisitor);
+            for (const PropertyMap* ownPm : ownVisitor.Results())
+                {
+                if (&ownPm->GetAs<SingleColumnDataPropertyMap>().GetColumn() == &baseCol)
+                    {
+                    inheritedColumnConflicts = true;
+                    break;
+                    }
+                }
+            if (inheritedColumnConflicts)
+                break;
+            }
+        }
+
+        if (inheritedColumnConflicts)
+            {
+            m_failedToLoadProperties.push_back(property);
             continue;
             }
 
@@ -568,6 +720,37 @@ BentleyStatus ClassMap::CopyModifiedBasePropertyMaps(SchemaImportContext& ctx){
         localPropertyMap->AcceptVisitor(localPropertyMapHash);
 
         if (localPropertyMapHash.GetHashCode() != basePropertyHash.GetHashCode()) {
+            /*
+             * POC-No-Remap
+             * If this class has an override entry in ec_PropertyMap_Overrides for this property, the override mechanism in ClassMap::_Load will wire the correct old column at query time.
+             * We must NOT copy the base class's new column here.
+             */
+            if (Enum::Contains(ctx.GetOptions(), SchemaManager::SchemaImportOptions::SkipRemapping) && m_ecdb.TableExists(TABLE_PropertyMap_Overrides))
+                {
+                /*
+                 * POC-No-Remap
+                 * Encountered in test SchemaRemapTestFixture.PutSiblingsIntoHierarchy (A property is a newly-inherited property that was deferred in _Load due to a conflict with an own
+                 *   property, then assigned a fresh shared column).
+                 * 
+                 * If this property was assigned a fresh column by a prior Update() call in this import, do NOT copy the base class's column.
+                 * The fresh assignment is intentionally different from the base and must be preserved to avoid a "column used by multiple properties" conflict.
+                 */
+                if (m_newlyMappedPropertyNames.count(property->GetName()) > 0)
+                    continue;
+
+                ECClassId classId = m_ecClass.GetId();
+                Utf8StringCR propName = property->GetName();
+                CachedStatementPtr skipStmt = m_ecdb.GetImpl().GetCachedSqliteStatement(
+                    "SELECT 1 FROM main." TABLE_PropertyMap_Overrides
+                    " WHERE ClassId = ? AND (AccessString = ? OR AccessString LIKE ? || '.%') LIMIT 1");
+                if (skipStmt.IsValid()
+                    && skipStmt->BindId(1, classId) == BE_SQLITE_OK
+                    && skipStmt->BindText(2, propName.c_str(), Statement::MakeCopy::No) == BE_SQLITE_OK
+                    && skipStmt->BindText(3, propName.c_str(), Statement::MakeCopy::No) == BE_SQLITE_OK
+                    && skipStmt->Step() == BE_SQLITE_ROW)
+                    continue;
+                }
+
             // Base property have modified
             auto idx = m_propertyMaps.IndexOf(*localPropertyMap);
             m_propertyMaps.Remove(localPropertyMap->GetName().c_str());
@@ -598,33 +781,6 @@ BentleyStatus ClassMap::Update(SchemaImportContext& ctx)
         return ERROR;
     }
 
-    if (ctx.RemapManager().HasFreedColumns())
-        {
-        for (ECPropertyCP property : m_ecClass.GetProperties(true))
-            {
-            const auto propMap = m_propertyMaps.Find(property->GetName().c_str());
-            if (propMap == nullptr || !propMap->IsData() || propMap->GetType() == PropertyMap::Type::Navigation)
-                continue;
-
-            GetColumnsPropertyMapVisitor colVisitor;
-            propMap->AcceptVisitor(colVisitor);
-
-            // If the property has been mapped to a column that has been freed in this schema import, avoid its reuse and force a re-load to allocate a new column
-            for (const DbColumn* column : colVisitor.GetColumns())
-                {
-                if (column->IsShared() && ctx.RemapManager().IsColumnFreed(*column))
-                    {
-                    m_propertyMaps.Remove(property->GetName().c_str());
-
-                    if (std::find(m_failedToLoadProperties.begin(), m_failedToLoadProperties.end(), property) == m_failedToLoadProperties.end())
-                        m_failedToLoadProperties.push_back(property);
-
-                    break;
-                    }
-                }
-            }
-        }
-
     //Follow can change ECInstanceId, ECClassId by optionally adding
     if (m_failedToLoadProperties.empty())
         return DbMappingManager::Classes::MapIndexes(ctx, *this, true);
@@ -644,6 +800,13 @@ BentleyStatus ClassMap::Update(SchemaImportContext& ctx)
             BeAssert(false);
             return ERROR;
             }
+
+        /*
+         * POC-No-Remap
+         * 
+         * Track this property so CopyModifiedBasePropertyMaps won't overwrite the freshly assigned column when this class is encountered a second time as a transitive derived class.
+         */
+        m_newlyMappedPropertyNames.insert(property->GetName());
 
         //Nav property maps cannot be saved here as they are not yet mapped.
         if (propMap->GetType() == PropertyMap::Type::Navigation)

--- a/iModelCore/ECDb/ECDb/ClassMap.h
+++ b/iModelCore/ECDb/ECDb/ClassMap.h
@@ -113,6 +113,11 @@ struct ClassMap
         mutable std::unique_ptr<ClassMapColumnFactory> m_columnFactory;
         std::unique_ptr<TablePerHierarchyHelper> m_tphHelper;
         bvector<ECN::ECPropertyCP> m_failedToLoadProperties;
+        /*
+         * POC-No-Remap
+         * Tracks property names that were freshly column-assigned by ClassMap::Update
+         */
+        std::set<Utf8String, CompareIUtf8Ascii> m_newlyMappedPropertyNames;
         ObjectState m_state;
         BentleyStatus CreateCurrentTimeStampTrigger(ECN::PrimitiveECPropertyCR);
         BentleyStatus AddOrUpdateTableList(DataPropertyMap const& propertyThatIsNotYetAdded);

--- a/iModelCore/ECDb/ECDb/ClassMapColumnFactory.cpp
+++ b/iModelCore/ECDb/ECDb/ClassMapColumnFactory.cpp
@@ -411,7 +411,37 @@ DbColumn* ClassMapColumnFactory::AllocateSharedColumn(SchemaImportContext& ctx, 
 
         }
 
-    auto* column = ReuseOrCreateSharedColumn(ctx);
+    /*
+     * POC-No-Remap
+     * 
+     * If this class already has a column override for this property (written by SchemaWriter::DeleteProperty before the cascade during an upgrade), use that column directly.
+     * This is because UpdateColumnResolutionScope pre-fills inherited entries that would otherwise allocate the new canonical column, but we must stay on the original physical column.
+     */
+    if (Enum::Contains(ctx.GetOptions(), SchemaManager::SchemaImportOptions::SkipRemapping))
+        {
+        BeInt64Id classId = m_classMap.GetSchemaManager().GetClassId(m_classMap.GetClass());
+        ECDbCR ecdb = ctx.GetECDb();
+        CachedStatementPtr overrideStmt = ecdb.GetImpl().GetCachedSqliteStatement(
+            "SELECT col.Name, tab.Name "
+            "FROM main.ec_PropertyMap_Overrides o "
+            "JOIN main.ec_Column col ON col.Id = o.ColumnId "
+            "JOIN main.ec_Table  tab ON tab.Id = col.TableId "
+            "WHERE o.ClassId = ? AND o.AccessString = ? LIMIT 1");
+        if (overrideStmt.IsValid()
+            && overrideStmt->BindId(1, classId) == BE_SQLITE_OK
+            && overrideStmt->BindText(2, accessString, Statement::MakeCopy::No) == BE_SQLITE_OK
+            && overrideStmt->Step() == BE_SQLITE_ROW)
+            {
+            const DbTable* table = m_classMap.GetSchemaManager().GetDbSchema().FindTable(overrideStmt->GetValueText(1));
+            if (table != nullptr)
+                {
+                if (DbColumn* col = table->FindColumnP(overrideStmt->GetValueText(0)))
+                    return RegisterColumnMap(accessString, col);
+                }
+            }
+        }
+
+    auto* column = ReuseOrCreateSharedColumn(ctx, accessString);
     return RegisterColumnMap(accessString, column);
     }
     
@@ -444,13 +474,13 @@ void ClassMapColumnFactory::EvaluateIfPropertyGoesToOverflow(Utf8StringCR proper
             }
 
     const uint32_t columnsRequired = MaxColumnsRequiredToPersistProperty(*property);
-    EvaluateIfPropertyGoesToOverflow(columnsRequired, ctx);
+    EvaluateIfPropertyGoesToOverflow(columnsRequired, ctx, &propertyName);
     }
 
 //------------------------------------------------------------------------------------------
 //@bsimethod
 //-----------------------------------------------------------------------------------------
-void ClassMapColumnFactory::EvaluateIfPropertyGoesToOverflow(uint32_t columnsRequired, SchemaImportContext& ctx) const
+void ClassMapColumnFactory::EvaluateIfPropertyGoesToOverflow(uint32_t columnsRequired, SchemaImportContext& ctx, Utf8StringCP accessString) const
     {
     if (m_putCurrentPropertyToOverflow)
         {
@@ -476,20 +506,7 @@ void ClassMapColumnFactory::EvaluateIfPropertyGoesToOverflow(uint32_t columnsReq
 
       const std::vector<DbColumn const*> sharedColumns = m_primaryOrJoinedTable->FindAll(DbColumn::Kind::SharedData);
       
-      uint32_t nSharedColumns;
-      if (!ctx.RemapManager().HasFreedColumns())
-          {
-          nSharedColumns = (uint32_t) sharedColumns.size();
-          }
-      else
-          {
-          nSharedColumns = 0;
-          for (DbColumn const* col : sharedColumns)
-              {
-              if (!ctx.RemapManager().IsColumnFreed(*col))
-                  nSharedColumns++;
-              }
-          }
+      const uint32_t nSharedColumns = (uint32_t) sharedColumns.size();
 
       //Determine how many shared columns can be created
       uint32_t sharedColumnThatCanBeCreated = 0;
@@ -499,7 +516,13 @@ void ClassMapColumnFactory::EvaluateIfPropertyGoesToOverflow(uint32_t columnsReq
           }
       else
           {
-          sharedColumnThatCanBeCreated = (nSharedColumns < m_maxSharedColumnCount.Value()) ? m_maxSharedColumnCount.Value() - nSharedColumns : 0;
+          if (nSharedColumns > m_maxSharedColumnCount.Value())
+              {
+              BeAssert(false && "SharedColumnCount bypassed the limit set in CA");
+              return;
+              }
+
+          sharedColumnThatCanBeCreated = m_maxSharedColumnCount.Value() - (uint32_t) sharedColumns.size();
           if (sharedColumnThatCanBeCreated > nAvaliablePhysicalColumns)
               sharedColumnThatCanBeCreated = nAvaliablePhysicalColumns; //restrict available shared columns to available physical columns
           }
@@ -514,14 +537,26 @@ void ClassMapColumnFactory::EvaluateIfPropertyGoesToOverflow(uint32_t columnsReq
         return;
         }
 
-    const bool hasFreedColumns = ctx.RemapManager().HasFreedColumns();
     for (DbColumn const* sharedColumn : sharedColumns)
         {
-        if (hasFreedColumns && ctx.RemapManager().IsColumnFreed(*sharedColumn))
-            continue;
-
         if (!IsColumnInUse(*sharedColumn) && !IsColumnUsedByAnyDerivedClass(*sharedColumn, ctx))
+            {
+            /*
+             * POC-No-Remap
+             * 
+             * We must also skip columns that are claimed for a different access string in ec_PropertyMap or ec_PropertyMap_Overrides.
+             * This mirrors the check in ReuseOrCreateSharedColumn so that the overflow decision here is consistent with which columns ReuseOrCreateSharedColumn will actually accept.
+             * Without this check, EvaluateIfPropertyGoesToOverflow may conclude that a column is reusable (because its ec_PropertyMap entry was deleted during the cascade),
+             * while ReuseOrCreateSharedColumn then rejects it (because an override entry still claims it for a different property), forcing a call to AddSharedColumn() and bypassing the
+             * MaxSharedColumnsBeforeOverflow limit.
+             */
+            if (Enum::Contains(ctx.GetOptions(), SchemaManager::SchemaImportOptions::SkipRemapping)
+                && accessString != nullptr
+                && IsColumnUsedForDifferentAccessString(*sharedColumn, ctx, *accessString))
+                continue; // column is reserved for a different property - not reusable
+
             requiredRemainingColumns--; //column can be reused
+            }
 
         if(requiredRemainingColumns <= 0)
             return;
@@ -572,7 +607,14 @@ DbColumn* ClassMapColumnFactory::Allocate(SchemaImportContext& ctx, ECN::ECPrope
         {
         if (IsCompatible(*column, type, param))
             {
-            if (!ctx.RemapManager().IsColumnFreed(*column))
+            /*
+             * POC-No-Remap
+             *
+             * The column maps may be pre-filled with a column from a stale derived-class ClassMap entry (via UpdateColumnResolutionScope::Full).
+             * If that column is still used in ec_PropertyMap for a DIFFERENT access string (i.e. a sibling property) we must not use it as the 
+             * canonical base-class column or we would create a "column used by multiple properties" conflict.
+             */ 
+            if (!Enum::Contains(ctx.GetOptions(), SchemaManager::SchemaImportOptions::SkipRemapping) || !IsColumnUsedForDifferentAccessString(*column, ctx, accessString))
                 return HandleOverflowColumn(column);
             }
         }
@@ -651,18 +693,27 @@ ColumnMaps* ClassMapColumnFactory::GetColumnMaps() const
 //------------------------------------------------------------------------------------------
 //@bsimethod
 //-----------------------------------------------------------------------------------------
-DbColumn* ClassMapColumnFactory::ReuseOrCreateSharedColumn(SchemaImportContext& ctx) const
+DbColumn* ClassMapColumnFactory::ReuseOrCreateSharedColumn(SchemaImportContext& ctx, Utf8StringCR accessString) const
     {
-    const bool hasFreedColumns = ctx.RemapManager().HasFreedColumns();
+    const bool skipRemap = Enum::Contains(ctx.GetOptions(), SchemaManager::SchemaImportOptions::SkipRemapping);
     for (DbColumn const* column : GetEffectiveTable(ctx)->GetColumns())
         {
         if (column->IsShared() && !GetColumnMaps()->IsColumnInUse(*column))
             {
-            if (hasFreedColumns && ctx.RemapManager().IsColumnFreed(*column))
-                continue;
+            if (!IsColumnUsedByAnyDerivedClass(*column, ctx))
+                {
+                /*
+                 * POC-No-Remap
+                 *
+                 * Avoid any column that is currently used by an ec_PropertyMap entry with a DIFFERENT access string.
+                 * That entry belongs to a sibling / derived class property and must not be displaced by the new canonical base-class property.
+                 * When ALL ec_PropertyMap entries for a column were deleted (same access string, now in overrides only), the column is safely reusable as the canonical slot.
+                 */
+                if (skipRemap && IsColumnUsedForDifferentAccessString(*column, ctx, accessString))
+                    continue;
 
-            if(!IsColumnUsedByAnyDerivedClass(*column, ctx))
                 return const_cast<DbColumn*>(column);
+                }
             }
         }
 
@@ -725,6 +776,46 @@ bool ClassMapColumnFactory::IsColumnUsedByAnyDerivedClass(DbColumn const& column
 
     bool result = stmt->GetValueBoolean(0);
     return result;
+    }
+
+//------------------------------------------------------------------------------------------
+//@bsimethod
+//-----------------------------------------------------------------------------------------
+bool ClassMapColumnFactory::IsColumnUsedForDifferentAccessString(DbColumn const& column, SchemaImportContext& ctx, Utf8StringCR accessString) const
+    {
+    /*
+     * POC-No-Remap
+     *
+     * Returns true if ec_PropertyMap or ec_PropertyMap_Overrides has any row that maps this physical column to an access string OTHER than the one being allocated.
+     * When such a row exists, the column is "claimed" by a different property of some class in the hierarchy.
+     * Assigning it as the canonical column for `accessString` would produce a "column used by multiple properties" conflict.
+     *
+     * We must check both tables:
+     *  - ec_PropertyMap: for properties still canonically mapped to this column.
+     *  - ec_PropertyMap_Overrides: for properties whose canonical ec_PropertyMap entry was
+     *    deleted, but whose physical column is still reserved for the original property's data.
+     *    Without this check, a sibling property's override column could be reused as the
+     *    canonical slot for a different property, causing stale data to appear in queries.
+     */
+    if (!column.HasId())
+        return false; // not yet persisted - no ec_PropertyMap entries can reference it
+
+    CachedStatementPtr stmt = ctx.GetECDb().GetImpl().GetCachedSqliteStatement(
+        "SELECT 1 FROM ("
+        "  SELECT pp.AccessString FROM main." TABLE_PropertyMap " pm "
+        "  JOIN main." TABLE_PropertyPath " pp ON pp.Id = pm.PropertyPathId "
+        "  WHERE pm.ColumnId = ? "
+        "  UNION ALL "
+        "  SELECT o.AccessString FROM main." TABLE_PropertyMap_Overrides " o "
+        "  WHERE o.ColumnId = ? "
+        ") sub WHERE sub.AccessString != ? LIMIT 1");
+    if (!stmt.IsValid())
+        return false;
+
+    stmt->BindId(1, column.GetId());
+    stmt->BindId(2, column.GetId());
+    stmt->BindText(3, accessString.c_str(), Statement::MakeCopy::No);
+    return stmt->Step() == BE_SQLITE_ROW;
     }
 
 //***************************************************************************************

--- a/iModelCore/ECDb/ECDb/ClassMapColumnFactory.h
+++ b/iModelCore/ECDb/ECDb/ClassMapColumnFactory.h
@@ -125,8 +125,9 @@ struct ClassMapColumnFactory final
         DbColumn* HandleOverflowColumn(DbColumn* column) const;
         DbTable* GetEffectiveTable(SchemaImportContext&) const;
         DbTable* GetOrCreateOverflowTable(SchemaImportContext&) const;
-        DbColumn* ReuseOrCreateSharedColumn(SchemaImportContext&) const;
+        DbColumn* ReuseOrCreateSharedColumn(SchemaImportContext&, Utf8StringCR accessString) const;
         bool IsColumnUsedByAnyDerivedClass(DbColumn const&, SchemaImportContext&) const;
+        bool IsColumnUsedForDifferentAccessString(DbColumn const&, SchemaImportContext&, Utf8StringCR accessString) const;
         ColumnMaps* GetColumnMaps() const;
         DbColumn* RegisterColumnMap(Utf8StringCR accessString, DbColumn* column) const;
         bool IsCompatible(DbColumn const&, DbColumn::Type, DbColumn::CreateParams const&) const;
@@ -153,7 +154,7 @@ struct ClassMapColumnFactory final
             }
             void EnsurePropertyGoesToOverflow(Utf8StringCR propertyName, SchemaImportContext& ctx) const;
             void EvaluateIfPropertyGoesToOverflow(Utf8StringCR propertyName, SchemaImportContext& ctx) const;
-            void EvaluateIfPropertyGoesToOverflow(uint32_t columnsRequired, SchemaImportContext& ctx) const;
+            void EvaluateIfPropertyGoesToOverflow(uint32_t columnsRequired, SchemaImportContext& ctx, Utf8StringCP accessString = nullptr) const;
             void ResetCurrentPropertyOverflowFlag() const { m_putCurrentPropertyToOverflow = false; }
             void Debug() const { GetColumnMaps()->Debug(); }
             DbColumn* Allocate(SchemaImportContext&, ECN::ECPropertyCR property, DbColumn::Type type, DbColumn::CreateParams const& param, Utf8StringCR accessString, bool forcePhysicalColum = false) const;

--- a/iModelCore/ECDb/ECDb/ProfileManager.cpp
+++ b/iModelCore/ECDb/ECDb/ProfileManager.cpp
@@ -481,6 +481,18 @@ DbResult ProfileManager::CreateProfileTables() const
     if (BE_SQLITE_OK != stat)
         return stat;
 
+    /*
+     * POC-No-Remap
+     * A new system table that is a first-class home for per-class column deviations, separate from ec_PropertyMap
+     */
+    stat = m_ecdb.GetImpl().ExecuteDDL("CREATE Table " TABLE_PropertyMap_Overrides 
+                            "(ClassId   INTEGER NOT NULL REFERENCES " TABLE_Class "(Id), "
+                            "AccessString TEXT NOT NULL COLLATE NOCASE, "
+                            "ColumnId INTEGER NOT NULL REFERENCES " TABLE_Column "(Id), "
+                            "PRIMARY KEY (ClassId, AccessString))");
+    if (BE_SQLITE_OK != stat)
+        return stat;
+
     stat = m_ecdb.GetImpl().ExecuteDDL("CREATE UNIQUE INDEX uix_ec_PropertyMap_ClassId_PropertyPathId_ColumnId ON " TABLE_PropertyMap "(ClassId,PropertyPathId,ColumnId);"
                            "CREATE INDEX ix_ec_PropertyMap_PropertyPathId ON " TABLE_PropertyMap "(PropertyPathId);"
                            "CREATE INDEX ix_ec_PropertyMap_ColumnId ON " TABLE_PropertyMap "(ColumnId);");

--- a/iModelCore/ECDb/ECDb/RemapManager.cpp
+++ b/iModelCore/ECDb/ECDb/RemapManager.cpp
@@ -81,8 +81,17 @@ WHERE [ecp].[Id] = ? AND [col].[ColumnKind] = 4
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //+---------------+---------------+---------------+---------------+---------------+------
-BentleyStatus RemapManager::CleanModifiedMappings()
+BentleyStatus RemapManager::CleanModifiedMappings(SchemaImportContext& ctx)
     {
+    /*
+     * POC-No-Remap
+     */
+    if (Enum::Contains(ctx.GetOptions(), SchemaManager::SchemaImportOptions::SkipRemapping))
+        {
+        LOG.infov("SkipRemapping: CleanModifiedMappings() skipped.");
+        return SUCCESS;
+        }
+
     ECDB_PERF_LOG_SCOPE("Schema import> Clean modified property mappings");
     std::set<ECPropertyId> cleanedPropertyIds; //hold a unique list of rootPropertyIds that have been cleaned, so we can purge orphans later
     for (auto& [key, remapInfo] : m_remapInfos)
@@ -151,51 +160,6 @@ WHERE [ec_PropertyPath].[RootPropertyId] = ? AND NOT EXISTS (SELECT 1 FROM [ec_P
         if(affectedRows >= 1)
             LOG.infov("Cleaned up %" PRIi32 " orphan row(s) in PropertyPath for property %d", affectedRows, cleanedPropertyId.GetValue());
         }
-
-    const auto& dbSchema = m_schemaManager.GetDbSchema();
-
-    // Get all the columns that were freed/cleaned during this schema import
-    std::map<const DbTable*, std::vector<const DbColumn*>> freedColumnsByTable;
-    for (auto const& classPair : m_cleanedMappingInfo)
-        {
-        for (auto const& cleaned : classPair.second)
-            {
-            const auto table = dbSchema.FindTable(cleaned.m_tableName.c_str());
-            if (table == nullptr)
-                continue;
-            const auto column = table->FindColumn(cleaned.m_columnName.c_str());
-            if (column == nullptr)
-                continue;
-            freedColumnsByTable[table].push_back(column);
-            }
-        }
-
-    // Only block columns on tables whose linked table also has a freed column which might lead to cross table circular remaps.
-    for (auto const& tablePair : freedColumnsByTable)
-        {
-        const auto table = tablePair.first;
-        auto linkedTableHasFreedColumns = false;
-
-        if (table->GetType() == DbTable::Type::Overflow)
-            {
-            // This is an overflow table, check whether its parent table also freed columns
-            if (const DbTable::LinkNode* parentNode = table->GetLinkNode().GetParent(); parentNode != nullptr)
-                linkedTableHasFreedColumns = (freedColumnsByTable.count(&parentNode->GetTable()) > 0);
-            }
-        else
-            {
-            // This is a primary or joined table, check whether its overflow child also freed columns
-            if (const DbTable::LinkNode* overflowNode = table->GetLinkNode().FindOverflowTable(); overflowNode != nullptr)
-                linkedTableHasFreedColumns = (freedColumnsByTable.count(&overflowNode->GetTable()) > 0);
-            }
-
-        if (!linkedTableHasFreedColumns)
-            continue; // safe to reuse, no risk of a possible circular remap across the linked tables
-
-        for (const DbColumn* column : tablePair.second)
-            m_allFreedColumnIdentifiers.insert(RemapManager::GetFullColumnIdentifier(column->GetTable().GetName(), column->GetName()));
-        }
-
 
     return SUCCESS;
     }
@@ -679,6 +643,15 @@ SELECT DISTINCT [s].[Name] from [ec_Class] c
 
 BentleyStatus RemapManager::RestoreAndProcessCleanedPropertyMaps(SchemaImportContext& ctx)
     {
+    /*
+     * POC-No-Remap
+     */
+    if (Enum::Contains(ctx.GetOptions(), SchemaManager::SchemaImportOptions::SkipRemapping))
+        {
+        LOG.infov("SkipRemapping: RestoreAndProcessCleanedPropertyMaps() skipped.");
+        return SUCCESS;
+        }
+
     if(m_cleanedMappingInfo.empty())
         return SUCCESS;
 
@@ -760,6 +733,15 @@ BentleyStatus RemapManager::RestoreAndProcessCleanedPropertyMaps(SchemaImportCon
 
 BentleyStatus RemapManager::UpgradeExistingECInstancesWithRemappedProperties(SchemaImportContext& ctx)
     {
+    /*
+     * POC-No-Remap
+     */
+    if (Enum::Contains(ctx.GetOptions(), SchemaManager::SchemaImportOptions::SkipRemapping))
+        {
+        LOG.infov("SkipRemapping: UpgradeExistingECInstancesWithRemappedProperties() skipped.");
+        return SUCCESS;
+        }
+
     ECDB_PERF_LOG_SCOPE( "Schema import> Upgrading existing ECInstances with remapped properties to different columns");
     for(auto& pair : m_remappedColumns)
         {

--- a/iModelCore/ECDb/ECDb/RemapManager.h
+++ b/iModelCore/ECDb/ECDb/RemapManager.h
@@ -127,7 +127,6 @@ public:
 //Clear Modified Mappings
 private:
     std::map<ECN::ECClassId, std::vector<CleanedMappingInfo>> m_cleanedMappingInfo;
-    std::set<Utf8String> m_allFreedColumnIdentifiers;
 
     std::vector<CleanedMappingInfo>& GetOrAddCleanedMappingInfo(ECN::ECClassId id)
         {
@@ -139,7 +138,7 @@ private:
     BentleyStatus CleanAddedBaseClass(RemapInfosForClass& remapInfo, AddedBaseClass& addedBaseClass, std::set<ECN::ECPropertyId>& cleanedPropertyIds);
     
 public:
-    BentleyStatus CleanModifiedMappings();
+    BentleyStatus CleanModifiedMappings(SchemaImportContext& ctx);
     BentleyStatus EnsureInvolvedSchemasAreLoaded(bvector<ECN::ECSchemaCP> const& schemasToMap);
     BentleyStatus RestoreAndProcessCleanedPropertyMaps(SchemaImportContext& ctx);
     void DiscardCleanedMappingInfoForClass(ECN::ECClassId classId)
@@ -174,21 +173,6 @@ public:
         {
         Utf8PrintfString idStr("%s:%s", tableName.c_str(), columnName.c_str());
         return idStr;
-        }
-
-    // Returns true if any columns were freed during CleanModifiedMappings on a table whose linked primary/overflow table also freed columns.
-    // Only such columns are tracked because they carry a risk of cross-table circular remaps.
-    // Columns freed on tables without a linked freed table are safe to reuse immediately and are NOT reflected here.
-    bool HasFreedColumns() const
-        {
-        return !m_allFreedColumnIdentifiers.empty();
-        }
-
-    // Returns true if the given column was freed during CleanModifiedMappings AND its table's linked primary/overflow table also freed columns in the same import.
-    // Such a column cannot be immediately reused due to the risk of a cross-table circular remap.
-    bool IsColumnFreed(const DbColumn& column) const
-        {
-        return m_allFreedColumnIdentifiers.count(RemapManager::GetFullColumnIdentifier(column.GetTable().GetName(), column.GetName())) > 0;
         }
     };
 

--- a/iModelCore/ECDb/ECDb/SchemaManagerDispatcher.cpp
+++ b/iModelCore/ECDb/ECDb/SchemaManagerDispatcher.cpp
@@ -1429,7 +1429,10 @@ SchemaImportResult MainSchemaManager::MapSchemas(SchemaImportContext& ctx, bvect
     DataChangeSqlListener dataChangeListener(ctx.GetECDb());
 #endif
 
-    if (SUCCESS != ctx.RemapManager().CleanModifiedMappings()) {
+    /*
+     * POC-No-Remap
+     */
+    if (SUCCESS != ctx.RemapManager().CleanModifiedMappings(ctx)) {
         return failedToMap();
     }
 

--- a/iModelCore/ECDb/ECDb/SchemaWriter.cpp
+++ b/iModelCore/ECDb/ECDb/SchemaWriter.cpp
@@ -1665,6 +1665,41 @@ BentleyStatus SchemaWriter::ImportProperty(Context& ctx, ECN::ECPropertyCR ecPro
       return result;
       }
 
+    /*
+     * POC-No-Remap
+     *
+     * Problem:
+     * When a new property is added to a class any subclass that already has the same property name mapped via a mixin or other inheritance path stores its data in the OLD column.
+     * With the SkipRemapping flag, CleanModifiedMappings is skipped, so CopyModifiedBasePropertyMaps would overwrite the subclass's column assignment to point at the new 
+     * base-class column, thus silently losing access to the pre-upgrade data.
+     *
+     * Fix:
+     * Write ec_PropertyMap_Overrides entries for every subclass of the owning class that currently has this property name in ec_PropertyMap under a DIFFERENT property Id (i.e. from a mixin or sibling class).
+     * The override causes _Load to remap the cloned base-class column back to the original physical column, and CopyModifiedBasePropertyMaps will see the override and skip the overwrite.
+     */
+    if (Enum::Contains(ctx.ImportCtx().GetOptions(), SchemaManager::SchemaImportOptions::SkipRemapping) && ctx.GetECDb().TableExists(TABLE_PropertyMap_Overrides))
+        {
+        const Utf8String owningClassIdStr = ecProperty.GetClass().GetId().ToString();
+        stat = ctx.GetECDb().ExecuteSql(SqlPrintfString(
+            "INSERT OR IGNORE INTO " TABLE_PropertyMap_Overrides " (ClassId, AccessString, ColumnId) "
+            "SELECT pm.ClassId, pp.AccessString, pm.ColumnId "
+            "FROM " TABLE_PropertyMap " pm "
+            "JOIN " TABLE_PropertyPath " pp ON pm.PropertyPathId = pp.Id "
+            "JOIN main." TABLE_Property " p ON pp.RootPropertyId = p.Id "
+            "WHERE p.Name = '%s' "
+            "  AND p.ClassId != %s "
+            "  AND EXISTS ("
+            "    SELECT 1 FROM main." TABLE_ClassHierarchyCache " h "
+            "    WHERE h.ClassId = pm.ClassId AND h.BaseClassId = %s"
+            "  )",
+            ecProperty.GetName().c_str(),
+            owningClassIdStr.c_str(),
+            owningClassIdStr.c_str()).GetUtf8CP());
+
+        if (BE_SQLITE_OK != stat)
+            return ERROR;
+        }
+
     ctx.ImportCtx().RemapManager().CollectRemapInfosFromNewProperty(ecProperty.GetClass(), ecProperty.GetName(), ecProperty.GetId());
     return result;
     }
@@ -3848,7 +3883,48 @@ BentleyStatus SchemaWriter::DeleteProperty(Context& ctx, PropertyChange& propert
         }
 
     if(isOverriddenProperty)
-        ctx.ImportCtx().RemapManager().CollectRemapInfosFromDeletedPropertyOverride(deletedProperty.GetId());
+        {
+        if (Enum::Contains(ctx.ImportCtx().GetOptions(), SchemaManager::SchemaImportOptions::SkipRemapping) && ctx.GetECDb().TableExists(TABLE_PropertyMap_Overrides))
+            {
+            /*
+             * POC-No-Remap
+             *
+             * Capture overrides for the directly-owning class AND all transitive subclasses that
+             * inherited this property without their own ec_PropertyMap row.
+             * Those subclasses also stored their data in the same physical column (eg: ps1), and they likewise need an override entry so ClassMap::_Load can remap them correctly after the upgrade.
+             * The recursive CTE stops descending through a subclass that has its own explicit ec_PropertyMap entry (it has its own mapping and therefore its own override row).
+             */
+            const auto result = ctx.GetECDb().ExecuteSql(SqlPrintfString(
+                "WITH RECURSIVE overridden_classes(ClassId, AccessString, ColumnId) AS ( "
+                "  SELECT pm.ClassId, pp.AccessString, pm.ColumnId "
+                "  FROM " TABLE_PropertyMap " pm JOIN " TABLE_PropertyPath " pp ON pm.PropertyPathId = pp.Id "
+                "  WHERE pp.RootPropertyId = %s "
+                "  UNION ALL "
+                "  SELECT h.ClassId, oc.AccessString, oc.ColumnId "
+                "  FROM main.ec_ClassHasBaseClasses h "
+                "  JOIN overridden_classes oc ON h.BaseClassId = oc.ClassId "
+                "  WHERE NOT EXISTS ( "
+                "    SELECT 1 FROM " TABLE_PropertyMap " pm2 "
+                "    JOIN " TABLE_PropertyPath " pp2 ON pm2.PropertyPathId = pp2.Id "
+                "    WHERE pm2.ClassId = h.ClassId AND pp2.RootPropertyId = %s "
+                "  ) "
+                ") "
+                "INSERT OR IGNORE INTO " TABLE_PropertyMap_Overrides " (ClassId, AccessString, ColumnId) "
+                "SELECT ClassId, AccessString, ColumnId FROM overridden_classes",
+                deletedProperty.GetId().ToString().c_str(),
+                deletedProperty.GetId().ToString().c_str()).GetUtf8CP());
+
+            if (result != BE_SQLITE_DONE && result != BE_SQLITE_OK)
+                {
+                BeAssert(false && "Failed to delete ecproperty");
+                return ERROR;
+                }
+            }
+        else
+            {
+            ctx.ImportCtx().RemapManager().CollectRemapInfosFromDeletedPropertyOverride(deletedProperty.GetId());
+            }
+        }
     
     LOG.infov("ECClass %s: ECProperty '%s' is being deleted.", ecClass.GetFullName(), deletedProperty.GetName().c_str());
     //Delete ECProperty entry make sure ec_Column is already deleted or set to null

--- a/iModelCore/ECDb/ECDb/SqlNames.h
+++ b/iModelCore/ECDb/ECDb/SqlNames.h
@@ -26,6 +26,7 @@ BEGIN_BENTLEY_SQLITE_EC_NAMESPACE
 #define TABLE_Property "ec_Property"
 #define TABLE_PropertyCategory "ec_PropertyCategory"
 #define TABLE_PropertyMap "ec_PropertyMap"
+#define TABLE_PropertyMap_Overrides "ec_PropertyMap_Overrides"
 #define TABLE_PropertyPath "ec_PropertyPath"
 #define TABLE_RelationshipConstraint "ec_RelationshipConstraint"
 #define TABLE_RelationshipConstraintClass "ec_RelationshipConstraintClass"

--- a/iModelCore/ECDb/ECDb/ViewGenerator.cpp
+++ b/iModelCore/ECDb/ECDb/ViewGenerator.cpp
@@ -554,6 +554,227 @@ BentleyStatus ViewGenerator::RenderMixinClassMap(NativeSqlBuilder& viewSql, Cont
     return SUCCESS;
     }
 
+/*
+ * POC-No-Remap
+ */
+//---------------------------------------------------------------------------------------
+// @bsimethod
+//---------------------------------------------------------------------------------------
+//static
+void ViewGenerator::CollectConcreteRelationshipClassMapsInTable(std::vector<const ClassMap*>& result, const ClassMap& classMap, const DbTable& table)
+    {
+    Nullable<std::vector<const ClassMap*>> derivedMaps = classMap.GetDerivedClassMaps();
+    if (!derivedMaps.IsNull())
+        {
+        for (const ClassMap* derivedMap : derivedMaps.Value())
+            {
+            if (!derivedMap->IsMappedTo(table))
+                continue;
+            CollectConcreteRelationshipClassMapsInTable(result, *derivedMap, table);
+            }
+        }
+
+    ECRelationshipClassCP relClass = classMap.GetClass().GetRelationshipClassCP();
+    // Include this class if it is a non-abstract, non-mixin relationship class
+    if (relClass != nullptr && relClass->GetClassModifier() != ECClassModifier::Abstract && classMap.GetType() == ClassMap::Type::RelationshipLinkTable)
+        result.push_back(&classMap);
+    }
+
+//---------------------------------------------------------------------------------------
+// @bsimethod
+//---------------------------------------------------------------------------------------
+//static
+void ViewGenerator::CollectConcreteEntityClassMapsInTable(std::vector<const ClassMap*>& result, const ClassMap& classMap, const DbTable& table)
+    {
+    Nullable<std::vector<const ClassMap*>> derivedMaps = classMap.GetDerivedClassMaps();
+    if (!derivedMaps.IsNull())
+        {
+        for (const ClassMap* derivedMap : derivedMaps.Value())
+            {
+            if (derivedMap->IsMixin() || !derivedMap->IsMappedTo(table))
+                continue;
+            CollectConcreteEntityClassMapsInTable(result, *derivedMap, table);
+            }
+        }
+
+    ECEntityClassCP entityClass = classMap.GetClass().GetEntityClassCP();
+    // Include this class if it is a non-abstract, non-mixin entity class
+    if (entityClass != nullptr && !entityClass->IsMixin() && entityClass->GetClassModifier() != ECClassModifier::Abstract)
+        result.push_back(&classMap);
+    }
+
+//---------------------------------------------------------------------------------------
+// @bsimethod
+//---------------------------------------------------------------------------------------
+//static
+bool ViewGenerator::HasDivergentColumnAssignments(const ClassMap& queryClassMap, const ClassMap& tableRootClassMap, const DbTable& table)
+    {
+    // Only TPH + ShareColumns hierarchies can have per-class column divergence
+    if (!queryClassMap.GetMapStrategy().IsTablePerHierarchy() || queryClassMap.GetMapStrategy().GetTphInfo().GetShareColumnsMode() == TablePerHierarchyInfo::ShareColumnsMode::No)
+        return false;
+
+    std::vector<const ClassMap*> concretes;
+
+    // Relationship classes are not entity classes, so GetEntityClassCP() returns nullptr for them.
+    // We must use the relationship-specific collector instead.
+    if (queryClassMap.GetClass().GetRelationshipClassCP() != nullptr)
+        CollectConcreteRelationshipClassMapsInTable(concretes, queryClassMap, table);
+    else
+        CollectConcreteEntityClassMapsInTable(concretes, queryClassMap, table);
+
+    SearchPropertyMapVisitor rootVisitor(PropertyMap::Type::SingleColumnData);
+    tableRootClassMap.GetPropertyMaps().AcceptVisitor(rootVisitor);
+    std::map<Utf8CP, const DbColumn*, CompareIUtf8Ascii> rootColumns;
+    for (const PropertyMap* pm : rootVisitor.Results())
+        rootColumns[pm->GetAccessString().c_str()] = &pm->GetAs<SingleColumnDataPropertyMap>().GetColumn();
+
+    for (const ClassMap* concreteMap : concretes)
+        {
+        if (concreteMap == &tableRootClassMap)
+            continue;
+
+        SearchPropertyMapVisitor concreteVisitor(PropertyMap::Type::SingleColumnData);
+        concreteMap->GetPropertyMaps().AcceptVisitor(concreteVisitor);
+        for (const PropertyMap* pm : concreteVisitor.Results())
+            {
+            auto it = rootColumns.find(pm->GetAccessString().c_str());
+            if (it == rootColumns.end())
+                continue; // property not on root class, no divergence for this access string
+            if (&pm->GetAs<SingleColumnDataPropertyMap>().GetColumn() != it->second)
+                return true;
+            }
+        }
+
+    return false;
+    }
+
+//---------------------------------------------------------------------------------------
+// @bsimethod
+//---------------------------------------------------------------------------------------
+//static
+BentleyStatus ViewGenerator::RenderDivergentEntityPartition(NativeSqlBuilder& viewSql, Context& ctx,
+    const ClassMap& queryClassMap, const ClassMap& tableRootClassMap, const DbTable& table)
+    {
+    std::vector<const ClassMap*> concretes;
+    CollectConcreteEntityClassMapsInTable(concretes, queryClassMap, table);
+    if (concretes.empty())
+        {
+        BeAssert(false && "RenderDivergentEntityPartition: no concrete classes found");
+        return ERROR;
+        }
+
+    // For SelectFromView queries with ONLY semantics, restrict the arms to the single queried class.
+    // Without this, the UNION ALL would contain arms for all derived classes, whose rows would pass through even when the caller issued "SELECT FROM ONLY B".
+    if (ctx.GetViewType() == ViewType::SelectFromView && !ctx.GetAs<SelectFromViewContext>().GetPolymorphicInfo().IsPolymorphic())
+        {
+        const TableSpaceSchemaManager& sm = ctx.GetSchemaManager();
+        ECClassId queryClassId = sm.GetClassId(queryClassMap.GetClass());
+        concretes.erase(std::remove_if(concretes.begin(), concretes.end(), [queryClassId, &sm](const ClassMap* cm) { return sm.GetClassId(cm->GetClass()) != queryClassId; }), concretes.end());
+        if (concretes.empty())
+            {
+            // The exact class is abstract or not in this table, nothing to render.
+            viewSql.Append("SELECT 1 WHERE 0");
+            return SUCCESS;
+            }
+        }
+
+    // Get the physical ECClassId column
+    const ECClassIdPropertyMap* ecClassIdPropMap = tableRootClassMap.GetECClassIdPropertyMap();
+    if (ecClassIdPropMap == nullptr)
+        return ERROR;
+    const SystemPropertyMap::PerTableIdPropertyMap* classIdDataPropMap = ecClassIdPropMap->FindDataPropertyMap(table);
+    if (classIdDataPropMap == nullptr || classIdDataPropMap->GetColumn().GetPersistenceType() != PersistenceType::Physical)
+        return ERROR;
+
+    Utf8String classIdColRef;
+    classIdColRef.Sprintf("[%s].[%s]", table.GetName().c_str(), classIdDataPropMap->GetColumn().GetName().c_str());
+
+    const TableSpaceSchemaManager& schemaManager = ctx.GetSchemaManager();
+
+    // Build UNION ALL arms. Each arm groups concrete classes that share an identical SELECT body.
+    struct Arm
+        {
+        Utf8String selectSql;
+        std::vector<ECClassId> classIds;
+
+        // Prevent merging a base class into the same arm as one of its derived classes.
+        // Ensure the results are in the expected order.
+        bool HasAncestorArm(ECClassCR cls, const TableSpaceSchemaManager& sm) const
+            {
+            for (ECClassId id : classIds)
+                {
+                ECClassCP other = sm.GetClass(id);
+                if (other != nullptr && cls.Is(other))
+                    return true;
+                }
+            return false;
+            }
+        };
+    std::vector<Arm> arms;
+
+    for (const ClassMap* concreteMap : concretes)
+        {
+        NativeSqlBuilder armSelect;
+        if (RenderEntityClassMap(armSelect, ctx, *concreteMap, table, &queryClassMap) != SUCCESS)
+            return ERROR;
+
+        ECClassId classId = schemaManager.GetClassId(concreteMap->GetClass());
+        Utf8String selectStr = armSelect.GetSql();
+
+        bool merged = false;
+        for (Arm& arm : arms)
+            {
+            if (arm.HasAncestorArm(concreteMap->GetClass(), schemaManager))
+                continue; // keep derived and ancestor in separate arms for ordering
+            if (arm.selectSql == selectStr)
+                {
+                arm.classIds.push_back(classId);
+                merged = true;
+                break;
+                }
+            }
+
+        if (!merged)
+            {
+            Arm newArm;
+            newArm.selectSql = std::move(selectStr);
+            newArm.classIds.push_back(classId);
+            arms.push_back(std::move(newArm));
+            }
+        }
+
+    NativeSqlBuilder::List unionList;
+    for (const Arm& arm : arms)
+        {
+        NativeSqlBuilder armView;
+        armView.Append(arm.selectSql.c_str());
+
+        if (arm.classIds.size() == 1)
+            {
+            armView.AppendFormatted(" WHERE %s=%lld", classIdColRef.c_str(), arm.classIds[0].GetValue());
+            }
+        else
+            {
+            armView.AppendFormatted(" WHERE %s IN (", classIdColRef.c_str());
+            for (size_t i = 0; i < arm.classIds.size(); i++)
+                {
+                if (i > 0)
+                    armView.Append(",");
+                armView.AppendFormatted("%lld", arm.classIds[i].GetValue());
+                }
+            armView.Append(")");
+            }
+
+        unionList.push_back(armView);
+        }
+
+    if (unionList.empty())
+        return ERROR;
+
+    viewSql.Append(unionList, " UNION ALL ");
+    return SUCCESS;
+    }
+
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //---------------------------------------------------------------------------------------
@@ -608,33 +829,58 @@ BentleyStatus ViewGenerator::RenderEntityClassMap(NativeSqlBuilder& viewSql, Con
             }
 
         ClassMap const* castInto = tableRootClassMap == &classMap ? nullptr : &classMap;
-        if (RenderEntityClassMap(view, ctx, *tableRootClassMap, partition->GetTable(), castInto) != SUCCESS)
-            return ERROR;
+
+        /*
+         * POC-No-Remap
+         *
+         * When any concrete class in the hierarchy stores a shared-column property at a different physical column than the table root, a single
+         * SELECT cannot serve all classes.
+         * Generate a UNION ALL with one arm per column-layout group so each class reads from its own correct physical column.
+         */
+        const bool divergent = HasDivergentColumnAssignments(classMap, *tableRootClassMap, partition->GetTable());
+        if (divergent)
+            {
+            if (RenderDivergentEntityPartition(view, ctx, classMap, *tableRootClassMap, partition->GetTable()) != SUCCESS)
+                return ERROR;
+            }
+        else
+            {
+            if (RenderEntityClassMap(view, ctx, *tableRootClassMap, partition->GetTable(), castInto) != SUCCESS)
+                return ERROR;
+            }
 
         //capture view column names only for the first class, all other classes will be unioned together and therefore
         //have the same select clause
         if (ctx.GetViewType() == ViewType::ECClassView)
             ctx.GetAs<ECClassViewContext>().StopCaptureViewColumnNames();
 
-        if (const auto ecClassIdPropertyMap = tableRootClassMap->GetECClassIdPropertyMap())
+        /*
+         * POC-No-Remap
+         *
+         * When the divergent path was used, the UNION ALL arms already carry per-arm WHERE ECClassId filters, so we can skip the normal GenerateECClassIdFilter join entirely.
+         */
+        if (!divergent)
             {
-            if (SystemPropertyMap::PerTableIdPropertyMap const* classIdPropertyMap = ecClassIdPropertyMap->FindDataPropertyMap(partition->GetTable()))
+            if (const auto ecClassIdPropertyMap = tableRootClassMap->GetECClassIdPropertyMap())
                 {
-                const bool isSelectFromView = ctx.GetViewType() == ViewType::SelectFromView;
-                if (classIdPropertyMap->GetColumn().GetPersistenceType() == PersistenceType::Physical &&
-                    (!isSelectFromView || ctx.GetAs<SelectFromViewContext>().IsECClassIdFilterEnabled()))
+                if (SystemPropertyMap::PerTableIdPropertyMap const* classIdPropertyMap = ecClassIdPropertyMap->FindDataPropertyMap(partition->GetTable()))
                     {
-                    const auto polymorphicInfo = isSelectFromView ? ctx.GetAs<SelectFromViewContext>().GetPolymorphicInfo() : PolymorphicInfo::All();
-                    Utf8String filterSQL;
-                    if (SUCCESS != GenerateECClassIdFilter(filterSQL, classMap, partition->GetTable(), classIdPropertyMap->GetColumn(), polymorphicInfo))
-                        return ERROR;
-
-                    if (!filterSQL.empty())
+                    const bool isSelectFromView = ctx.GetViewType() == ViewType::SelectFromView;
+                    if (classIdPropertyMap->GetColumn().GetPersistenceType() == PersistenceType::Physical &&
+                        (!isSelectFromView || ctx.GetAs<SelectFromViewContext>().IsECClassIdFilterEnabled()))
                         {
-                        if (polymorphicInfo.IsOnly())
-                            view.Append(" WHERE ").Append(filterSQL.c_str());
-                        else
-                            view.Append(" ").Append(filterSQL.c_str());
+                        const auto polymorphicInfo = isSelectFromView ? ctx.GetAs<SelectFromViewContext>().GetPolymorphicInfo() : PolymorphicInfo::All();
+                        Utf8String filterSQL;
+                        if (SUCCESS != GenerateECClassIdFilter(filterSQL, classMap, partition->GetTable(), classIdPropertyMap->GetColumn(), polymorphicInfo))
+                            return ERROR;
+
+                        if (!filterSQL.empty())
+                            {
+                            if (polymorphicInfo.IsOnly())
+                                view.Append(" WHERE ").Append(filterSQL.c_str());
+                            else
+                                view.Append(" ").Append(filterSQL.c_str());
+                            }
                         }
                     }
                 }
@@ -782,42 +1028,99 @@ BentleyStatus ViewGenerator::RenderRelationshipClassLinkTableMap(NativeSqlBuilde
         ConstraintECClassIdJoinInfo sourceECClassIdJoinInfo = ConstraintECClassIdJoinInfo::Create(*relationMap.GetSourceECClassIdPropMap(), partition.GetTable(), isSourceClassIdSelected);
         ConstraintECClassIdJoinInfo targetECClassIdJoinInfo = ConstraintECClassIdJoinInfo::Create(*relationMap.GetTargetECClassIdPropMap(), partition.GetTable(), isTargetClassIdSelected);
 
-        if (DoRenderRelationshipClassMap(view, ctx, contextRelationship, partition.GetTable(), sourceECClassIdJoinInfo, targetECClassIdJoinInfo, castInto) != SUCCESS)
-            return ERROR;
+        /*
+         * POC-No-Remap
+         *
+         * When any concrete relationship subclass stores a shared-column property at a different physical column than the table root, a single SELECT cannot serve all classes.
+         * Generate a UNION ALL with one arm per concrete subclass so each reads from its own correct physical column.
+         */
+        std::vector<const ClassMap*> concretes;
+        CollectConcreteRelationshipClassMapsInTable(concretes, contextRelationship, partition.GetTable());
+        const bool divergent = !concretes.empty() && HasDivergentColumnAssignments(relationMap, contextRelationship, partition.GetTable());
 
-        //capture view column names only for the first table, all other tables will be unioned together and therefore
-        //have the same select clause
-        if (ctx.GetViewType() == ViewType::ECClassView)
-            ctx.GetAs<ECClassViewContext>().StopCaptureViewColumnNames();
-
-        if (sourceECClassIdJoinInfo.IsClassIdSelected() && sourceECClassIdJoinInfo.RequiresJoin())
-            view.Append(sourceECClassIdJoinInfo.GetNativeJoinSql());
-
-        if (targetECClassIdJoinInfo.IsClassIdSelected() && targetECClassIdJoinInfo.RequiresJoin())
-            view.Append(targetECClassIdJoinInfo.GetNativeJoinSql());
-
-        ECClassIdPropertyMap const* classIdPropMap = relationMap.GetECClassIdPropertyMap();
-        if (SystemPropertyMap::PerTableIdPropertyMap const* classIdDataPropertyMap = classIdPropMap->FindDataPropertyMap(partition.GetTable()))
+        if (divergent)
             {
-            const bool isSelectFromView = ctx.GetViewType() == ViewType::SelectFromView;
-            if (classIdDataPropertyMap->GetColumn().GetPersistenceType() == PersistenceType::Physical && (!isSelectFromView || ctx.GetAs<SelectFromViewContext>().IsECClassIdFilterEnabled()))
+            // Get ECClassId column reference for the per-arm WHERE filter
+            const ECClassIdPropertyMap* ecClassIdPropMap = contextRelationship.GetECClassIdPropertyMap();
+            if (ecClassIdPropMap == nullptr)
+                return ERROR;
+            const SystemPropertyMap::PerTableIdPropertyMap* classIdDataPropMap = ecClassIdPropMap->FindDataPropertyMap(partition.GetTable());
+            if (classIdDataPropMap == nullptr || classIdDataPropMap->GetColumn().GetPersistenceType() != PersistenceType::Physical)
+                return ERROR;
+
+            Utf8String classIdColRef;
+            classIdColRef.Sprintf("[%s].[%s]", partition.GetTable().GetName().c_str(), classIdDataPropMap->GetColumn().GetName().c_str());
+
+            const TableSpaceSchemaManager& schemaManager = ctx.GetSchemaManager();
+            bool capturedColumnNames = false;
+            for (const ClassMap* concreteClassMap : concretes)
                 {
-                Utf8String filterSQL;
-                const auto polymorphicInfo = isSelectFromView ? ctx.GetAs<SelectFromViewContext>().GetPolymorphicInfo() : PolymorphicInfo::All();
-                if (SUCCESS != GenerateECClassIdFilter(filterSQL, relationMap, partition.GetTable(), classIdDataPropertyMap->GetColumn(), polymorphicInfo))
+                const RelationshipClassLinkTableMap& concreteRelMap = concreteClassMap->GetAs<RelationshipClassLinkTableMap>();
+                const RelationshipClassLinkTableMap* castIntoForConcrete = (&concreteRelMap == &relationMap) ? nullptr : &relationMap;
+
+                NativeSqlBuilder armView;
+                if (DoRenderRelationshipClassMap(armView, ctx, concreteRelMap, partition.GetTable(), sourceECClassIdJoinInfo, targetECClassIdJoinInfo, castIntoForConcrete) != SUCCESS)
                     return ERROR;
 
-                if (!filterSQL.empty())
+                // Capture view column names only for the first arm
+                if (!capturedColumnNames && ctx.GetViewType() == ViewType::ECClassView)
                     {
-                    if (polymorphicInfo.IsOnly())
-                        view.Append(" WHERE ").Append(filterSQL.c_str());
-                    else
-                        view.Append(" ").Append(filterSQL.c_str());
+                    ctx.GetAs<ECClassViewContext>().StopCaptureViewColumnNames();
+                    capturedColumnNames = true;
                     }
+
+                if (sourceECClassIdJoinInfo.IsClassIdSelected() && sourceECClassIdJoinInfo.RequiresJoin())
+                    armView.Append(sourceECClassIdJoinInfo.GetNativeJoinSql());
+
+                if (targetECClassIdJoinInfo.IsClassIdSelected() && targetECClassIdJoinInfo.RequiresJoin())
+                    armView.Append(targetECClassIdJoinInfo.GetNativeJoinSql());
+
+                ECClassId concreteClassId = schemaManager.GetClassId(concreteRelMap.GetClass());
+                armView.AppendFormatted(" WHERE %s = %lld",
+                    classIdColRef.c_str(), concreteClassId.GetValue());
+
+                unionList.push_back(armView);
                 }
             }
+        else
+            {
+            if (DoRenderRelationshipClassMap(view, ctx, contextRelationship, partition.GetTable(), sourceECClassIdJoinInfo, targetECClassIdJoinInfo, castInto) != SUCCESS)
+                return ERROR;
 
-        unionList.push_back(view);
+            //capture view column names only for the first table, all other tables will be unioned together and therefore
+            //have the same select clause
+            if (ctx.GetViewType() == ViewType::ECClassView)
+                ctx.GetAs<ECClassViewContext>().StopCaptureViewColumnNames();
+
+            if (sourceECClassIdJoinInfo.IsClassIdSelected() && sourceECClassIdJoinInfo.RequiresJoin())
+                view.Append(sourceECClassIdJoinInfo.GetNativeJoinSql());
+
+            if (targetECClassIdJoinInfo.IsClassIdSelected() && targetECClassIdJoinInfo.RequiresJoin())
+                view.Append(targetECClassIdJoinInfo.GetNativeJoinSql());
+
+            const ECClassIdPropertyMap* classIdPropMap = relationMap.GetECClassIdPropertyMap();
+            if (const SystemPropertyMap::PerTableIdPropertyMap* classIdDataPropertyMap = classIdPropMap->FindDataPropertyMap(partition.GetTable()))
+                {
+                const bool isSelectFromView = ctx.GetViewType() == ViewType::SelectFromView;
+                if (classIdDataPropertyMap->GetColumn().GetPersistenceType() == PersistenceType::Physical && (!isSelectFromView || ctx.GetAs<SelectFromViewContext>().IsECClassIdFilterEnabled()))
+                    {
+                    Utf8String filterSQL;
+                    const auto polymorphicInfo = isSelectFromView ? ctx.GetAs<SelectFromViewContext>().GetPolymorphicInfo() : PolymorphicInfo::All();
+                    if (SUCCESS != GenerateECClassIdFilter(filterSQL, relationMap, partition.GetTable(), classIdDataPropertyMap->GetColumn(), polymorphicInfo))
+                        return ERROR;
+
+                    if (!filterSQL.empty())
+                        {
+                        if (polymorphicInfo.IsOnly())
+                            view.Append(" WHERE ").Append(filterSQL.c_str());
+                        else
+                            view.Append(" ").Append(filterSQL.c_str());
+                        }
+                    }
+                }
+
+            unionList.push_back(view);
+            }
         }
 
     if (unionList.empty() || relationMap.GetMapStrategy().GetStrategy() == MapStrategy::UnsupportedByECVersion)
@@ -1219,7 +1522,7 @@ BentleyStatus ViewGenerator::DoRenderRelationshipClassMap(NativeSqlBuilder& view
     NativeSqlBuilder dataPropertySql;
     bset<DbTable const*> requireJoinTo;
     bool sourceOrTargetRequiresJoin = (sourceJoinInfo.IsClassIdSelected() && sourceJoinInfo.RequiresJoin()) || (targetJoinInfo.IsClassIdSelected() && targetJoinInfo.RequiresJoin());
-    if (RenderPropertyMaps(dataPropertySql, ctx, requireJoinTo, relationMap, contextTable, nullptr, PropertyMap::Type::Data, sourceOrTargetRequiresJoin) != SUCCESS)
+    if (RenderPropertyMaps(dataPropertySql, ctx, requireJoinTo, relationMap, contextTable, castInto, PropertyMap::Type::Data, sourceOrTargetRequiresJoin) != SUCCESS)
         return ERROR;
 
     if (!requireJoinTo.empty())

--- a/iModelCore/ECDb/ECDb/ViewGenerator.h
+++ b/iModelCore/ECDb/ECDb/ViewGenerator.h
@@ -183,6 +183,18 @@ struct ViewGenerator final
         static BentleyStatus RenderEntityClassMap(NativeSqlBuilder& viewSql, Context&, ClassMap const& classMap);
         static BentleyStatus RenderEntityClassMap(NativeSqlBuilder& viewSql, Context&, ClassMap const& classMap, DbTable const& contextTable, ClassMap const* castAs = nullptr);
         static BentleyStatus RenderNullView(NativeSqlBuilder& viewSql, Context&, ClassMap const& classMap);
+
+        // SkipRemapping support: divergent column rendering
+        // Collects all non-mixin concrete entity ClassMaps mapped to the given table in DFS order
+        static void CollectConcreteEntityClassMapsInTable(std::vector<const ClassMap*>& result, const ClassMap& classMap, const DbTable& table);
+        // Collects all non-abstract concrete RelationshipLinkTable ClassMaps mapped to the given table in DFS order.
+        static void CollectConcreteRelationshipClassMapsInTable(std::vector<const ClassMap*>& result, const ClassMap& classMap, const DbTable& table);
+        // Returns true if any concrete class in the hierarchy maps a shared-column property to a different
+        // physical column than the given tableRootClassMap does.
+        // Drives the UNION ALL rendering path.
+        static bool HasDivergentColumnAssignments(ClassMap const& queryClassMap, ClassMap const& tableRootClassMap, DbTable const& table);
+        // Renders a UNION ALL SELECT for the given queryClassMap over the given table.
+        static BentleyStatus RenderDivergentEntityPartition(NativeSqlBuilder& viewSql, Context& ctx, ClassMap const& queryClassMap, ClassMap const& tableRootClassMap, DbTable const& table);
         static BentleyStatus RenderMixinClassMap(NativeSqlBuilder& viewSql, Context&, ClassMap const& classMap);
         static BentleyStatus RenderMixinClassMap(bmap<Utf8String, bpair<DbTable const*, bvector<ECN::ECClassId>>, CompareIUtf8Ascii>& selectClauses, Context& ctx, ClassMap const& mixInClassMap, ClassMap const& derivedClassMap);
         static BentleyStatus GenerateECClassIdFilter(Utf8StringR filterSqlExpression, ClassMap const&, DbTable const&, DbColumn const& classIdColumn, PolymorphicInfo const& polymorphic);

--- a/iModelCore/ECDb/PublicAPI/ECDb/SchemaManager.h
+++ b/iModelCore/ECDb/PublicAPI/ECDb/SchemaManager.h
@@ -410,6 +410,11 @@ struct SchemaManager final : ECN::IECSchemaLocater, ECN::IECClassLocater
             DoNotFailForDeletionsOrModifications        = 1 << 2,   //! This is for the case of domain schemas that differ between files even though the schema name and versions are unchanged.  In such a case, we only want to merge in acceptable changes, not delete anything
             AllowDataTransformDuringSchemaUpgrade       = 1 << 4,   //! The allow schema upgrade to transform data if needed.
             AllowMajorSchemaUpgradeForDynamicSchemas    = 1 << 5,   //! If specified, schema upgrades where the major version has changed are only supported for dynamic schemas. Takes precedence over DisallowMajorSchemaUpgrade.
+            /*
+             * POC-No-Remap
+             * Skip the column-remapping pipeline during schema upgrade.
+             */
+            SkipRemapping                         = 1 << 6,
             };
 #if !defined (DOCUMENTATION_GENERATOR)
         struct Dispatcher;

--- a/iModelCore/ECDb/Tests/NonPublished/SchemaRemapTests.cpp
+++ b/iModelCore/ECDb/Tests/NonPublished/SchemaRemapTests.cpp
@@ -117,7 +117,7 @@ TEST_F(SchemaRemapTestFixture, StructPropertyRemap) {
     )xml");
 
     ASSERT_EQ(BentleyStatus::SUCCESS, ImportSchema(schema2,
-      SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade
+      SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade | SchemaManager::SchemaImportOptions::SkipRemapping
     ));
 
     SchemaItem schema3(R"xml(
@@ -162,7 +162,7 @@ TEST_F(SchemaRemapTestFixture, StructPropertyRemap) {
     )xml");
 
     ASSERT_EQ(BentleyStatus::SUCCESS, ImportSchema(schema3,
-                           SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade));
+                           SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade | SchemaManager::SchemaImportOptions::SkipRemapping));
     m_ecdb.SaveChanges();
 }
 
@@ -524,7 +524,7 @@ TEST_F(SchemaRemapTestFixture, MovePropertyUpInHierarchyUsingOverflowTable)
           </ECEntityClass>
         </ECSchema>
         )schema");
-    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade));
+    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade | SchemaManager::SchemaImportOptions::SkipRemapping));
 
     // Verify we can insert and select
     ASSERT_ECSQL(m_ecdb, ECSqlStatus::Success, BE_SQLITE_DONE, "INSERT INTO TestSchema.BAFFLE_SILENCERS (MovingProperty) VALUES ('SECOND')");
@@ -596,7 +596,7 @@ TEST_F(SchemaRemapTestFixture, MovePropertyUpInHierarchySimplified)
           </ECEntityClass>
         </ECSchema>
         )schema");
-    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade));
+    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade | SchemaManager::SchemaImportOptions::SkipRemapping));
 
     // Verify we can insert and select
     ASSERT_ECSQL(m_ecdb, ECSqlStatus::Success, BE_SQLITE_DONE, "INSERT INTO TestSchema.A (MovingProperty) VALUES ('SECOND')");
@@ -641,6 +641,8 @@ TEST_F(SchemaRemapTestFixture, MovePropertyUpInHierarchyRemoveOriginal)
 
     auto result = GetHelper().ExecuteSelectECSql("SELECT MovingProperty FROM TestSchema.A");
     ASSERT_EQ(JsonValue(R"json([{"MovingProperty":"FIRST"}])json"), result);
+
+    m_ecdb.SaveChanges();
     }
 
     //import edited schema with some changes.
@@ -667,7 +669,7 @@ TEST_F(SchemaRemapTestFixture, MovePropertyUpInHierarchyRemoveOriginal)
           </ECEntityClass>
         </ECSchema>
         )schema");
-    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade));
+    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade | SchemaManager::SchemaImportOptions::SkipRemapping));
 
     // Verify the instance is still intact
     {
@@ -739,7 +741,7 @@ TEST_F(SchemaRemapTestFixture, MovePropertyUpInHierarchyDeleteBeforeAddInSchema)
           </ECEntityClass>
         </ECSchema>
         )schema");
-    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade));
+    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade | SchemaManager::SchemaImportOptions::SkipRemapping));
 
     // Verify the instance is still intact
     {
@@ -885,7 +887,7 @@ TEST_F(SchemaRemapTestFixture, MoveMultiplePropertiesUpInHierarchy)
           </ECEntityClass>
         </ECSchema>
         )schema");
-    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade));
+    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade | SchemaManager::SchemaImportOptions::SkipRemapping));
 
     // Verify the instance is still intact
     {
@@ -1017,7 +1019,7 @@ TEST_F(SchemaRemapTestFixture, AddNewBaseClassInMiddleMovePropertyUp)
           </ECEntityClass>
         </ECSchema>
         )schema");
-    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade));
+    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade | SchemaManager::SchemaImportOptions::SkipRemapping));
 
     // Verify the instance is still intact
     {
@@ -1063,7 +1065,7 @@ TEST_F(SchemaRemapTestFixture, AddNewBaseClassInMiddleMovePropertyUpRemoveOrigin
     ASSERT_ECSQL(m_ecdb, ECSqlStatus::Success, BE_SQLITE_DONE, "INSERT INTO TestSchema.A (MovingProperty) VALUES ('FIRST')");
 
     auto result = GetHelper().ExecuteSelectECSql("SELECT MovingProperty FROM TestSchema.A");
-    ASSERT_EQ(JsonValue(R"json([{"MovingProperty":"FIRST"}])json"), result);
+    EXPECT_EQ(JsonValue(R"json([{"MovingProperty":"FIRST"}])json"), result);
     }
 
     //import edited schema with some changes.
@@ -1096,12 +1098,12 @@ TEST_F(SchemaRemapTestFixture, AddNewBaseClassInMiddleMovePropertyUpRemoveOrigin
           </ECEntityClass>
         </ECSchema>
         )schema");
-    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade));
+    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade | SchemaManager::SchemaImportOptions::SkipRemapping));
 
     // Verify the instance is still intact
     {
     auto result = GetHelper().ExecuteSelectECSql("SELECT MovingProperty FROM TestSchema.A");
-    ASSERT_EQ(JsonValue(R"json([{"MovingProperty":"FIRST"}])json"), result);
+    EXPECT_EQ(JsonValue(R"json([{"MovingProperty":"FIRST"}])json"), result);
     }
     }
 
@@ -1170,7 +1172,7 @@ TEST_F(SchemaRemapTestFixture, AddNewBaseClassInMiddleMovePropertyUpReversed)
           </ECEntityClass>
         </ECSchema>
         )schema");
-    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade));
+    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade | SchemaManager::SchemaImportOptions::SkipRemapping));
 
     // Verify the instance is still intact
     {
@@ -1243,7 +1245,7 @@ TEST_F(SchemaRemapTestFixture, AddNewBaseClassInMiddleMovePropertyUpRemoveOrigin
           </ECEntityClass>
         </ECSchema>
         )schema");
-    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade));
+    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade | SchemaManager::SchemaImportOptions::SkipRemapping));
 
     // Verify the instance is still intact
     {
@@ -1392,7 +1394,7 @@ TEST_F(SchemaRemapTestFixture, MoveMultiColumnPropertyUp)
           </ECEntityClass>
         </ECSchema>
         )schema");
-    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade));
+    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade | SchemaManager::SchemaImportOptions::SkipRemapping));
     {
     ASSERT_ECSQL(m_ecdb, ECSqlStatus::Success, BE_SQLITE_DONE, "INSERT INTO TestSchema.A (MovingProperty.blue, MovingProperty.green, MovingProperty.red) VALUES (4,5,6)");
 
@@ -1502,7 +1504,7 @@ TEST_F(SchemaRemapTestFixture, MoveMultiColumnPropertiesUp)
           </ECEntityClass>
         </ECSchema>
         )schema");
-    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade));
+    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade | SchemaManager::SchemaImportOptions::SkipRemapping));
 
     {
     auto result = GetHelper().ExecuteSelectECSql("SELECT Color, SimpleProp, Coords FROM TestSchema.A");
@@ -1884,7 +1886,7 @@ TEST_F(SchemaRemapTestFixture, ModifyAndMoveStruct)
           </ECEntityClass>
         </ECSchema>
         )schema");
-    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade));
+    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade | SchemaManager::SchemaImportOptions::SkipRemapping));
     {
     ASSERT_ECSQL(m_ecdb, ECSqlStatus::Success, BE_SQLITE_DONE, "INSERT INTO TestSchema.A (MovingProperty.blue, MovingProperty.green, MovingProperty.red) VALUES (4,5,6)");
 
@@ -2099,7 +2101,7 @@ TEST_F(SchemaRemapTestFixture, MovePropertyOnRelationshipClass)
           </ECEntityClass>
         </ECSchema>
         )schema");
-    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade));
+    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade | SchemaManager::SchemaImportOptions::SkipRemapping));
 
     // Verify old and new instances
     {
@@ -2480,7 +2482,7 @@ TEST_F(SchemaRemapTestFixture, SpatialCompositionNewBaseScenario)
     </ECEntityClass>
         </ECSchema>
         )schema");
-    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade));
+    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade | SchemaManager::SchemaImportOptions::SkipRemapping));
 
     // Verify old and new instances
     {
@@ -3014,7 +3016,7 @@ TEST_F(SchemaRemapTestFixture, MoveMultiplePropertiesUp)
           </ECEntityClass>
         </ECSchema>
         )schema");
-    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade));
+    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade | SchemaManager::SchemaImportOptions::SkipRemapping));
 
     // Verify instances are still intact
     {
@@ -3097,7 +3099,7 @@ TEST_F(SchemaRemapTestFixture, MovePropertyToOverflow)
           </ECEntityClass>
         </ECSchema>
         )schema");
-    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade));
+    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade | SchemaManager::SchemaImportOptions::SkipRemapping));
 
     {
     auto result = GetHelper().ExecuteSelectECSql("SELECT Base1,Base2,Base3,A1,A2 FROM TestSchema.A");
@@ -3180,7 +3182,7 @@ TEST_F(SchemaRemapTestFixture, MovePropertyFromOverflow)
           </ECEntityClass>
         </ECSchema>
         )schema");
-    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade));
+    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade | SchemaManager::SchemaImportOptions::SkipRemapping));
 
     {
     auto result = GetHelper().ExecuteSelectECSql("SELECT Base1,Base2,Base3,A1,A2,A3 FROM TestSchema.A");
@@ -3267,7 +3269,7 @@ TEST_F(SchemaRemapTestFixture, SwapColumnsWithOverflow)
           </ECEntityClass>
         </ECSchema>
         )schema");
-    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade));
+    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade | SchemaManager::SchemaImportOptions::SkipRemapping));
 
     {
     ASSERT_ECSQL(m_ecdb, ECSqlStatus::Success, BE_SQLITE_DONE, "INSERT INTO TestSchema.Peanut (A,B,C) VALUES ('PA','PB','PC')");
@@ -3428,7 +3430,7 @@ TEST_F(SchemaRemapTestFixture, SwapColumnsForProperty)
           </ECEntityClass>
         </ECSchema>
         )schema");
-    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade));
+    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade | SchemaManager::SchemaImportOptions::SkipRemapping));
 
     {
     auto result = GetHelper().ExecuteSelectECSql("SELECT Base1,Sub1,Sub2 FROM TestSchema.A");
@@ -3528,7 +3530,7 @@ TEST_F(SchemaRemapTestFixture, MoveMultiplePropertiesInCircle)
           </ECEntityClass>
         </ECSchema>
         )schema");
-    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade));
+    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade | SchemaManager::SchemaImportOptions::SkipRemapping));
 
     {
     auto result = GetHelper().ExecuteSelectECSql("SELECT A,B,C,D FROM TestSchema.Class1");
@@ -3617,7 +3619,7 @@ TEST_F(SchemaRemapTestFixture, MovePropertyToOverflowUsingDifferentIdColumn)
           </ECEntityClass>
         </ECSchema>
         )schema");
-    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade));
+    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade | SchemaManager::SchemaImportOptions::SkipRemapping));
 
     {
     auto result = GetHelper().ExecuteSelectECSql("SELECT Base1,Base2,Base3,A1,A2 FROM TestSchema.A");
@@ -3895,7 +3897,7 @@ TEST_F(SchemaRemapTestFixture, CivilProblemMay21)
         </ECSchema>
         )schema");
 
-    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade));
+    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade | SchemaManager::SchemaImportOptions::SkipRemapping));
     //Verify our instances are still intact
     {
     auto result = GetHelper().ExecuteSelectECSql("SELECT Name, GeometryClass FROM ONLY TestSchema.Alignment");
@@ -4261,7 +4263,7 @@ TEST_F(SchemaRemapTestFixture, IfcProblemJune21)
 </ECSchema>
         )schema");
 
-    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade));
+    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade | SchemaManager::SchemaImportOptions::SkipRemapping));
     }
 
 //---------------------------------------------------------------------------------------
@@ -4460,7 +4462,7 @@ TEST_F(SchemaRemapTestFixture, MixinToBaseClass)
           </ECEntityClass>
         </ECSchema>
         )schema");
-    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade));
+    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade | SchemaManager::SchemaImportOptions::SkipRemapping));
 
     // Verify instances are intact
     {
@@ -4575,7 +4577,7 @@ TEST_F(SchemaRemapTestFixture, DerivedMixinToBaseClass)
           </ECEntityClass>
         </ECSchema>
         )schema");
-    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade));
+    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade | SchemaManager::SchemaImportOptions::SkipRemapping));
 
     // Verify instances are intact
     {
@@ -4682,7 +4684,7 @@ TEST_F(SchemaRemapTestFixture, MixinToBaseClassTwoLevels)
           </ECEntityClass>
         </ECSchema>
         )schema");
-    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade));
+    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade | SchemaManager::SchemaImportOptions::SkipRemapping));
 
     // Verify instances are intact
     {
@@ -5121,7 +5123,7 @@ TEST_F(SchemaRemapTestFixture, BuildingUSMappingProblem)
     </ECEntityClass>
 </ECSchema>
         )schema");
-    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade));
+    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade | SchemaManager::SchemaImportOptions::SkipRemapping));
     }
 
 
@@ -5204,7 +5206,7 @@ TEST_F(SchemaRemapTestFixture, PutSiblingsIntoHierarchy)
     </ECEntityClass>
 </ECSchema>
         )schema");
-    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade));
+    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade | SchemaManager::SchemaImportOptions::SkipRemapping));
 
     {
     auto result = GetHelper().ExecuteSelectECSql("SELECT A FROM TestSchema.Building");
@@ -5309,7 +5311,7 @@ TEST_F(SchemaRemapTestFixture, PutMultipleSiblingsIntoHierarchy)
             </ECEntityClass>
         </ECSchema>
         )schema");
-    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade));
+    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade | SchemaManager::SchemaImportOptions::SkipRemapping));
 
     {
     auto result = GetHelper().ExecuteSelectECSql("SELECT A FROM TestSchema.Building");
@@ -5407,7 +5409,7 @@ TEST_F(SchemaRemapTestFixture, PutSiblingsIntoHierarchyWithStruct)
           </ECEntityClass>
         </ECSchema>
         )schema");
-    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade));
+    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade | SchemaManager::SchemaImportOptions::SkipRemapping));
     {
     auto result = GetHelper().ExecuteSelectECSql("SELECT PropA FROM TestSchema.A");
     ASSERT_EQ(JsonValue(R"json([{"PropA":{"blue":1,"green":2,"red":3}}])json"), result);
@@ -5500,7 +5502,7 @@ TEST_F(SchemaRemapTestFixture, InsertBaseClassRemapSiblingsWithStruct)
           </ECEntityClass>
         </ECSchema>
         )schema");
-    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade));
+    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade | SchemaManager::SchemaImportOptions::SkipRemapping));
     {
     auto result = GetHelper().ExecuteSelectECSql("SELECT PropA FROM TestSchema.A");
     ASSERT_EQ(JsonValue(R"json([{"PropA":{"blue":1,"green":2,"red":3}}])json"), result);
@@ -5594,7 +5596,7 @@ TEST_F(SchemaRemapTestFixture, InsertTwoConnectedBaseClassesRemapSiblings)
           </ECEntityClass>
         </ECSchema>
         )schema");
-    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade));
+    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade | SchemaManager::SchemaImportOptions::SkipRemapping));
     {
     auto result = GetHelper().ExecuteSelectECSql("SELECT PropA FROM TestSchema.A");
     ASSERT_EQ(JsonValue(R"json([{"PropA":{"blue":1,"green":2,"red":3}}])json"), result);
@@ -5677,7 +5679,7 @@ TEST_F(SchemaRemapTestFixture, InsertBaseClassTwice)
           </ECEntityClass>
         </ECSchema>
         )schema");
-    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade));
+    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade | SchemaManager::SchemaImportOptions::SkipRemapping));
     {
     auto result = GetHelper().ExecuteSelectECSql("SELECT PropA, PropC, PropE FROM TestSchema.E");
     ASSERT_EQ(JsonValue(R"json([{"PropA":"A","PropC":"C","PropE":"E"}])json"), result);
@@ -5766,7 +5768,7 @@ TEST_F(SchemaRemapTestFixture, PutTwoClassesIntoHierarchy)
           </ECEntityClass>
         </ECSchema>
         )schema");
-    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade));
+    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade | SchemaManager::SchemaImportOptions::SkipRemapping));
     {
     auto result = GetHelper().ExecuteSelectECSql("SELECT PropA, PropC, PropE FROM TestSchema.E");
     ASSERT_EQ(JsonValue(R"json([{"PropA":"A","PropC":"C","PropE":"E"}])json"), result);
@@ -5867,7 +5869,7 @@ TEST_F(SchemaRemapTestFixture, PutSiblingsIntoHierarchyWithNestedStruct)
           </ECEntityClass>
         </ECSchema>
         )schema");
-    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade));
+    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade | SchemaManager::SchemaImportOptions::SkipRemapping));
     {
     auto result = GetHelper().ExecuteSelectECSql("SELECT f, g FROM ONLY TestSchema.A");
     ASSERT_EQ(JsonValue(R"json([{"f":{"c":{"a":"f.c.a","b":"f.c.b"},"d":"f.d"},"g":"g"}])json"), result);
@@ -5967,7 +5969,7 @@ TEST_F(SchemaRemapTestFixture, PutSiblingsIntoHierarchyWithPropertyOverrides)
           </ECEntityClass>
         </ECSchema>
         )schema");
-    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade));
+    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade | SchemaManager::SchemaImportOptions::SkipRemapping));
 
     {
     auto result = GetHelper().ExecuteSelectECSql("SELECT a, b, c FROM TestSchema.A");
@@ -6079,7 +6081,7 @@ TEST_F(SchemaRemapTestFixture, PutBaseClassTurnPropertiesIntoOverrides)
           </ECEntityClass>
         </ECSchema>
         )schema");
-    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade));
+    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade | SchemaManager::SchemaImportOptions::SkipRemapping));
     {
     auto result = GetHelper().ExecuteSelectECSql("SELECT a, b, c, d, e, f, g, h FROM TestSchema.Leaf");
     ASSERT_EQ(JsonValue(R"json([{"a":"A","b":"B","c":"C","d":"D","e":"E","f":"F","g":"G","h":"H"}])json"), result);
@@ -6177,7 +6179,7 @@ TEST_F(SchemaRemapTestFixture, CreateBaseClassTurnPropertiesIntoOverrides)
           </ECEntityClass>
         </ECSchema>
         )schema");
-    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade));
+    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade | SchemaManager::SchemaImportOptions::SkipRemapping));
     {
     auto result = GetHelper().ExecuteSelectECSql("SELECT a, b, c, d, e, f, g, h FROM TestSchema.Leaf");
     ASSERT_EQ(JsonValue(R"json([{"a":"A","b":"B","c":"C","d":"D","e":"E","f":"F","g":"G","h":"H"}])json"), result);
@@ -6275,7 +6277,7 @@ TEST_F(SchemaRemapTestFixture, PutSiblingsWithSwappedPropertiesIntoHierarchy)
     </ECEntityClass>
 </ECSchema>
         )schema");
-    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade));
+    ASSERT_EQ(SUCCESS, ImportSchema(editedSchemaItem, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade | SchemaManager::SchemaImportOptions::SkipRemapping));
     {
     auto result = GetHelper().ExecuteSelectECSql("SELECT name, description FROM TestSchema.Duck");
     ASSERT_EQ(JsonValue(R"json([{"name":"Nemo","description":"Nemo the Clownfish"},{"name":"Donald","description":"Donald the Duck"}])json"), result);
@@ -6365,7 +6367,7 @@ TEST_F(SchemaRemapTestFixture, InjectBaseClassInBaseSchema)
           </ECEntityClass>
         </ECSchema>
         )schema");
-    ASSERT_EQ(SUCCESS, ImportSchema(s1v2, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade));
+    ASSERT_EQ(SUCCESS, ImportSchema(s1v2, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade | SchemaManager::SchemaImportOptions::SkipRemapping));
     {
     auto result = GetHelper().ExecuteSelectECSql("SELECT PropA, PropC, PropD1, PropD2 FROM Schema2.D");
     ASSERT_EQ(JsonValue(R"json([{"PropA":"A","PropC":"C","PropD1":"D1","PropD2":"D2"}])json"), result);
@@ -6468,7 +6470,7 @@ TEST_F(SchemaRemapTestFixture, InjectBaseClassInBaseSchema2)
           </ECEntityClass>
         </ECSchema>
         )schema");
-    ASSERT_EQ(SUCCESS, ImportSchema(s1v2, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade));
+    ASSERT_EQ(SUCCESS, ImportSchema(s1v2, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade | SchemaManager::SchemaImportOptions::SkipRemapping));
     {
     auto result = GetHelper().ExecuteSelectECSql("SELECT PropA, PropC, PropD1, PropD2 FROM Schema2.D");
     ASSERT_EQ(JsonValue(R"json([{"PropA":"A","PropC":"C","PropD1":"D1","PropD2":"D2"}])json"), result);
@@ -6552,7 +6554,7 @@ TEST_F(SchemaRemapTestFixture, InjectBaseClassInBaseSchema3)
           </ECEntityClass>
         </ECSchema>
         )schema");
-    ASSERT_EQ(SUCCESS, ImportSchema(s1v2, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade));
+    ASSERT_EQ(SUCCESS, ImportSchema(s1v2, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade | SchemaManager::SchemaImportOptions::SkipRemapping));
     {
     auto result = GetHelper().ExecuteSelectECSql("SELECT PropA, PropC, PropD1, PropD2 FROM Schema2.D");
     ASSERT_EQ(JsonValue(R"json([{"PropA":"A","PropC":"C","PropD1":"D1","PropD2":"D2"}])json"), result);
@@ -6684,7 +6686,7 @@ TEST_F(SchemaRemapTestFixture, InjectBaseClassInBaseSchema4)
           </ECEntityClass>
       </ECSchema>
         )schema");
-    ASSERT_EQ(SUCCESS, ImportSchema(spCompV2, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade));
+    ASSERT_EQ(SUCCESS, ImportSchema(spCompV2, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade | SchemaManager::SchemaImportOptions::SkipRemapping));
     {
     auto result = GetHelper().ExecuteSelectECSql("SELECT ifcCompositionType FROM IFCDynamic.IfcBuilding");
     ASSERT_EQ(JsonValue(R"json([{"ifcCompositionType":"A"}])json"), result);
@@ -6837,7 +6839,7 @@ TEST_F(SchemaRemapTestFixture, InjectBaseClass4_Simplified)
             </ECEntityClass>
         </ECSchema>
         )schema");
-    ASSERT_EQ(SUCCESS, ImportSchema(spCompV2, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade));
+    ASSERT_EQ(SUCCESS, ImportSchema(spCompV2, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade | SchemaManager::SchemaImportOptions::SkipRemapping));
     {
     auto result = GetHelper().ExecuteSelectECSql("SELECT ifcCompositionType FROM TestSchema.IfcBuilding");
     ASSERT_EQ(JsonValue(R"json([{"ifcCompositionType":"A"}])json"), result);
@@ -6973,7 +6975,7 @@ TEST_F(SchemaRemapTestFixture, RevitStoryScenario)
     //import edited schema with some changes.
     Utf8PrintfString schemaV2Xml(schemaBaseline, "01.00.01", "FacilityPart");
     SchemaItem schemaV2(schemaV2Xml);
-    ASSERT_EQ(SUCCESS, ImportSchema(schemaV2, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade));
+    ASSERT_EQ(SUCCESS, ImportSchema(schemaV2, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade | SchemaManager::SchemaImportOptions::SkipRemapping));
     {
     ASSERT_ECSQL(m_ecdb, ECSqlStatus::Success, BE_SQLITE_DONE, "INSERT INTO TestSchema.Level (Description,RevitId) VALUES ('D','RevitId2')");
 
@@ -7133,7 +7135,7 @@ TEST_F(SchemaRemapTestFixture, RevitStoryScenarioWithSiblingAndMixins)
     //import edited schema with some changes.
     Utf8PrintfString schemaV2Xml(schemaBaseline, "01.00.01", "FacilityPart", "Facility");
     SchemaItem schemaV2(schemaV2Xml);
-    ASSERT_EQ(SUCCESS, ImportSchema(schemaV2, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade));
+    ASSERT_EQ(SUCCESS, ImportSchema(schemaV2, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade | SchemaManager::SchemaImportOptions::SkipRemapping));
     {
     auto result = GetHelper().ExecuteSelectECSql("SELECT RevitId,Label,ELEM_CATEGORY_PARAM,IFC_GUID,PHASE_CREATED,LEVEL_IS_STRUCTURAL FROM TestSchema.Level");
     ASSERT_EQ(JsonValue(R"json([{"RevitId":"RevitId","Label":"Label","ELEM_CATEGORY_PARAM":"ELEM_CATEGORY_PARAM","IFC_GUID":"IFC_GUID","PHASE_CREATED":"PHASE_CREATED","LEVEL_IS_STRUCTURAL":"LEVEL_IS_STRUCTURAL"}])json"), result);
@@ -7160,4 +7162,180 @@ TEST_F(SchemaRemapTestFixture, RevitStoryScenarioWithSiblingAndMixins)
     }
     }
 
+//=============================================================================
+// POC: SkipRemapping tests
+// These tests verify that the SkipRemapping import option correctly
+// avoids data movement while still returning the right data through queries,
+// thanks to the UNION ALL ViewGenerator path for divergent columns.
+//=============================================================================
+
+//---------------------------------------------------------------------------------------
+// @bsimethod
+// Scenario 6.1 from the design doc: "Move Property Up" without data transform.
+// A.age (new base property) gets a new column; subclass B.age keeps its old column.
+// A polymorphic query on A must return data from both columns correctly.
+//+---------------+---------------+---------------+---------------+---------------+------
+TEST_F(SchemaRemapTestFixture, SkipRemapping_MovePropertyUp_PolymorphicQueryCorrect)
+    {
+    SchemaItem schemaV1(R"schema(<?xml version='1.0' encoding='utf-8' ?>
+        <ECSchema schemaName="TestSchema" alias="ts" version="01.00.01" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+          <ECSchemaReference name="ECDbMap" version="02.00.00" alias="ecdbmap"/>
+          <ECEntityClass typeName="A">
+            <ECCustomAttributes>
+              <ClassMap xmlns="ECDbMap.02.00.00">
+                <MapStrategy>TablePerHierarchy</MapStrategy>
+              </ClassMap>
+              <ShareColumns xmlns="ECDbMap.02.00.00">
+                <MaxSharedColumnsBeforeOverflow>32</MaxSharedColumnsBeforeOverflow>
+              </ShareColumns>
+            </ECCustomAttributes>
+          </ECEntityClass>
+          <ECEntityClass typeName="B">
+            <BaseClass>A</BaseClass>
+            <ECProperty propertyName="Prop" typeName="string" />
+          </ECEntityClass>
+          <ECEntityClass typeName="C">
+            <BaseClass>A</BaseClass>
+            <ECProperty propertyName="Prop" typeName="string" />
+          </ECEntityClass>
+        </ECSchema>
+        )schema");
+
+    ASSERT_EQ(BentleyStatus::SUCCESS, SetupECDb("skipRemap_movePropertyUp.ecdb", schemaV1));
+
+    // Insert rows for both subclasses BEFORE the upgrade
+    ASSERT_ECSQL(m_ecdb, ECSqlStatus::Success, BE_SQLITE_DONE, "INSERT INTO TestSchema.B (Prop) VALUES ('B_BEFORE')");
+    ASSERT_ECSQL(m_ecdb, ECSqlStatus::Success, BE_SQLITE_DONE, "INSERT INTO TestSchema.C (Prop) VALUES ('C_BEFORE')");
+
+    // V2: promote Prop to the base class A; subclasses keep their overrides to simulate
+    //     the state after SkipRemapping (no column cleanup occurred).
+    SchemaItem schemaV2(R"schema(<?xml version='1.0' encoding='utf-8' ?>
+        <ECSchema schemaName="TestSchema" alias="ts" version="01.00.02" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+          <ECSchemaReference name="ECDbMap" version="02.00.00" alias="ecdbmap"/>
+          <ECEntityClass typeName="A">
+            <ECCustomAttributes>
+              <ClassMap xmlns="ECDbMap.02.00.00">
+                <MapStrategy>TablePerHierarchy</MapStrategy>
+              </ClassMap>
+              <ShareColumns xmlns="ECDbMap.02.00.00">
+                <MaxSharedColumnsBeforeOverflow>32</MaxSharedColumnsBeforeOverflow>
+              </ShareColumns>
+            </ECCustomAttributes>
+            <ECProperty propertyName="Prop" typeName="string" />
+          </ECEntityClass>
+          <ECEntityClass typeName="B">
+            <BaseClass>A</BaseClass>
+            <ECProperty propertyName="Prop" typeName="string" />
+          </ECEntityClass>
+          <ECEntityClass typeName="C">
+            <BaseClass>A</BaseClass>
+            <ECProperty propertyName="Prop" typeName="string" />
+          </ECEntityClass>
+        </ECSchema>
+        )schema");
+
+    ASSERT_EQ(SUCCESS, ImportSchema(schemaV2, SchemaManager::SchemaImportOptions::SkipRemapping));
+
+    // After import, old rows for B and C must still be readable via B-specific queries.
+    {
+    auto result = GetHelper().ExecuteSelectECSql("SELECT Prop FROM TestSchema.B");
+    ASSERT_EQ(JsonValue(R"json([{"Prop":"B_BEFORE"}])json"), result) << "B row should survive upgrade";
+    }
+    {
+    auto result = GetHelper().ExecuteSelectECSql("SELECT Prop FROM TestSchema.C");
+    ASSERT_EQ(JsonValue(R"json([{"Prop":"C_BEFORE"}])json"), result) << "C row should survive upgrade";
+    }
+
+    // Insert new rows AFTER the upgrade – they go through A's (new) column assignment.
+    ASSERT_ECSQL(m_ecdb, ECSqlStatus::Success, BE_SQLITE_DONE, "INSERT INTO TestSchema.B (Prop) VALUES ('B_AFTER')");
+    ASSERT_ECSQL(m_ecdb, ECSqlStatus::Success, BE_SQLITE_DONE, "INSERT INTO TestSchema.C (Prop) VALUES ('C_AFTER')");
+
+    // Polymorphic query on A must return all 4 rows with correct Prop values despite
+    // the divergent physical column assignments.
+    {
+    auto result = GetHelper().ExecuteSelectECSql("SELECT Prop FROM TestSchema.A ORDER BY Prop");
+    ASSERT_EQ(JsonValue(R"json([{"Prop":"B_AFTER"},{"Prop":"B_BEFORE"},{"Prop":"C_AFTER"},{"Prop":"C_BEFORE"}])json"), result)
+        << "Polymorphic query on A should return all rows via UNION ALL";
+    }
+    }
+
+//---------------------------------------------------------------------------------------
+// @bsimethod
+// Scenario 6.2: Insert new class in middle of hierarchy without remapping.
+// Before: D -> A.  After: D -> B -> A (B inserted, B has its own Prop).
+// Querying A polymorphically must still return D's data via the UNION ALL path.
+//+---------------+---------------+---------------+---------------+---------------+------
+TEST_F(SchemaRemapTestFixture, SkipRemapping_InsertBaseClass_PolymorphicQueryCorrect)
+    {
+    SchemaItem schemaV1(R"schema(<?xml version='1.0' encoding='utf-8' ?>
+        <ECSchema schemaName="TestSchema" alias="ts" version="01.00.01" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+          <ECSchemaReference name="ECDbMap" version="02.00.00" alias="ecdbmap"/>
+          <ECEntityClass typeName="A">
+            <ECCustomAttributes>
+              <ClassMap xmlns="ECDbMap.02.00.00">
+                <MapStrategy>TablePerHierarchy</MapStrategy>
+              </ClassMap>
+              <ShareColumns xmlns="ECDbMap.02.00.00">
+                <MaxSharedColumnsBeforeOverflow>32</MaxSharedColumnsBeforeOverflow>
+              </ShareColumns>
+            </ECCustomAttributes>
+          </ECEntityClass>
+          <ECEntityClass typeName="D">
+            <BaseClass>A</BaseClass>
+            <ECProperty propertyName="Prop" typeName="string" />
+          </ECEntityClass>
+        </ECSchema>
+        )schema");
+
+    ASSERT_EQ(BentleyStatus::SUCCESS, SetupECDb("skipRemap_insertBaseClass.ecdb", schemaV1));
+    ASSERT_ECSQL(m_ecdb, ECSqlStatus::Success, BE_SQLITE_DONE, "INSERT INTO TestSchema.D (Prop) VALUES ('D_BEFORE')");
+
+    // Insert B between A and D without remapping column assignments.
+    SchemaItem schemaV2(R"schema(<?xml version='1.0' encoding='utf-8' ?>
+        <ECSchema schemaName="TestSchema" alias="ts" version="01.00.02" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+          <ECSchemaReference name="ECDbMap" version="02.00.00" alias="ecdbmap"/>
+          <ECEntityClass typeName="A">
+            <ECCustomAttributes>
+              <ClassMap xmlns="ECDbMap.02.00.00">
+                <MapStrategy>TablePerHierarchy</MapStrategy>
+              </ClassMap>
+              <ShareColumns xmlns="ECDbMap.02.00.00">
+                <MaxSharedColumnsBeforeOverflow>32</MaxSharedColumnsBeforeOverflow>
+              </ShareColumns>
+            </ECCustomAttributes>
+          </ECEntityClass>
+          <ECEntityClass typeName="B">
+            <BaseClass>A</BaseClass>
+            <ECProperty propertyName="Prop" typeName="string" />
+          </ECEntityClass>
+          <ECEntityClass typeName="D">
+            <BaseClass>B</BaseClass>
+            <ECProperty propertyName="Prop" typeName="string" />
+          </ECEntityClass>
+        </ECSchema>
+        )schema");
+
+    ASSERT_EQ(SUCCESS, ImportSchema(schemaV2, SchemaManager::SchemaImportOptions::SkipRemapping));
+
+    // Pre-upgrade D row must still be readable.
+    {
+    auto result = GetHelper().ExecuteSelectECSql("SELECT Prop FROM TestSchema.D");
+    ASSERT_EQ(JsonValue(R"json([{"Prop":"D_BEFORE"}])json"), result) << "D row should survive upgrade";
+    }
+
+    // Insert a new D row and a new B row after upgrade.
+    ASSERT_ECSQL(m_ecdb, ECSqlStatus::Success, BE_SQLITE_DONE, "INSERT INTO TestSchema.D (Prop) VALUES ('D_AFTER')");
+    ASSERT_ECSQL(m_ecdb, ECSqlStatus::Success, BE_SQLITE_DONE, "INSERT INTO TestSchema.B (Prop) VALUES ('B_AFTER')");
+
+    {
+    auto result = GetHelper().ExecuteSelectECSql("SELECT Prop FROM TestSchema.D ORDER BY Prop");
+    ASSERT_EQ(JsonValue(R"json([{"Prop":"D_AFTER"},{"Prop":"D_BEFORE"}])json"), result);
+    }
+    {
+    auto result = GetHelper().ExecuteSelectECSql("SELECT Prop FROM TestSchema.B ORDER BY Prop");
+    ASSERT_EQ(JsonValue(R"json([{"Prop":"B_AFTER"},{"Prop":"D_AFTER"},{"Prop":"D_BEFORE"}])json"), result);
+    }
+    }
+
 END_ECDBUNITTESTS_NAMESPACE
+


### PR DESCRIPTION
## 1. Background

When an ECSchema is upgraded in ECDb - for example, promoting a property from a subclass to a base class, or inserting a new class into the middle of an existing hierarchy - the existing "remap pipeline" detects that the new canonical column for a property differs from where data was previously stored, and **physically moves the data** into the new column.

This pipeline (`RemapManager`) is:
- Correct and well-tested.
- Required to hold a **write lock** for the duration of the upgrade.
- Expensive for large files: it performs full-table scans and row-by-row UPDATE operations.
- But more importantly from our perspective, it is internally complex. It must detect and handle circular column swaps, cross-table remaps between primary/overflow table pairs, and transitive inheritance chains.

> Note: Everything stems for a single architectural decision baked into the system which unfortunately, we cannot skip: ec_PropertyMap is a canonical, single-truth mapping where each (property, class-in-hierarchy) pair maps to exactly one column.
All the changes to the ClassMap in-memory model, SavePropertyMapVisitor, ClassMapColumnFactory, DbMapValidator, and the entire ViewGenerator SQL pipeline done in this POC all rely on this invariant.

The No-Remap POC investigates a fundamentally different approach: **skip all data movement entirely**, and instead:
1. Record where data *actually lives* (the original physical columns) in a new sidecar table (`ec_PropertyMap_Overrides`).
2. At schema-load time, remap the in-memory `ClassMap` to reflect the real storage layout.
3. At query time, detect when sibling classes in the same table hierarchy store the same logical property in *different* physical columns, and generate a `UNION ALL` query that reads from the correct column for each class partition.

## 2. Changes Made in the POC

### 2.1 New Schema Import Flag `SkipRemapping`

A new flag `SkipRemapping` was added to `SchemaManager::SchemaImportOptions`.  
All remap-sensitive code paths gate on this flag during schema import/upgrade.

> Note: This flag was added just to get the POC up, a different method must be decided if we are to go ahead with this approach in production. The reason being, once we switch to the no-remapping approach and import/upgrade a schema, there is no going back. The user cannot be allowed to do incremental schema changes while using this flag as an option as it will lead to data corruption.

---

### 2.2 New Sidecar Table `ec_PropertyMap_Overrides`

```sql
CREATE TABLE ec_PropertyMap_Overrides (
    ClassId       INTEGER NOT NULL REFERENCES ec_Class(Id),
    AccessString  TEXT    NOT NULL COLLATE NOCASE,
    ColumnId      INTEGER NOT NULL REFERENCES ec_Column(Id),
    PRIMARY KEY (ClassId, AccessString)
)
```

A new system table is added which stores **per-class column deviations**: cases where a class's property data physically resides in a column that differs from what `ec_PropertyMap` canonically records after the upgrade.

---

### 2.3 Remap Pipeline Bypassed

When `SkipRemapping` is active, the three core remap steps return `SUCCESS` immediately without doing any work:

---

### 2.4 Divergent-Column Query Generation

This is the **read-side counterpart** to the no-remap strategy.

#### Detection: `HasDivergentColumnAssignments()`
Walks all concrete class maps in the TPH table, compares their columns against the table-root class's assignments, and returns `true` if any mismatch is found, signaling a divergent column.
Only triggered for `TablePerHierarchy + ShareColumns` hierarchies (the only ones that use shared columns).

#### Rendering: `RenderDivergentEntityPartition()`
When divergence is detected, generates a `UNION ALL` where:
- Each **arm** is a full `SELECT` rendered for a single concrete class map (using its own column-remapped `PropertyMap`).
- Each arm is filtered with `WHERE [ECClassId] = <id>` (or `IN (...)` when multiple concrete classes share an identical SELECT body).
- Arms are de-duplicated: concrete classes whose rendered SQL is identical are merged into a single arm with an `IN` list.
- For `ONLY` queries (non-polymorphic), only the arm matching the queried class is emitted.

---

### 2.5 Tests - `SchemaRemapTests.cpp`

- **~30 existing tests** updated to use `SkipRemapping` so the test suite exercises the new no-remap approach.
- All are passing.

---

## 3. Pros

| # | Benefit |
|---|---|
| 1 | **No data movement during upgrade** - avoids full-table scans and row-by-row UPDATEs that can be slow for large files. |
| 2 | **No data-write lock required** - since rows are never touched, the upgrade footprint is limited to DDL + metadata writes. |
| 3 | **Entire remap pipeline complexity bypassed** - circular-remap sorting, cross-table overflow/primary pair detection, and the `RemappedColumnInfo` graph are no longer executed. |
| 4 | **Existing data is immutable** - no risk of data corruption from a failed mid-upgrade data migration. |
| 5 | **Correct read-back via UNION ALL** - pre-upgrade and post-upgrade rows are both served correctly by the divergent-partition query path. |
| 6 | **Smaller `ec_PropertyMap` churn** - the canonical system table is updated only once (new canonical column assignment), not cleaned + re-populated for every derived class. |
| 7 | **`ec_PropertyMap_Overrides` is an explicit contract** - the sidecar table makes the per-class column deviation a first-class, inspectable piece of metadata rather than implicit state in the remap pipeline. |


---


## 4. Cons

| # | Drawback |
|---|---|
| 1 | **Query performance regression for divergent hierarchies** - every polymorphic `SELECT` on a class whose hierarchy contains divergent column assignments becomes a `UNION ALL` instead of a single `SELECT`. For large hierarchies with many concrete subclasses this can multiply the query plan significantly. |
| 2 | **Divergence accumulates over repeated upgrades** - each no-remap upgrade adds more `ec_PropertyMap_Overrides` rows and potentially more UNION ALL arms. Without a consolidation step, the performance impact compounds. |
| 3 | **Two sources of truth for column assignments** - `ec_PropertyMap` and `ec_PropertyMap_Overrides` must be kept consistent. Any tool or code path that only reads one table gets an incomplete picture. |
| 4 | **Every column allocation decision now queries `ec_PropertyMap_Overrides`** - three new SQL queries per shared-column allocation add I/O overhead at schema-import time. |
| 5 | **In-memory `Remap()` is applied on every database open** - the `_Load()` phase re-reads `ec_PropertyMap_Overrides` and re-wires `PropertyMap` pointers each time the schema is loaded, adding startup cost proportional to the number of overrides. |
| 6 | **`SkipRemapping` is an opt-in flag** - it is the caller's responsibility to request it; the default path still uses the full remap pipeline. Meant to be used as a one-off call, forever switching to the no-remap after the initial use, unless a revert is made. |
| 7 | Debugging the data - since there are no remaps, after a few schema upgrades, the data is going to end up scattered. Refer to the example in section 4.1 below. |
---

### 4.1 Data readability problem example:

- Consider a very simple scenario where:
1. An initial schema state has a common base TPH class with shared columns with a set of child sibling classes all having an identical property "Prop1" kept in the shared column ps1.
2. A schema upgrade moves this property to a common base class but keeps all the child properties intact as overrides.
- With a remap, the properties get a new shared column "Prop1", and the data is moved over and consolidated.
- But without a remap, the new column "Prop1" will be created but the data will not be moved.
- The child class values for Prop1 will continue to exist in ps1, new inserts will also be in ps1, and Prop1 will continue to remain empty for the child classes.
- This will create difficulties when trying to reason out the data in the underlying db table/columns directly.
- When looking at raw data, we will always have to either use an ECSql which supports the no-remap code or look at the schema directly to reason out why the data is in this state.
- And this will only compound with time and further upgrades.

--- 
## 5. Limitations

### 5.1 ECDb Profile Version Upgrade needed
The `ec_PropertyMap_Overrides` table is created in `CreateProfileTables()` (new databases only). There is **no profile version increment** and **no upgrader** to create this table in existing databases opened after the code change. Any attempt to run `SkipRemapping` against an older database that lacks the table will either fail silently or assert.

### 5.3 Multi-Column (Struct) Properties
Multi-column properties (e.g., `Point3d`, `struct`) generate multiple access strings (`Color.red`, `Color.green`, `Color.blue`). The override mechanism handles each sub-column individually, but the conflict-check and override-population SQL paths become proportionally more expensive and have been tested only through a small number of struct scenarios. A lot more testing is required.

### 5.4 ECSql UPDATE Semantics for Pre-Upgrade Rows
After a no-remap upgrade, a row inserted *before* the upgrade stores its property in the old physical column, while a row inserted *after* uses the new canonical column. The behavior of an ECSql `UPDATE` has not been explored in this POC. The update logic will also have to be updated to make it aware of possible divergent columns.

### 5.5 No Automatic Override Consolidation
There is no mechanism to "consolidate" overrides back into canonical `ec_PropertyMap` entries (i.e., perform a lazy, deferred remap). Divergence can only grow; it never shrinks without manual intervention.

### 5.6 Changeset / Briefcase / SchemaSync / Semantic Rebase Integration Not Verified
`ec_PropertyMap_Overrides` is a new system table. Its interaction with changeset push/pull, `SchemaSync`, semantic rebase has not been analyzed or tested. It is possible that overrides are lost or duplicated during schema-changeset apply.

### 5.7 Lots of edge cases still unexplored
Edge cases involving mixin queries and abstract-class queries against a divergent hierarchy have not been tested.

---

## 6. POC Validity Assessment

- The core concept is **viable**: data can survive a schema upgrade without being physically moved.
- A `UNION ALL` query strategy can **correctly reconstruct** property values for both pre-upgrade (old column) and post-upgrade (new column) rows from the same polymorphic query.
- The `ec_PropertyMap_Overrides` table provides a clean, inspectable mechanism for recording per-class column deviations.
- The majority of the existing `SchemaRemapTests` suite (30+ scenarios) passes under `SkipRemapping`, covering property promotion, base-class injection, sibling merging, mixin-to-base conversion, struct properties, overflow tables, relationship classes as well as some real-world Revit scenarios.

## 7. To-Do:

- Benchmark UNION ALL vs. single SELECT on realistic iModel workloads
- Verify and test ECSql `UPDATE` / `DELETE` semantics for pre-upgrade rows in divergent hierarchies
- Test `ec_PropertyMap_Overrides` behavior during changeset push/pull and rebase
- Extend `SearchPropertyMapVisitor` and other metadata tools to include override columns
- Test deep hierarchies and multiple sequential no-remap upgrades
- A lot of edge case testing