### PR TITLE
Fix debug builds on Windows

### DIFF
--- a/iModelCore/iModelPlatform/iModelPlatform.mke
+++ b/iModelCore/iModelPlatform/iModelPlatform.mke
@@ -459,6 +459,7 @@ LINKER_LIBRARIES        =   $(ContextSubpartsLibs)$(libprefix)iTwinSQLiteEC$(lib
 %endif
 
 %if $(TARGET_PLATFORM)=="Windows"
+    DLM_SPECIAL_LINKOPT = -NODEFAULTLIB:msvcrtd.lib
     LINKER_LIBRARIES + iphlpapi.lib
     LINKER_LIBRARIES + winhttp.lib
 %endif


### PR DESCRIPTION
The vcpkg zlib updates broke debug builds on Windows without me noticing (due to the iTwinPlatform DLL using msvcrt instead of msvcrt**d** even for debug builds). This fixes that by adding `-NODEFAULTLIB:msvcrtd.lib` to the build options of that DLL.