### PR TITLE
[PROPOSAL] Add AppModelDb support and changeset functionality

### DIFF
--- a/iModelCore/BeSQLite/AppModelDb.cpp
+++ b/iModelCore/BeSQLite/AppModelDb.cpp
@@ -1,0 +1,1005 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the repository root for full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+#include <BeSQLite/AppModelDb.h>
+#include <BeSQLite/ChangesetFile.h>
+#include <Bentley/BeAssert.h>
+#include <Bentley/BeStringUtilities.h>
+#include <Bentley/Logging.h>
+#include <Bentley/SHA1.h>
+#include <vector>
+#include <memory>
+
+USING_NAMESPACE_BENTLEY_LOGGING
+#define LOG CategoryLogger("BeSQLite")
+#define PROFILENAME "AppModel"
+
+BEGIN_BENTLEY_APPMODEL_NAMESPACE
+
+//=======================================================================================
+// AppModel table names.
+//=======================================================================================
+#define APPMODEL_TABLE_Dgns                   "Dgns"
+#define APPMODEL_TABLE_DgnStreams             "DgnStreams"
+#define APPMODEL_TABLE_Models                 "Models"
+#define APPMODEL_TABLE_Elements               "Elements"
+#define APPMODEL_TABLE_DgnReferencesModels    "DgnReferencesModels"
+#define APPMODEL_TABLE_ModelUsesDgnLibElement "ModelUsesDgnLibElement"
+#define APPMODEL_TABLE_Schemas                "Schemas"
+#define APPMODEL_TABLE_DgnContainsSchemas     "DgnContainsSchemas"
+#define APPMODEL_TABLE_SchemaClasses          "SchemaClasses"
+#define APPMODEL_TABLE_RasterImages           "RasterImages"
+#define APPMODEL_TABLE_Txns                   "appmodel_txns"
+
+//=======================================================================================
+// Centralized DDL for the AppModel tables. Each macro contains the CREATE TABLE statement
+// followed by its indexes so that the DDL can be shared between profile creation and any
+// future profile migrators that need to add the table to an existing file.
+//=======================================================================================
+#define TABLEDDL_Dgns "CREATE TABLE " APPMODEL_TABLE_Dgns \
+    "(ID INTEGER PRIMARY KEY AUTOINCREMENT," \
+    "Name TEXT NOT NULL," \
+    "Description TEXT," \
+    "FileHeaderStream BLOB," \
+    "SeedId INTEGER REFERENCES " APPMODEL_TABLE_Dgns "(ID)," \
+    "IsDgnLib BOOLEAN NOT NULL);" \
+    "CREATE INDEX idx_Dgns_SeedId ON " APPMODEL_TABLE_Dgns "(SeedId) WHERE SeedId IS NOT NULL;"
+
+#define TABLEDDL_DgnStreams "CREATE TABLE " APPMODEL_TABLE_DgnStreams \
+    "(ID INTEGER PRIMARY KEY," \
+    "DgnId INTEGER NOT NULL REFERENCES " APPMODEL_TABLE_Dgns "(ID) ON DELETE CASCADE," \
+    "StreamPath TEXT NOT NULL," \
+    "Data BLOB NOT NULL," \
+    "UNIQUE (DgnId, StreamPath));" \
+    "CREATE INDEX idx_DgnStreams_DgnId_StreamPath ON " APPMODEL_TABLE_DgnStreams "(DgnId, StreamPath);"
+
+#define TABLEDDL_Models "CREATE TABLE " APPMODEL_TABLE_Models \
+    "(ID INTEGER PRIMARY KEY AUTOINCREMENT," \
+    "DgnId INTEGER NOT NULL REFERENCES " APPMODEL_TABLE_Dgns "(ID) ON DELETE CASCADE," \
+    "V8ModelId INTEGER NOT NULL," \
+    "Type INTEGER NOT NULL," \
+    "Name TEXT NOT NULL," \
+    "Description TEXT," \
+    "Is3d BOOLEAN NOT NULL," \
+    "Gcs TEXT," \
+    "UNIQUE (V8ModelId, DgnId));" \
+    "CREATE INDEX idx_Models_Type ON " APPMODEL_TABLE_Models "(Type);" \
+    "CREATE INDEX idx_Models_DgnId ON " APPMODEL_TABLE_Models "(DgnId);"
+
+#define TABLEDDL_Elements "CREATE TABLE " APPMODEL_TABLE_Elements \
+    "(ID INTEGER PRIMARY KEY AUTOINCREMENT," \
+    "ModelId INTEGER NOT NULL REFERENCES " APPMODEL_TABLE_Models "(ID) ON DELETE CASCADE," \
+    "V8ElementId INTEGER NOT NULL," \
+    "Type INTEGER NOT NULL," \
+    "ParentId INTEGER," \
+    "DgnFragment BLOB NOT NULL," \
+    "xattrs BLOB," \
+    "iModelType TEXT," \
+    "iModelFragment TEXT," \
+    "TableKind INTEGER," \
+    "TableScope INTEGER," \
+    "TableEntryId INTEGER," \
+    "UNIQUE (V8ElementId, ModelId, Type));" \
+    "CREATE INDEX idx_Elements_ModelId ON " APPMODEL_TABLE_Elements "(ModelId);" \
+    "CREATE INDEX idx_Elements_ParentId ON " APPMODEL_TABLE_Elements "(ParentId) WHERE ParentId IS NOT NULL;" \
+    "CREATE INDEX idx_Elements_ModelId_Type ON " APPMODEL_TABLE_Elements "(ModelId, Type);"
+
+#define TABLEDDL_DgnReferencesModels "CREATE TABLE " APPMODEL_TABLE_DgnReferencesModels \
+    "(ID INTEGER PRIMARY KEY," \
+    "DgnId INTEGER NOT NULL REFERENCES " APPMODEL_TABLE_Dgns "(ID) ON DELETE CASCADE," \
+    "TargetModelId INTEGER NOT NULL REFERENCES " APPMODEL_TABLE_Models "(ID) ON DELETE CASCADE," \
+    "IsVisible BOOLEAN NOT NULL," \
+    "TranslateX DOUBLE NOT NULL DEFAULT 0.0," \
+    "TranslateY DOUBLE NOT NULL DEFAULT 0.0," \
+    "TranslateZ DOUBLE NOT NULL DEFAULT 0.0," \
+    "Yaw DOUBLE NOT NULL DEFAULT 0.0," \
+    "Pitch DOUBLE NOT NULL DEFAULT 0.0," \
+    "Roll DOUBLE NOT NULL DEFAULT 0.0);" \
+    "CREATE INDEX idx_DgnReferencesModels_DgnId ON " APPMODEL_TABLE_DgnReferencesModels "(DgnId);" \
+    "CREATE INDEX idx_DgnReferencesModels_TargetModelId ON " APPMODEL_TABLE_DgnReferencesModels "(TargetModelId);"
+
+#define TABLEDDL_ModelUsesDgnLibElement "CREATE TABLE " APPMODEL_TABLE_ModelUsesDgnLibElement \
+    "(ID INTEGER PRIMARY KEY AUTOINCREMENT," \
+    "LocalDgnElementId INTEGER NOT NULL," \
+    "ModelId INTEGER NOT NULL REFERENCES " APPMODEL_TABLE_Models "(ID) ON DELETE CASCADE," \
+    "DgnLibModelId INTEGER NOT NULL," \
+    "DgnLibElementId INTEGER NOT NULL," \
+    "FOREIGN KEY (DgnLibElementId) REFERENCES " APPMODEL_TABLE_Elements "(ID));" \
+    "CREATE INDEX idx_ModelUsesDgnLibElement_ModelId ON " APPMODEL_TABLE_ModelUsesDgnLibElement "(ModelId);" \
+    "CREATE INDEX idx_ModelUsesDgnLibElement_LibElement ON " APPMODEL_TABLE_ModelUsesDgnLibElement "(DgnLibModelId, DgnLibElementId);"
+
+#define TABLEDDL_Schemas "CREATE TABLE " APPMODEL_TABLE_Schemas \
+    "(ID INTEGER PRIMARY KEY AUTOINCREMENT," \
+    "Name TEXT NOT NULL," \
+    "Version TEXT NOT NULL," \
+    "Alias TEXT NOT NULL," \
+    "DisplayLabel TEXT," \
+    "Checksum INTEGER NOT NULL," \
+    "Xml TEXT NOT NULL," \
+    "UNIQUE(Name, Version, Checksum));"
+
+#define TABLEDDL_DgnContainsSchemas "CREATE TABLE " APPMODEL_TABLE_DgnContainsSchemas \
+    "(DgnId INTEGER NOT NULL REFERENCES " APPMODEL_TABLE_Dgns "(ID) ON DELETE CASCADE," \
+    "SchemaId INTEGER NOT NULL REFERENCES " APPMODEL_TABLE_Schemas "(ID) ON DELETE CASCADE," \
+    "PRIMARY KEY (DgnId, SchemaId));"
+
+#define TABLEDDL_SchemaClasses "CREATE TABLE " APPMODEL_TABLE_SchemaClasses \
+    "(SchemaId INTEGER NOT NULL REFERENCES " APPMODEL_TABLE_Schemas "(ID) ON DELETE CASCADE," \
+    "ClassName TEXT NOT NULL," \
+    "IsPrimary BOOLEAN NOT NULL," \
+    "PRIMARY KEY (SchemaId, ClassName));" \
+    "CREATE INDEX idx_SchemaClasses_SchemaId ON " APPMODEL_TABLE_SchemaClasses "(SchemaId);"
+
+#define TABLEDDL_RasterImages "CREATE TABLE " APPMODEL_TABLE_RasterImages \
+    "(ID INTEGER PRIMARY KEY AUTOINCREMENT," \
+    "Identifier TEXT NOT NULL," \
+    "ImageData BLOB NOT NULL," \
+    "UNIQUE(Identifier));"
+
+// Change-tracking table. A row is written for each SaveChanges that produced changes.
+// DDL and data changes are stored side-by-side in two columns (Ddl and Change) rather than
+// as separate rows. Description and Props (JSON) hold caller-supplied metadata. This table is
+// itself excluded from change tracking (see Txns::_FilterTable).
+#define TABLEDDL_Txns "CREATE TABLE " APPMODEL_TABLE_Txns \
+    "(Id INTEGER PRIMARY KEY," \
+    "Type INTEGER NOT NULL," \
+    "Description TEXT," \
+    "Props TEXT," \
+    "Ddl TEXT," \
+    "Change BLOB," \
+    "Time TIMESTAMP DEFAULT(julianday('now')));"
+
+struct ProfileMigrator;
+
+//=======================================================================================
+//! Manages the AppModel profile of an AppModelDb: creating it in a new file, checking its
+//! version when a file is opened, and upgrading it in place. Mirrors BeSQLiteProfileManager.
+// @bsiclass
+//+===============+===============+===============+===============+===============+======
+struct ProfileManager final
+    {
+private:
+    ProfileManager() = delete;
+    ~ProfileManager() = delete;
+
+    //! Version of the AppModel profile expected by this build.
+    static ProfileVersion GetExpectedVersion() { return AppModelDb::CurrentProfileVersion(); }
+    //! Minimum version that can still be auto-upgraded to the latest profile version.
+    static ProfileVersion GetMinimumSupportedVersion() { return AppModelDb::MinimumUpgradableProfileVersion(); }
+
+    static DbResult CreateProfileTables(DbR);
+    static DbResult AssignProfileVersion(DbR, bool onProfileCreation);
+    static void GetMigratorSequence(std::vector<std::unique_ptr<ProfileMigrator>>&, ProfileVersion const& fileProfileVersion);
+
+public:
+    //! Checks whether the file's AppModel profile version is compatible with this build.
+    static ProfileState CheckProfileVersion(DbCR);
+
+    //! Creates the AppModel profile (stamps the version and creates the tables) in a newly-created file.
+    //! Must be called inside the create transaction. Rolls back on failure.
+    static DbResult CreateProfile(DbR);
+
+    //! Upgrades the AppModel profile of the file to the latest version by running the migrator sequence.
+    //! Must be called inside the open transaction. Rolls back on failure.
+    static DbResult UpgradeProfile(DbR);
+
+    //! Reads the AppModel profile version from the file.
+    //! @return BE_SQLITE_OK on success, BE_SQLITE_ERROR_InvalidProfileVersion if the file has no AppModel profile.
+    static DbResult ReadProfileVersion(ProfileVersion&, DbCR);
+    };
+
+//=======================================================================================
+//! Base class for an in-situ AppModel profile migration step. Each concrete migrator
+//! migrates a file from one profile version to the next. Mirrors BeSQLiteProfileUpgrader.
+// @bsiclass
+//+===============+===============+===============+===============+===============+======
+struct ProfileMigrator
+    {
+private:
+    virtual DbResult _Migrate(DbR db) const = 0;
+
+protected:
+    ProfileMigrator() {}
+
+public:
+    virtual ~ProfileMigrator() {}
+    DbResult Migrate(DbR db) const { return _Migrate(db); }
+    };
+
+// NOTE: There are no AppModel profile migrators yet - the profile is at its initial version.
+// When the profile version is bumped, add a concrete migrator here (e.g. struct ProfileMigrator_1001)
+// that performs the DDL/data migration from the prior version, and push it onto the sequence in
+// ProfileManager::GetMigratorSequence, ordered from oldest to newest.
+
+//--------------------------------------------------------------------------------------
+// @bsimethod
+//---------------+---------------+---------------+---------------+---------------+------
+//static
+DbResult ProfileManager::CreateProfile(DbR db)
+    {
+    if (!db.GetDefaultTransaction()->IsActive())
+        {
+        BeAssert(false && "Programmer Error. AppModelDb expects that BeSQLite::CreateNewDb keeps the default transaction active when it creates its profile.");
+        return BE_SQLITE_ERROR_NoTxnActive;
+        }
+
+    DbResult stat = AssignProfileVersion(db, true);
+    if (BE_SQLITE_OK != stat)
+        {
+        LOG.errorv("Failed to create " PROFILENAME " profile in '%s'. Could not assign profile version. %s", db.GetDbFileName(), db.GetLastError().c_str());
+        db.AbandonChanges();
+        return stat;
+        }
+
+    stat = CreateProfileTables(db);
+    if (BE_SQLITE_OK != stat)
+        {
+        LOG.errorv("Failed to create " PROFILENAME " profile in '%s'. Could not create tables. %s", db.GetDbFileName(), db.GetLastError().c_str());
+        db.AbandonChanges();
+        return stat;
+        }
+
+    db.SaveChanges();
+    return BE_SQLITE_OK;
+    }
+
+//--------------------------------------------------------------------------------------
+// @bsimethod
+//---------------+---------------+---------------+---------------+---------------+------
+//static
+ProfileState ProfileManager::CheckProfileVersion(DbCR db)
+    {
+    ProfileVersion fileProfileVersion(0, 0, 0, 0);
+    if (BE_SQLITE_OK != ReadProfileVersion(fileProfileVersion, db))
+        return ProfileState::Error();
+
+    return Db::CheckProfileVersion(GetExpectedVersion(), fileProfileVersion, GetMinimumSupportedVersion(), PROFILENAME);
+    }
+
+//--------------------------------------------------------------------------------------
+// @bsimethod
+//---------------+---------------+---------------+---------------+---------------+------
+//static
+DbResult ProfileManager::UpgradeProfile(DbR db)
+    {
+    BeAssert(!db.IsReadonly());
+    if (!db.GetDefaultTransaction()->IsActive())
+        {
+        BeAssert(false && "Programmer Error. AppModelDb expects that BeSQLite::OpenBeSQLiteDb keeps the default transaction active when it upgrades its profile.");
+        return BE_SQLITE_ERROR_NoTxnActive;
+        }
+
+    ProfileVersion fileProfileVersion(0, 0, 0, 0);
+    DbResult stat = ReadProfileVersion(fileProfileVersion, db);
+    if (BE_SQLITE_OK != stat)
+        {
+        LOG.errorv("Upgrade of " PROFILENAME " profile of file '%s' failed. File has no AppModel profile.", db.GetDbFileName());
+        return stat;
+        }
+
+    if (fileProfileVersion == GetExpectedVersion())
+        return BE_SQLITE_OK; // already up-to-date
+
+    // Let migrators incrementally upgrade the profile to the latest state.
+    std::vector<std::unique_ptr<ProfileMigrator>> migrators;
+    GetMigratorSequence(migrators, fileProfileVersion);
+    for (std::unique_ptr<ProfileMigrator> const& migrator : migrators)
+        {
+        stat = migrator->Migrate(db);
+        if (BE_SQLITE_OK != stat)
+            {
+            db.AbandonChanges();
+            return BE_SQLITE_ERROR_ProfileUpgradeFailed;
+            }
+        }
+
+    // Stamp the new profile version after the migrators have run.
+    stat = AssignProfileVersion(db, false);
+    if (BE_SQLITE_OK != stat)
+        {
+        db.AbandonChanges();
+        LOG.errorv("Upgrade of " PROFILENAME " profile of file '%s' failed. Could not assign new profile version. %s", db.GetDbFileName(), db.GetLastError().c_str());
+        return BE_SQLITE_ERROR_ProfileUpgradeFailed;
+        }
+
+    LOG.infov("Upgraded " PROFILENAME " profile of file '%s' from version %s to version %s.",
+              db.GetDbFileName(), fileProfileVersion.ToString().c_str(), GetExpectedVersion().ToString().c_str());
+    return BE_SQLITE_OK;
+    }
+
+//--------------------------------------------------------------------------------------
+// @bsimethod
+//---------------+---------------+---------------+---------------+---------------+------
+//static
+DbResult ProfileManager::AssignProfileVersion(DbR db, bool onProfileCreation)
+    {
+    Utf8String versionStr = GetExpectedVersion().ToJson();
+
+    if (onProfileCreation)
+        {
+        DbResult stat = db.SavePropertyString(AppModelDb::InitialProfileVersionProperty(), versionStr);
+        if (BE_SQLITE_OK != stat)
+            return stat;
+        }
+
+    return db.SavePropertyString(AppModelDb::ProfileVersionProperty(), versionStr);
+    }
+
+//--------------------------------------------------------------------------------------
+// @bsimethod
+//---------------+---------------+---------------+---------------+---------------+------
+//static
+DbResult ProfileManager::ReadProfileVersion(ProfileVersion& profileVersion, DbCR db)
+    {
+    profileVersion = ProfileVersion(0, 0, 0, 0);
+
+    Utf8String versionStr;
+    if (BE_SQLITE_ROW != db.QueryProperty(versionStr, AppModelDb::ProfileVersionProperty()))
+        return BE_SQLITE_ERROR_InvalidProfileVersion; // no AppModel profile in this file
+
+    if (BentleyStatus::SUCCESS != profileVersion.FromJson(versionStr.c_str()))
+        return BE_SQLITE_ERROR_InvalidProfileVersion;
+
+    return BE_SQLITE_OK;
+    }
+
+//--------------------------------------------------------------------------------------
+// @bsimethod
+//---------------+---------------+---------------+---------------+---------------+------
+//static
+DbResult ProfileManager::CreateProfileTables(DbR db)
+    {
+    // Order matters: tables with foreign keys must be created after the tables they reference.
+    Utf8CP const ddls[] =
+        {
+        TABLEDDL_Dgns,
+        TABLEDDL_DgnStreams,
+        TABLEDDL_Models,
+        TABLEDDL_Elements,
+        TABLEDDL_DgnReferencesModels,
+        TABLEDDL_ModelUsesDgnLibElement,
+        TABLEDDL_Schemas,
+        TABLEDDL_DgnContainsSchemas,
+        TABLEDDL_SchemaClasses,
+        TABLEDDL_RasterImages,
+        TABLEDDL_Txns,
+        };
+
+    for (Utf8CP ddl : ddls)
+        {
+        DbResult stat = db.ExecuteDdl(ddl);
+        if (BE_SQLITE_OK != stat)
+            return stat;
+        }
+
+    return BE_SQLITE_OK;
+    }
+
+//--------------------------------------------------------------------------------------
+// @bsimethod
+//---------------+---------------+---------------+---------------+---------------+------
+//static
+void ProfileManager::GetMigratorSequence(std::vector<std::unique_ptr<ProfileMigrator>>& migrators, ProfileVersion const& /*fileProfileVersion*/)
+    {
+    migrators.clear();
+    // No migrators yet - the profile is at its initial version (see the ProfileMigrator note above).
+    // Example for the future:
+    //   if (fileProfileVersion < ProfileVersion(1, 0, 0, 1))
+    //       migrators.push_back(std::make_unique<ProfileMigrator_1001>());
+    }
+
+//---------------------------------------------------------------------------------------
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+--------
+AppModelDb::AppModelDb() {}
+
+//---------------------------------------------------------------------------------------
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+--------
+AppModelDb::~AppModelDb() {}
+
+//---------------------------------------------------------------------------------------
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+--------
+DbResult AppModelDb::QueryProfileVersion(ProfileVersion& version) const { return ProfileManager::ReadProfileVersion(version, *this); }
+
+//---------------------------------------------------------------------------------------
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+--------
+Txns& AppModelDb::GetTxns()
+    {
+    if (!m_txns.IsValid())
+        m_txns = new Txns(*this); // the Txns ctor registers itself as this db's change tracker
+    return *m_txns;
+    }
+
+//---------------------------------------------------------------------------------------
+//! Attach the AppModel change tracker and enable tracking when the db is writable. Called after
+//! the profile exists. Change tracking records local changes into APPMODEL_TABLE_Txns on SaveChanges.
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+--------
+void AppModelDb::SetupChangeTracking()
+    {
+    Txns& txns = GetTxns(); // creates + registers the tracker
+    if (!IsReadonly())
+        txns.EnableTracking(true); // record changes only on a writable db
+    }
+
+//---------------------------------------------------------------------------------------
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+--------
+DbResult AppModelDb::_OnDbCreated(CreateParams const& params)
+    {
+    DbResult stat = Db::_OnDbCreated(params);
+    if (BE_SQLITE_OK != stat)
+        return stat;
+
+    BeAssert(!IsReadonly());
+    stat = ProfileManager::CreateProfile(*this);
+    if (BE_SQLITE_OK != stat)
+        return stat;
+
+    // Enable tracking only after the profile (including its tables) has been created, so that the
+    // profile's own DDL is not recorded as a txn.
+    SetupChangeTracking();
+    return BE_SQLITE_OK;
+    }
+
+//---------------------------------------------------------------------------------------
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+--------
+DbResult AppModelDb::_OnDbOpened(OpenParams const& params)
+    {
+    DbResult stat = Db::_OnDbOpened(params);
+    if (BE_SQLITE_OK != stat)
+        return stat;
+
+    SetupChangeTracking();
+    return BE_SQLITE_OK;
+    }
+
+//---------------------------------------------------------------------------------------
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+--------
+void AppModelDb::_OnDbClose()
+    {
+    if (m_txns.IsValid())
+        {
+        m_txns->EndTracking();
+        SetChangeTracker(nullptr); // detach from the DbFile (drops its reference)
+        m_txns = nullptr;          // drop our reference; the tracker is deleted when the last ref is gone
+        }
+
+    Db::_OnDbClose();
+    }
+
+//---------------------------------------------------------------------------------------
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+--------
+ProfileState AppModelDb::_CheckProfileVersion() const
+    {
+    // The base BeSQLite profile must be usable before we even consider the AppModel profile.
+    ProfileState besqliteState = Db::_CheckProfileVersion();
+    if (!besqliteState.IsUpToDate())
+        return besqliteState;
+
+    // Note: we intentionally do not use ProfileState::Merge here. Merge discards the right-hand state when it is an
+    // error (and the left-hand state is up-to-date), which would let a plain BeSQLite file - one without any AppModel
+    // profile - open as an AppModelDb. Returning the AppModel state directly ensures a missing profile is rejected.
+    return ProfileManager::CheckProfileVersion(*this);
+    }
+
+//---------------------------------------------------------------------------------------
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+--------
+DbResult AppModelDb::_UpgradeProfile(OpenParams const& params)
+    {
+    DbResult stat = Db::_UpgradeProfile(params);
+    if (BE_SQLITE_OK != stat)
+        return stat;
+
+    return ProfileManager::UpgradeProfile(*this);
+    }
+
+//=======================================================================================
+// Header prepended to the Snappy-compressed changeset blob stored in APPMODEL_TABLE_Txns.Change.
+// @bsistruct
+//=======================================================================================
+struct ChangesBlobHeader
+    {
+    static const uint32_t Signature = 0x0601;
+    uint32_t m_signature;
+    uint32_t m_size;
+    explicit ChangesBlobHeader(uint32_t size) : m_signature(Signature), m_size(size) {}
+    explicit ChangesBlobHeader(SnappyReader& in) { uint32_t actuallyRead; in._Read((Byte*)this, sizeof(*this), actuallyRead); }
+    bool IsValid() const { return m_signature == Signature && m_size != 0; }
+    };
+
+//---------------------------------------------------------------------------------------
+//! Construct the tracker and register it as the db's change tracker. SetChangeTracker also
+//! sets this tracker's Db back-pointer and takes a reference (held in the DbFile).
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+--------
+Txns::Txns(AppModelDb& db) : ChangeTracker("appmodel_txns")
+    {
+    db.SetChangeTracker(this);
+    }
+
+//---------------------------------------------------------------------------------------
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+--------
+ChangeTracker::TrackChangesForTable Txns::_FilterTable(Utf8CP tableName)
+    {
+    // Skip be_Local (derived/redundant) and the txns table itself (writing a txn must not be tracked).
+    if (0 == BeStringUtilities::StricmpAscii(tableName, BEDB_TABLE_Local) ||
+        0 == BeStringUtilities::StricmpAscii(tableName, APPMODEL_TABLE_Txns))
+        return TrackChangesForTable::No;
+
+    return TrackChangesForTable::Yes;
+    }
+
+//---------------------------------------------------------------------------------------
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+--------
+ChangeTracker::OnCommitStatus Txns::_OnCommit(bool isCommit, Utf8CP operation)
+    {
+    // Capture the tracked DDL and data changes, then restart the tracker.
+    DdlChanges ddlChanges = std::move(m_ddlChanges);
+
+    ChangeSet dataChanges;
+    if (HasDataChanges())
+        {
+        if (BE_SQLITE_OK != dataChanges.FromChangeTrack(*this))
+            {
+            LOG.error("Txns: failed to create data changeset from tracker");
+            return OnCommitStatus::Abort;
+            }
+        Restart(); // clear the tracker now that changes are captured
+        }
+
+    if (!isCommit)
+        {
+        // AbandonChanges: discard the captured changes and let BeSQLite perform the rollback.
+        return OnCommitStatus::NoChanges;
+        }
+
+    if (dataChanges._IsEmpty() && ddlChanges._IsEmpty())
+        return OnCommitStatus::NoChanges;
+
+    // 'operation' is the description passed to Db::SaveChanges - store it on the txn.
+    if (BE_SQLITE_OK != WriteTxn(operation, ddlChanges, dataChanges))
+        {
+        LOG.error("Txns: failed to write txn");
+        return OnCommitStatus::Abort;
+        }
+
+    return OnCommitStatus::Commit;
+    }
+
+//---------------------------------------------------------------------------------------
+//! Store one txn row holding both the DDL and the data changeset in separate columns.
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+--------
+DbResult Txns::WriteTxn(Utf8CP description, DdlChanges const& ddlChanges, ChangeSet const& dataChanges)
+    {
+    AppModelDb& db = GetAppModelDb();
+
+    TxnType type = ddlChanges._IsEmpty() ? TxnType::Data : TxnType::Schema;
+    Utf8String ddlStr = ddlChanges._IsEmpty() ? Utf8String() : ddlChanges.ToString();
+
+    enum Column : int { Type = 1, Description = 2, Props = 3, Ddl = 4, Change = 5 };
+    Statement stmt;
+    DbResult rc = stmt.Prepare(db, "INSERT INTO " APPMODEL_TABLE_Txns "(Type,Description,Props,Ddl,Change) VALUES(?,?,?,?,?)");
+    if (BE_SQLITE_OK != rc)
+        return rc;
+
+    stmt.BindInt(Column::Type, (int) type);
+    if (!Utf8String::IsNullOrEmpty(description))
+        stmt.BindText(Column::Description, description, Statement::MakeCopy::No);
+    if (!m_pendingProps.empty())
+        stmt.BindText(Column::Props, m_pendingProps, Statement::MakeCopy::No);
+    if (!ddlStr.empty())
+        stmt.BindText(Column::Ddl, ddlStr, Statement::MakeCopy::No);
+
+    // Compress the data changeset (if any) into the Change blob column, reusing this tracker's SnappyToBlob.
+    SnappyToBlob& snappyTo = m_snappyToBlob;
+    uint32_t zipSize = 0;
+    if (!dataChanges._IsEmpty())
+        {
+        snappyTo.Init();
+        ChangesBlobHeader header((uint32_t) dataChanges.GetSize());
+        snappyTo.Write((Byte const*) &header, sizeof(header));
+        for (auto const& chunk : dataChanges.m_data.m_chunks)
+            snappyTo.Write(chunk.data(), (uint32_t) chunk.size());
+
+        zipSize = snappyTo.GetCompressedSize();
+        if (0 < zipSize)
+            {
+            if (1 == snappyTo.GetCurrChunk())
+                rc = stmt.BindBlob(Column::Change, snappyTo.GetChunkData(0), zipSize, Statement::MakeCopy::No);
+            else
+                rc = stmt.BindZeroBlob(Column::Change, zipSize); // multi-chunk: write via SaveToRow after insert
+            if (BE_SQLITE_OK != rc)
+                return rc;
+            }
+        }
+
+    if (BE_SQLITE_DONE != stmt.Step())
+        return BE_SQLITE_ERROR;
+
+    if (0 < zipSize && 1 != snappyTo.GetCurrChunk())
+        {
+        rc = snappyTo.SaveToRow(db, APPMODEL_TABLE_Txns, "Change", db.GetLastInsertRowId());
+        if (BE_SQLITE_OK != rc)
+            return rc;
+        }
+
+    m_pendingProps.clear();
+    return BE_SQLITE_OK;
+    }
+
+//---------------------------------------------------------------------------------------
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+--------
+DbResult Txns::ReadTxnDataChanges(ChangeSet& dataChanges, int64_t txnId) const
+    {
+    SnappyFromBlob snappyFrom;
+    if (ZIP_SUCCESS != snappyFrom.Init(GetAppModelDb(), APPMODEL_TABLE_Txns, "Change", txnId))
+        return BE_SQLITE_ERROR;
+
+    ChangesBlobHeader header(snappyFrom);
+    if (!header.IsValid())
+        return BE_SQLITE_ERROR;
+
+    return (ZIP_SUCCESS == snappyFrom.ReadToChunkedArray(dataChanges.m_data, header.m_size)) ? BE_SQLITE_OK : BE_SQLITE_ERROR;
+    }
+
+//---------------------------------------------------------------------------------------
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+--------
+bool Txns::HasPendingTxns() const
+    {
+    Statement stmt;
+    if (BE_SQLITE_OK != stmt.Prepare(GetAppModelDb(), "SELECT 1 FROM " APPMODEL_TABLE_Txns " LIMIT 1"))
+        return false;
+
+    return BE_SQLITE_ROW == stmt.Step();
+    }
+
+//---------------------------------------------------------------------------------------
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+--------
+Utf8String Txns::GetParentChangesetId() const
+    {
+    Utf8String changesetId;
+    return (BE_SQLITE_ROW == GetAppModelDb().QueryBriefcaseLocalValue(changesetId, "appmodel_ParentChangesetId")) ? changesetId : Utf8String();
+    }
+
+//---------------------------------------------------------------------------------------
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+--------
+DbResult Txns::SetParentChangesetId(Utf8StringCR changesetId)
+    {
+    // be_Local is excluded from change tracking, so this does not produce a txn.
+    return GetAppModelDb().SaveBriefcaseLocalValue("appmodel_ParentChangesetId", changesetId);
+    }
+
+//---------------------------------------------------------------------------------------
+//! Begin creating a changeset: combine all recorded txns into a single AppModel changeset file and fill @p props
+//! with the resulting changeset's properties (parent id, computed SHA1 id, db guid, file, type). The captured
+//! txns are remembered so EndCreateChangeset can delete them and advance the changeset id once the file is safely
+//! persisted. Modeled on TxnManager::WriteChangesToFile in iModelPlatform.
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+--------
+DbResult Txns::BeginCreateChangeset(ChangesetProps& props, BeFileNameCR pathname)
+    {
+    AppModelDb& db = GetAppModelDb();
+
+    DdlChanges ddlChanges;
+    ChangeGroup dataChangeGroup(db);
+
+    Statement stmt;
+    DbResult rc = stmt.Prepare(db, "SELECT Id,Ddl,(Change IS NOT NULL) FROM " APPMODEL_TABLE_Txns " ORDER BY Id");
+    if (BE_SQLITE_OK != rc)
+        return rc;
+
+    bool hasAnyTxn = false;
+    bool hasSchemaChange = false;
+    int64_t lastTxnId = 0;
+    while (BE_SQLITE_ROW == stmt.Step())
+        {
+        hasAnyTxn = true;
+        int64_t txnId = stmt.GetValueInt64(0);
+        lastTxnId = txnId; // rows are ordered by Id, so this ends as the highest captured txn id
+
+        if (!stmt.IsColumnNull(1))
+            {
+            ddlChanges.AddDDL(stmt.GetValueText(1));
+            hasSchemaChange = true;
+            }
+
+        if (0 != stmt.GetValueInt(2)) // Change blob present
+            {
+            ChangeSet dataChanges;
+            rc = ReadTxnDataChanges(dataChanges, txnId);
+            if (BE_SQLITE_OK != rc)
+                {
+                LOG.errorv("Txns: failed to read data changes for txn %lld", (long long) txnId);
+                return rc;
+                }
+            // Data changes from all captured txns are squashed into one changegroup. This relies on schema changes
+            // being additive and applied only during migration (see the class @note on Txns): a table's column
+            // count must not change in between two data changes to that same table within one changeset window, or
+            // AddToChangeGroup would return BE_SQLITE_SCHEMA.
+            rc = dataChanges.AddToChangeGroup(dataChangeGroup);
+            if (BE_SQLITE_OK != rc)
+                return rc;
+            }
+        }
+
+    if (!hasAnyTxn)
+        return BE_SQLITE_ERROR; // nothing to write
+
+    ChangesetFileWriter writer(pathname, false /*containsEcSchemaChanges*/, ddlChanges, &db, LzmaEncoder::LzmaParams(), ChangesetKind::AppModel);
+    rc = writer.Initialize();
+    if (BE_SQLITE_OK != rc)
+        return rc;
+
+    rc = writer.FromChangeGroup(dataChangeGroup);
+    if (BE_SQLITE_OK != rc)
+        return rc;
+
+    // Compute the changeset properties: parent is this db's current changeset id, the new id is the
+    // SHA1 of (parent id + file contents).
+    Utf8String parentId = GetParentChangesetId();
+    Utf8String changesetId = ChangesetProps::ComputeChangesetId(parentId, pathname);
+    if (changesetId.empty())
+        return BE_SQLITE_ERROR;
+
+    props = ChangesetProps(changesetId, parentId, db.GetDbGuid().ToString(),
+                           pathname, hasSchemaChange ? ChangesetType::Schema : ChangesetType::Regular);
+
+    // Remember what EndCreateChangeset must finalize: the new changeset id and the highest captured txn id.
+    m_creatingChangesetId = changesetId;
+    m_creatingChangesetLastTxnId = lastTxnId;
+    return BE_SQLITE_OK;
+    }
+
+//---------------------------------------------------------------------------------------
+//! Finalize the changeset started by BeginCreateChangeset: delete the captured txns and advance this db's current
+//! changeset id, then commit. Txns recorded after BeginCreateChangeset (Id greater than the captured high-water
+//! mark) are preserved for the next changeset.
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+--------
+DbResult Txns::EndCreateChangeset()
+    {
+    if (m_creatingChangesetId.empty() || 0 == m_creatingChangesetLastTxnId)
+        return BE_SQLITE_ERROR; // no BeginCreateChangeset in progress
+
+    AppModelDb& db = GetAppModelDb();
+
+    // Delete the txns captured by BeginCreateChangeset. The txns table is excluded from change tracking (see
+    // _FilterTable), so this is not recorded as a new txn. Newer txns (Id > high-water mark) are left in place.
+    // Scope the statement so it is finalized before the commit below.
+    DbResult rc;
+    {
+    Statement stmt;
+    rc = stmt.Prepare(db, "DELETE FROM " APPMODEL_TABLE_Txns " WHERE Id<=?");
+    if (BE_SQLITE_OK != rc)
+        return rc;
+
+    stmt.BindInt64(1, m_creatingChangesetLastTxnId);
+    if (BE_SQLITE_DONE != stmt.Step())
+        return BE_SQLITE_ERROR;
+    }
+
+    // Advance this db's current changeset id so the next changeset chains onto the one just created.
+    rc = SetParentChangesetId(m_creatingChangesetId);
+    if (BE_SQLITE_OK != rc)
+        {
+        db.AbandonChanges();
+        return rc;
+        }
+
+    rc = db.SaveChanges();
+    if (BE_SQLITE_OK != rc)
+        {
+        db.AbandonChanges(); // leave the pending create in place so the caller can retry
+        return rc;
+        }
+
+    m_creatingChangesetId.clear();
+    m_creatingChangesetLastTxnId = 0;
+    return BE_SQLITE_OK;
+    }
+
+//---------------------------------------------------------------------------------------
+//! Apply the DDL then the data changes from an AppModel changeset file, with change tracking
+//! suspended so the applied changes are not recorded as new txns.
+//---------------------------------------------------------------------------------------
+// Reader for applying an AppModel changeset file. Overrides conflict handling to fail on ANY
+// conflict for now. This is the extension point for future, more nuanced conflict resolution
+// (e.g. skipping benign FK cascade cases like iModel's ChangesetFileReader does).
+// @bsistruct
+//---------------------------------------------------------------------------------------
+struct ChangesetReader : ChangesetFileReaderBase
+    {
+    explicit ChangesetReader(BeFileNameCR pathname, Db const* db)
+        : ChangesetFileReaderBase({pathname}, db, ChangesetKind::AppModel) {}
+
+    protected:
+        ChangeSet::ConflictResolution _OnConflict(ChangeSet::ConflictCause cause, Changes::Change iter) override
+            {
+            // Fail on any conflict. Future: inspect 'cause'/'iter' and resolve selectively.
+            return ChangeSet::ConflictResolution::Abort;
+            }
+    };
+
+//---------------------------------------------------------------------------------------
+//! Apply the DDL then the data changes from an AppModel changeset file, with change tracking
+//! suspended so the applied changes are not recorded as new txns. Conflicts abort the apply.
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+--------
+DbResult Txns::ApplyChangesetFile(BeFileNameCR pathname)
+    {
+    AppModelDb& db = GetAppModelDb();
+
+    ChangesetReader reader(pathname, &db);
+
+    // Read the DDL (schema) changes carried by the changeset.
+    bool containsSchemaChanges = false;
+    DdlChanges ddlChanges;
+    if (BE_SQLITE_OK != reader.MakeReader()->GetSchemaChanges(containsSchemaChanges, ddlChanges))
+        return BE_SQLITE_ERROR;
+
+    const bool wasTracking = IsTracking();
+    EnableTracking(false); // do not record the applied changes as new txns
+
+    DbResult rc = BE_SQLITE_OK;
+    if (!ddlChanges._IsEmpty())
+        {
+        for (Utf8StringCR ddl : ddlChanges.GetDDLs())
+            {
+            rc = db.ExecuteDdl(ddl.c_str());
+            if (BE_SQLITE_OK != rc)
+                break;
+            }
+        }
+
+    if (BE_SQLITE_OK == rc)
+        rc = reader.ApplyChanges(db, ApplyChangesArgs()); // ChangesetReader::_OnConflict aborts on any conflict
+
+    if (wasTracking)
+        EnableTracking(true);
+
+    return rc;
+    }
+
+//---------------------------------------------------------------------------------------
+// SHA1 changeset-id generator. Feeds the parent id (as bytes), the changeset file prefix and the
+// changeset body through a SHA1 hash. Mirrors TxnManager's ChangesetIdGenerator.
+// @bsistruct
+//---------------------------------------------------------------------------------------
+struct ChangesetIdGenerator : ChangeStream
+    {
+    SHA1 m_hash;
+
+    static int HexCharToInt(char c)
+        {
+        if (c >= '0' && c <= '9') return c - '0';
+        if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+        if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+        BeAssert(false);
+        return 0;
+        }
+
+    void AddStringToHash(Utf8StringCR hashString)
+        {
+        Byte hashValue[SHA1::HashBytes];
+        if (hashString.empty())
+            {
+            memset(hashValue, 0, SHA1::HashBytes);
+            }
+        else
+            {
+            BeAssert(hashString.length() == SHA1::HashBytes * 2);
+            for (int ii = 0; ii < SHA1::HashBytes; ii++)
+                hashValue[ii] = (Byte)(16 * HexCharToInt(hashString.at(2 * ii)) + HexCharToInt(hashString.at(2 * ii + 1)));
+            }
+        m_hash.Add(hashValue, SHA1::HashBytes);
+        }
+
+    DbResult _Append(Byte const* pData, int nData) override { m_hash.Add(pData, nData); return BE_SQLITE_OK; }
+    ChangeSet::ConflictResolution _OnConflict(ChangeSet::ConflictCause, Changes::Change) override { return ChangeSet::ConflictResolution::Abort; }
+    bool _IsEmpty() const override final { return false; }
+    RefCountedPtr<Changes::Reader> _GetReader() const override { return nullptr; }
+    };
+
+//---------------------------------------------------------------------------------------
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+--------
+Utf8String ChangesetProps::ComputeChangesetId(Utf8StringCR parentId, BeFileNameCR changesetFile)
+    {
+    if (!parentId.empty() && parentId.length() != SHA1::HashBytes * 2)
+        return ""; // invalid parent id: must be empty or a SHA1 hex string
+
+    if (!changesetFile.DoesPathExist())
+        return "";
+
+    ChangesetIdGenerator idGen;
+    idGen.AddStringToHash(parentId);
+
+    ChangesetFileReaderBase fs({changesetFile}, nullptr, ChangesetKind::AppModel);
+    auto reader = fs.MakeReader();
+
+    DbResult result;
+    Utf8StringCR prefix = reader->GetPrefix(result);
+    if (BE_SQLITE_OK != result)
+        return "";
+
+    if (!prefix.empty())
+        idGen._Append((Byte const*) prefix.c_str(), (int) prefix.SizeInBytes());
+
+    if (BE_SQLITE_OK != idGen.ReadFrom(*reader))
+        return "";
+
+    return idGen.m_hash.GetHashString();
+    }
+
+//---------------------------------------------------------------------------------------
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+--------
+DbResult ChangesetProps::ValidateContent(AppModelDb const& db) const
+    {
+    if (m_dbGuid != db.GetDbGuid().ToString())
+        return BE_SQLITE_MISMATCH; // changeset did not originate from this db
+
+    if (!m_fileName.DoesPathExist())
+        return BE_SQLITE_ERROR;
+
+    Utf8String computedId = ComputeChangesetId(m_parentId, m_fileName);
+    if (computedId.empty() || !computedId.EqualsIAscii(m_id))
+        return BE_SQLITE_ERROR_InvalidChangeSetVersion; // incorrect id for changeset
+
+    return BE_SQLITE_OK;
+    }
+
+//---------------------------------------------------------------------------------------
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+--------
+DbResult Txns::MergeChangeset(ChangesetProps const& props)
+    {
+    AppModelDb& db = GetAppModelDb();
+
+    // The changeset must chain onto our current changeset.
+    if (GetParentChangesetId() != props.GetParentId())
+        return BE_SQLITE_MISMATCH;
+
+    // Verify db guid + recompute and compare the SHA1 id.
+    DbResult rc = props.ValidateContent(db);
+    if (BE_SQLITE_OK != rc)
+        return rc;
+
+    rc = ApplyChangesetFile(props.GetFileName());
+    if (BE_SQLITE_OK != rc)
+        {
+        db.AbandonChanges();
+        return rc;
+        }
+
+    rc = SetParentChangesetId(props.GetChangesetId());
+    if (BE_SQLITE_OK != rc)
+        {
+        db.AbandonChanges();
+        return rc;
+        }
+
+    rc = db.SaveChanges();
+    if (BE_SQLITE_OK != rc)
+        db.AbandonChanges(); // mirror the paths above: never leave the applied changes + advanced parent id pending
+
+    return rc;
+    }
+
+END_BENTLEY_APPMODEL_NAMESPACE

--- a/iModelCore/BeSQLite/BeSQLite.mke
+++ b/iModelCore/BeSQLite/BeSQLite.mke
@@ -74,6 +74,8 @@ $(o)ChangesetFile$(oext) : $(baseDir)ChangesetFile.cpp $(baseDir)/PublicAPI/BeSQ
 
 $(o)BeSQLiteProfileManager$(oext) : $(baseDir)BeSQLiteProfileManager.cpp $(baseDir)/BeSQLiteProfileManager.h  $(baseDir)/PublicAPI/BeSQLite/BeSQLite.h ${MultiCompileDepends}
 
+$(o)AppModelDb$(oext) : $(baseDir)AppModelDb.cpp $(baseDir)/PublicAPI/BeSQLite/AppModelDb.h  $(baseDir)/PublicAPI/BeSQLite/ChangeSet.h  $(baseDir)/PublicAPI/BeSQLite/ChangesetFile.h  $(baseDir)/PublicAPI/BeSQLite/BeSQLite.h ${MultiCompileDepends}
+
 $(o)Profiler$(oext) : $(baseDir)Profiler.cpp $(baseDir)/PublicAPI/BeSQLite/Profiler.h ${MultiCompileDepends}
 
 $(o)VirtualTab$(oext) : $(baseDir)VirtualTab.cpp $(baseDir)/PublicAPI/BeSQLite/VirtualTab.h ${MultiCompileDepends}

--- a/iModelCore/BeSQLite/ChangesetFile.cpp
+++ b/iModelCore/BeSQLite/ChangesetFile.cpp
@@ -11,6 +11,7 @@ USING_NAMESPACE_BENTLEY_SQLITE
 
 #define CHANGESET_FORMAT_VERSION  0x10
 #define CHANGESET_LZMA_MARKER   "ChangeSetLzma"
+#define CHANGESET_APPMODEL_MARKER   "AppModelChangeset"
 #define JSON_PROP_DDL                   "DDL"
 #define JSON_PROP_ContainsSchemaChanges "ContainsSchemaChanges"
 
@@ -77,6 +78,53 @@ public:
     }
 };
 
+//=======================================================================================
+// LZMA Header written to the beginning of an AppModel changeset file.
+// This is intentionally a distinct format from ChangesetLzmaHeader: it uses the marker
+// "AppModelChangeset" and a larger identifier buffer to hold it. The iModel header layout
+// (ChangesetLzmaHeader) must never change to preserve backwards compatibility, so AppModel
+// changesets carry their own self-describing header instead.
+// @bsiclass
+//=======================================================================================
+struct AppModelChangesetHeader {
+private:
+    uint16_t m_sizeOfHeader;
+    char m_idString[20];
+    uint16_t m_formatVersionNumber;
+    uint16_t m_compressionType;
+
+public:
+    static const int formatVersionNumber = CHANGESET_FORMAT_VERSION;
+    enum CompressionType {
+        LZMA2 = 2
+    };
+
+    AppModelChangesetHeader() {
+        CharCP idString = CHANGESET_APPMODEL_MARKER;
+        BeAssert((strlen(idString) + 1) <= sizeof(m_idString));
+        memset(this, 0, sizeof(*this));
+        m_sizeOfHeader = (uint16_t)sizeof(AppModelChangesetHeader);
+        strcpy(m_idString, idString);
+        m_compressionType = CompressionType::LZMA2;
+        m_formatVersionNumber = formatVersionNumber;
+    }
+
+    int GetVersion() { return m_formatVersionNumber; }
+
+    bool IsValid() {
+        if (m_sizeOfHeader != sizeof(AppModelChangesetHeader))
+            return false;
+
+        if (strcmp(m_idString, CHANGESET_APPMODEL_MARKER))
+            return false;
+
+        if (formatVersionNumber != m_formatVersionNumber)
+            return false;
+
+        return m_compressionType == LZMA2;
+    }
+};
+
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //---------------------------------------------------------------------------------------
@@ -93,8 +141,11 @@ DbResult ChangesetFileWriter::StartOutput() {
     }
 
     ChangesetLzmaHeader header;
+    AppModelChangesetHeader appModelHeader;
     uint32_t bytesWritten;
-    ZipErrors zipStatus = m_outLzmaFileStream->_Write(&header, sizeof(header), bytesWritten);
+    ZipErrors zipStatus = (m_kind == ChangesetKind::AppModel)
+        ? m_outLzmaFileStream->_Write(&appModelHeader, sizeof(appModelHeader), bytesWritten)
+        : m_outLzmaFileStream->_Write(&header, sizeof(header), bytesWritten);
     if (zipStatus != ZIP_SUCCESS) {
         BeAssert(false);
         return BE_SQLITE_ERROR;
@@ -168,7 +219,7 @@ DbResult ChangesetFileWriter::WritePrefix() {
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //---------------------------------------------------------------------------------------
-ChangesetFileWriter::ChangesetFileWriter(BeFileNameCR pathname, bool containsEcSchemaChanges, DdlChangesCR ddlChanges, Db const *dgnDb, BeSQLite::LzmaEncoder::LzmaParams const &lzmaParams) : m_pathname(pathname), m_prefix(""), m_db(dgnDb), m_outLzmaFileStream(nullptr), m_lzmaEncoder(lzmaParams) {
+ChangesetFileWriter::ChangesetFileWriter(BeFileNameCR pathname, bool containsEcSchemaChanges, DdlChangesCR ddlChanges, Db const *dgnDb, BeSQLite::LzmaEncoder::LzmaParams const &lzmaParams, ChangesetKind kind) : m_pathname(pathname), m_prefix(""), m_db(dgnDb), m_outLzmaFileStream(nullptr), m_lzmaEncoder(lzmaParams), m_kind(kind) {
     m_prefix = "";
     if (!containsEcSchemaChanges && ddlChanges._IsEmpty())
         return;
@@ -206,10 +257,18 @@ DbResult ChangesetFileReaderBase::Reader::StartInput() {
         return BE_SQLITE_ERROR;
     }
 
-    ChangesetLzmaHeader header;
-    uint32_t actuallyRead;
-    m_inLzmaFileStream->_Read(&header, sizeof(header), actuallyRead);
-    if (actuallyRead != sizeof(header) || !header.IsValid()) {
+    uint32_t actuallyRead = 0;
+    bool headerValid = false;
+    if (m_base.m_kind == ChangesetKind::AppModel) {
+        AppModelChangesetHeader header;
+        m_inLzmaFileStream->_Read(&header, sizeof(header), actuallyRead);
+        headerValid = (actuallyRead == sizeof(header)) && header.IsValid();
+    } else {
+        ChangesetLzmaHeader header;
+        m_inLzmaFileStream->_Read(&header, sizeof(header), actuallyRead);
+        headerValid = (actuallyRead == sizeof(header)) && header.IsValid();
+    }
+    if (!headerValid) {
         BeAssert(false && "Attempt to read an invalid revision version");
         return BE_SQLITE_ERROR_InvalidChangeSetVersion;
     }

--- a/iModelCore/BeSQLite/PublicAPI/BeSQLite/AppModelDb.h
+++ b/iModelCore/BeSQLite/PublicAPI/BeSQLite/AppModelDb.h
@@ -1,0 +1,261 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the repository root for full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+#pragma once
+
+#include "BeSQLite.h"
+#include "ChangeSet.h"
+
+//! be_Prop namespace under which the AppModel profile properties are stored.
+#define APPMODEL_PROPSPEC_NAMESPACE "appmodel_Db"
+
+//! Macros for the BentleyApi::BeSQLite::AppModel namespace, following the same pattern EC uses for
+//! BentleyApi::BeSQLite::EC (see BEGIN_BENTLEY_SQLITE_EC_NAMESPACE).
+#define BEGIN_BENTLEY_APPMODEL_NAMESPACE   BEGIN_BENTLEY_SQLITE_NAMESPACE namespace AppModel {
+#define END_BENTLEY_APPMODEL_NAMESPACE     } END_BENTLEY_SQLITE_NAMESPACE
+#define USING_NAMESPACE_BENTLEY_APPMODEL   using namespace BentleyApi::BeSQLite::AppModel;
+
+BEGIN_BENTLEY_APPMODEL_NAMESPACE
+
+//=======================================================================================
+//! Version digits for the AppModel profile.
+//! @see AppModelDb::CurrentProfileVersion, AppModelDb::MinimumUpgradableProfileVersion
+// @bsiclass
+//=======================================================================================
+enum SchemaValues
+    {
+    APPMODEL_CURRENT_VERSION_Major = 1,
+    APPMODEL_CURRENT_VERSION_Minor = 0,
+    APPMODEL_CURRENT_VERSION_Sub1  = 0,
+    APPMODEL_CURRENT_VERSION_Sub2  = 0,
+
+    //! Oldest version of the AppModel profile that the current API can still upgrade in-situ.
+    APPMODEL_SUPPORTED_VERSION_Major = APPMODEL_CURRENT_VERSION_Major,
+    APPMODEL_SUPPORTED_VERSION_Minor = APPMODEL_CURRENT_VERSION_Minor,
+    APPMODEL_SUPPORTED_VERSION_Sub1  = 0,
+    APPMODEL_SUPPORTED_VERSION_Sub2  = 0,
+    };
+
+//=======================================================================================
+//! The kind of change recorded by a single AppModel txn (see APPMODEL_TABLE_Txns.Type).
+// @bsiclass
+//=======================================================================================
+enum class TxnType
+    {
+    Data = 0,   //!< The txn contains data changes only.
+    Schema = 1, //!< The txn contains schema (DDL) changes, possibly along with data changes.
+    };
+
+//=======================================================================================
+//! The kind of change carried by an AppModel changeset file.
+// @bsiclass
+//=======================================================================================
+enum class ChangesetType
+    {
+    Regular = 0, //!< Contains data changes only.
+    Schema  = 1, //!< Contains schema (DDL) changes (possibly along with data changes).
+    };
+
+struct AppModelDb;
+
+//=======================================================================================
+//! Properties that describe an AppModel changeset file: its SHA1 id, the id of its parent
+//! changeset, the guid of the db it originated from, the on-disk file, and its kind.
+//!
+//! The changeset id is a SHA1 hash computed from the parent changeset id and the contents of the
+//! changeset file, exactly as iModel changesets are identified. This lets a changeset be validated
+//! (its id recomputed and compared) before it is merged, and forms a parent/child chain of changesets.
+// @bsiclass
+//=======================================================================================
+struct ChangesetProps
+    {
+    Utf8String m_id;
+    Utf8String m_parentId;
+    Utf8String m_dbGuid;
+    BeFileName m_fileName;
+    ChangesetType m_changesetType;
+
+    ChangesetProps() : m_changesetType(ChangesetType::Regular) {}
+    ChangesetProps(Utf8StringCR id, Utf8StringCR parentId, Utf8StringCR dbGuid, BeFileNameCR fileName, ChangesetType changesetType)
+        : m_id(id), m_parentId(parentId), m_dbGuid(dbGuid), m_fileName(fileName), m_changesetType(changesetType) {}
+
+    Utf8StringCR GetChangesetId() const { return m_id; }
+    Utf8StringCR GetParentId() const { return m_parentId; }
+    Utf8StringCR GetDbGuid() const { return m_dbGuid; }
+    BeFileNameCR GetFileName() const { return m_fileName; }
+    ChangesetType GetChangesetType() const { return m_changesetType; }
+    bool ContainsSchemaChanges() const { return m_changesetType == ChangesetType::Schema; }
+
+    //! Verify that this changeset originated from @p db (matching db guid) and that its id is the correct
+    //! SHA1 of its parent id + file contents.
+    //! @return BE_SQLITE_OK if valid; BE_SQLITE_MISMATCH if the db guid differs; BE_SQLITE_ERROR_InvalidChangeSetVersion
+    //! if the id does not match the file; BE_SQLITE_ERROR if the file is missing/corrupt.
+    BE_SQLITE_EXPORT DbResult ValidateContent(AppModelDb const& db) const;
+
+    //! Compute the SHA1 changeset id from a parent changeset id and an AppModel changeset file.
+    //! @param[in] parentId the parent changeset id (empty for the first changeset), or a 40-char SHA1 hex string.
+    //! @param[in] changesetFile the AppModel changeset file whose contents are hashed.
+    //! @return the 40-char SHA1 hex id, or an empty string if the file could not be read.
+    BE_SQLITE_EXPORT static Utf8String ComputeChangesetId(Utf8StringCR parentId, BeFileNameCR changesetFile);
+    };
+
+struct Txns;
+
+//=======================================================================================
+//! A BeSQLite @ref Db that carries an "AppModel" profile on top of the base BeSQLite profile.
+//!
+//! %AppModelDb manages its profile the same way ECDb does. When a new file is created, the current
+//! AppModel profile version is stamped into the be_Prop table and the AppModel's own set of tables
+//! is created. When an existing file is opened, the stored profile version is validated against the
+//! version expected by the software and, if the file is older but upgradable, it is upgraded in place
+//! by a sequence of internal profile migrators.
+//!
+//! The AppModel schema (the set of tables) and the profile migrators are internal to this
+//! implementation - consumers simply create/open an %AppModelDb and get a fully set-up file.
+//!
+//! @note %AppModelDb currently lives in BeSQLite. It is expected to move into its own component in the
+//! future, so it deliberately depends only on the base BeSQLite @ref Db API.
+//!
+//! @ingroup GROUP_BeSQLite
+// @bsiclass
+//=======================================================================================
+struct EXPORT_VTABLE_ATTRIBUTE AppModelDb : Db
+{
+private:
+    RefCountedPtr<Txns> m_txns;
+
+    void SetupChangeTracking();
+
+protected:
+    //! @name Profile hooks (forwarded from Db)
+    //! @{
+    BE_SQLITE_EXPORT DbResult _OnDbCreated(CreateParams const& params) override;
+    BE_SQLITE_EXPORT DbResult _OnDbOpened(OpenParams const& params) override;
+    BE_SQLITE_EXPORT void _OnDbClose() override;
+    BE_SQLITE_EXPORT ProfileState _CheckProfileVersion() const override;
+    BE_SQLITE_EXPORT DbResult _UpgradeProfile(OpenParams const& params) override;
+    //! @}
+
+public:
+    BE_SQLITE_EXPORT AppModelDb();
+    BE_SQLITE_EXPORT ~AppModelDb();
+
+    //! The AppModel profile version expected by this build of the software.
+    static ProfileVersion CurrentProfileVersion() { return ProfileVersion(APPMODEL_CURRENT_VERSION_Major, APPMODEL_CURRENT_VERSION_Minor, APPMODEL_CURRENT_VERSION_Sub1, APPMODEL_CURRENT_VERSION_Sub2); }
+
+    //! The oldest AppModel profile version that can still be upgraded in-situ to the current version.
+    //! Files with an older version cannot be upgraded.
+    static ProfileVersion MinimumUpgradableProfileVersion() { return ProfileVersion(APPMODEL_SUPPORTED_VERSION_Major, APPMODEL_SUPPORTED_VERSION_Minor, APPMODEL_SUPPORTED_VERSION_Sub1, APPMODEL_SUPPORTED_VERSION_Sub2); }
+
+    //! be_Prop spec under which the current AppModel profile version is stored.
+    static PropertySpec ProfileVersionProperty() { return PropertySpec("SchemaVersion", APPMODEL_PROPSPEC_NAMESPACE); }
+    //! be_Prop spec under which the AppModel profile version that the file was originally created with is stored.
+    static PropertySpec InitialProfileVersionProperty() { return PropertySpec("InitialSchemaVersion", APPMODEL_PROPSPEC_NAMESPACE); }
+
+    //! Gets the AppModel profile version stored in this (open) file.
+    //! @param[out] version the profile version read from the file.
+    //! @return BE_SQLITE_OK if the version was read, BE_SQLITE_ERROR_InvalidProfileVersion if the file has no AppModel profile.
+    BE_SQLITE_EXPORT DbResult QueryProfileVersion(ProfileVersion& version) const;
+
+    //! The change tracker for this db. All change-tracking, changeset creation and merge operations live on
+    //! Txns, e.g. GetTxns().BeginCreateChangeset(...) and GetTxns().MergeChangeset(...).
+    //! @note The tracker records changes only when the db is open read-write; on a readonly db it exists but
+    //! tracking is disabled.
+    BE_SQLITE_EXPORT Txns& GetTxns();
+};
+
+//=======================================================================================
+//! Change tracker for an AppModelDb. Records local changes and, on each SaveChanges that produced changes,
+//! writes a single row into the APPMODEL_TABLE_Txns table capturing both the DDL (schema) changes and the data
+//! changes. It also creates AppModel changeset files from the recorded txns and merges changeset files from
+//! other AppModelDbs.
+//!
+//! @note This tracker does not implement undo/redo. Recorded txns are a durable log used to produce changeset
+//! files; they are not reversed/reinstated.
+//!
+//! @note Schema (DDL) changes are assumed to be *additive only* (for example adding a table or a column, never
+//! dropping or redefining one), and the application is expected to perform DDL only during a migration step that
+//! adds a new feature - never as part of normal, changeset-tracked data operations. Because all recorded txns are
+//! combined into a single changeset, changing a table's column count in between two data changes to that same
+//! table within one changeset window is not supported; the additive + migration-only-DDL assumptions keep normal
+//! operation clear of that case.
+// @bsiclass
+//+===============+===============+===============+===============+===============+======
+struct EXPORT_VTABLE_ATTRIBUTE Txns : ChangeTracker
+    {
+private:
+    Utf8String m_pendingProps;
+    SnappyToBlob m_snappyToBlob; //!< reused compressor for writing txn change blobs (mirrors TxnManager::m_snappyTo)
+    Utf8String m_creatingChangesetId; //!< id of the changeset produced by BeginCreateChangeset, finalized by EndCreateChangeset
+    int64_t m_creatingChangesetLastTxnId = 0; //!< highest APPMODEL_TABLE_Txns.Id captured by BeginCreateChangeset (0 = none in progress)
+
+    AppModelDb& GetAppModelDb() const { return *static_cast<AppModelDb*>(const_cast<Txns*>(this)->GetDb()); }
+
+    DbResult WriteTxn(Utf8CP description, DdlChanges const& ddlChanges, ChangeSet const& dataChanges);
+    DbResult ReadTxnDataChanges(ChangeSet& dataChanges, int64_t txnId) const;
+
+    //! Apply the DDL and data changes from an AppModel changeset file to this db, without recording them as
+    //! new txns (change tracking is suspended for the duration). Conflicts abort the apply (see ChangesetReader).
+    DbResult ApplyChangesetFile(BeFileNameCR pathname);
+
+    //! Set the id of this db's current (parent) changeset. Private: it is advanced by MergeChangeset once a
+    //! changeset has been successfully applied. Stored in be_Local (which is excluded from change tracking).
+    DbResult SetParentChangesetId(Utf8StringCR changesetId);
+
+protected:
+    //! Skip be_Local (redundant/derived) and the AppModel txns table itself (writing txns must not be tracked).
+    BE_SQLITE_EXPORT TrackChangesForTable _FilterTable(Utf8CP tableName) override;
+
+    //! On commit, capture the tracked DDL + data changes and store them as one row in APPMODEL_TABLE_Txns.
+    //! @note @p operation is the description passed to Db::SaveChanges; it is stored as the txn's Description.
+    BE_SQLITE_EXPORT OnCommitStatus _OnCommit(bool isCommit, Utf8CP operation) override;
+
+public:
+    //! Construct a tracker for @p db and register it as the db's change tracker.
+    BE_SQLITE_EXPORT explicit Txns(AppModelDb& db);
+
+    Txns(Txns const&) = delete;
+    Txns& operator=(Txns const&) = delete;
+    Txns(Txns&&) = delete;
+    Txns& operator=(Txns&&) = delete;
+
+    //! Stage a JSON properties string to store on the next committed txn. Cleared after the txn is written.
+    void SetTxnProps(Utf8CP propsJson) { m_pendingProps.AssignOrClear(propsJson); }
+
+    //! Determine whether any txns have been recorded in this file (i.e. there are rows in APPMODEL_TABLE_Txns).
+    BE_SQLITE_EXPORT bool HasPendingTxns() const;
+
+    //! The id of this db's current changeset ("" if none yet). This is the parent id used when creating or
+    //! validating the next changeset.
+    BE_SQLITE_EXPORT Utf8String GetParentChangesetId() const;
+
+    //! Begin creating an AppModel changeset: combine all recorded txns into a single AppModel changeset file that
+    //! can be applied to another AppModelDb, and fill @p props with the changeset's properties: its parent changeset
+    //! id (this db's current changeset id), a freshly computed SHA1 changeset id, this db's guid, the file, and the
+    //! changeset type.
+    //! @note This only writes the file; it does not yet remove the captured txns or advance this db's changeset id.
+    //! Call EndCreateChangeset once the changeset file has been safely persisted to finalize the operation.
+    //! @param[out] props the properties of the created changeset.
+    //! @param[in] pathname the full path of the changeset file to create.
+    //! @return BE_SQLITE_OK on success, or an error if there are no txns or the file could not be written.
+    BE_SQLITE_EXPORT DbResult BeginCreateChangeset(ChangesetProps& props, BeFileNameCR pathname);
+
+    //! Finalize the changeset started by BeginCreateChangeset: delete the txns that were captured into it (so the next
+    //! changeset contains only subsequent changes) and advance this db's current changeset id to the newly created
+    //! changeset (so the next changeset chains onto it), then commit. Txns recorded after BeginCreateChangeset are
+    //! preserved. Call this only after the changeset file produced by BeginCreateChangeset has been safely persisted.
+    //! @return BE_SQLITE_OK on success; BE_SQLITE_ERROR if there is no changeset creation in progress.
+    BE_SQLITE_EXPORT DbResult EndCreateChangeset();
+
+    //! Apply (merge) an AppModel changeset onto this db. First validates that the changeset originated from this
+    //! db (matching guid), that its parent id matches this db's current changeset id, and that its SHA1 id is
+    //! correct. The changes are applied without being recorded as new txns; any conflict aborts the merge. On
+    //! success this db's parent changeset id is advanced to the merged changeset's id and the change is committed.
+    //! @param[in] props the properties of the changeset to merge (its m_fileName must point at the file).
+    //! @return BE_SQLITE_OK on success; BE_SQLITE_MISMATCH if it did not originate from this db or its parent does
+    //! not match; BE_SQLITE_ERROR_InvalidChangeSetVersion if its id is incorrect; error otherwise.
+    BE_SQLITE_EXPORT DbResult MergeChangeset(ChangesetProps const& props);
+    };
+
+END_BENTLEY_APPMODEL_NAMESPACE

--- a/iModelCore/BeSQLite/PublicAPI/BeSQLite/ChangesetFile.h
+++ b/iModelCore/BeSQLite/PublicAPI/BeSQLite/ChangesetFile.h
@@ -11,6 +11,17 @@
 BEGIN_BENTLEY_SQLITE_NAMESPACE
 
 //=======================================================================================
+//! Identifies the "kind" of a changeset file, which selects the on-disk header format/marker.
+//! iModel changesets and AppModel changesets share the same body format but use different,
+//! self-describing headers so that a reader of one kind rejects a file of the other kind.
+// @bsiclass
+//=======================================================================================
+enum class ChangesetKind {
+    iModel = 0,   //!< Standard iModel changeset (header marker "ChangeSetLzma").
+    AppModel = 1, //!< AppModel changeset (header marker "AppModelChangeset").
+};
+
+//=======================================================================================
 //! Streams the contents of a file containing serialized change streams
 // @bsiclass
 //=======================================================================================
@@ -18,6 +29,7 @@ struct EXPORT_VTABLE_ATTRIBUTE ChangesetFileReaderBase : ChangeStream {
 private:
     Db const* m_db; // Used only for debugging
     bvector<BeFileName> m_files;
+    ChangesetKind m_kind;
 
     struct Reader : Changes::Reader {
         ChangesetFileReaderBase const& m_base;
@@ -46,8 +58,9 @@ public:
     bool _IsEmpty() const override { return m_files.size() == 0; }
     RefCountedPtr<Reader> MakeReader() const { return new Reader(*this); }
     RefCountedPtr<Changes::Reader> _GetReader() const override { return MakeReader(); }
-    ChangesetFileReaderBase(bvector<BeFileName> const& files, Db const* db = nullptr) : m_files(files), m_db(db) {}
+    ChangesetFileReaderBase(bvector<BeFileName> const& files, Db const* db = nullptr, ChangesetKind kind = ChangesetKind::iModel) : m_files(files), m_db(db), m_kind(kind) {}
     Db const* GetDb() const { return m_db; }
+    ChangesetKind GetChangesetKind() const { return m_kind; }
 };
 
 //=======================================================================================
@@ -61,6 +74,7 @@ private:
     BeFileLzmaOutStream* m_outLzmaFileStream;
     Utf8String m_prefix;
     Db const* m_db; // Only for debugging
+    ChangesetKind m_kind;
 
     DbResult StartOutput();
     BE_SQLITE_EXPORT void FinishOutput();
@@ -73,7 +87,8 @@ private:
 
 public:
     BE_SQLITE_EXPORT ChangesetFileWriter(BeFileNameCR pathname, bool containsEcSchemaChanges, DdlChangesCR ddlChanges, Db const*,
-                                         BeSQLite::LzmaEncoder::LzmaParams const& lzmaParams = BeSQLite::LzmaEncoder::LzmaParams());
+                                         BeSQLite::LzmaEncoder::LzmaParams const& lzmaParams = BeSQLite::LzmaEncoder::LzmaParams(),
+                                         ChangesetKind kind = ChangesetKind::iModel);
     BE_SQLITE_EXPORT DbResult Initialize();
     ~ChangesetFileWriter() { FinishOutput(); }
 };

--- a/iModelCore/BeSQLite/Tests/NonPublished/AppModelDb_Test.cpp
+++ b/iModelCore/BeSQLite/Tests/NonPublished/AppModelDb_Test.cpp
@@ -1,0 +1,527 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the repository root for full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+#include "BeSQLiteNonPublishedTests.h"
+#include <BeSQLite/AppModelDb.h>
+
+USING_NAMESPACE_BENTLEY_APPMODEL
+
+//---------------------------------------------------------------------------------------
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+------
+static BeFileName GetOutputFile(WCharCP name)
+    {
+    BeFileName tempDir;
+    BeTest::GetHost().GetTempDir(tempDir);
+    BeSQLiteLib::Initialize(tempDir);
+
+    BeFileName fileName;
+    BeTest::GetHost().GetOutputRoot(fileName);
+    fileName.AppendToPath(name);
+    if (BeFileName::DoesPathExist(fileName))
+        BeFileName::BeDeleteFile(fileName);
+
+    return fileName;
+    }
+
+//---------------------------------------------------------------------------------------
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+------
+TEST(AppModelDb, CreateStampsProfileAndCreatesTables)
+    {
+    BeFileName fileName = GetOutputFile(L"appmodeldb_create.db");
+
+    AppModelDb db;
+    ASSERT_EQ(BE_SQLITE_OK, db.CreateNewDb(fileName.GetNameUtf8().c_str()));
+
+    // The AppModel profile creates its own set of tables internally.
+    EXPECT_TRUE(db.TableExists("Dgns"));
+    EXPECT_TRUE(db.TableExists("DgnStreams"));
+    EXPECT_TRUE(db.TableExists("Models"));
+    EXPECT_TRUE(db.TableExists("Elements"));
+    EXPECT_TRUE(db.TableExists("DgnReferencesModels"));
+    EXPECT_TRUE(db.TableExists("ModelUsesDgnLibElement"));
+    EXPECT_TRUE(db.TableExists("Schemas"));
+    EXPECT_TRUE(db.TableExists("DgnContainsSchemas"));
+    EXPECT_TRUE(db.TableExists("SchemaClasses"));
+    EXPECT_TRUE(db.TableExists("RasterImages"));
+
+    ProfileVersion version(0, 0, 0, 0);
+    ASSERT_EQ(BE_SQLITE_OK, db.QueryProfileVersion(version));
+    EXPECT_EQ(0, version.CompareTo(AppModelDb::CurrentProfileVersion())) << "Created file must carry the current AppModel profile version";
+
+    db.SaveChanges();
+    db.CloseDb();
+    }
+
+//---------------------------------------------------------------------------------------
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+------
+TEST(AppModelDb, ReopenSucceedsForCurrentProfile)
+    {
+    BeFileName fileName = GetOutputFile(L"appmodeldb_reopen.db");
+
+    {
+    AppModelDb db;
+    ASSERT_EQ(BE_SQLITE_OK, db.CreateNewDb(fileName.GetNameUtf8().c_str()));
+    db.SaveChanges();
+    db.CloseDb();
+    }
+
+    AppModelDb reopened;
+    ASSERT_EQ(BE_SQLITE_OK, reopened.OpenBeSQLiteDb(fileName.GetNameUtf8().c_str(), Db::OpenParams(Db::OpenMode::ReadWrite)))
+        << "A file with the current AppModel profile version should open without upgrade";
+    EXPECT_TRUE(reopened.TableExists("Elements"));
+    }
+
+//---------------------------------------------------------------------------------------
+// A plain BeSQLite file has no AppModel profile, so opening it as an AppModelDb must fail.
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+------
+TEST(AppModelDb, OpenRejectsFileWithoutAppModelProfile)
+    {
+    BeFileName fileName = GetOutputFile(L"appmodeldb_plain.db");
+
+    {
+    Db plain;
+    ASSERT_EQ(BE_SQLITE_OK, plain.CreateNewDb(fileName.GetNameUtf8().c_str()));
+    plain.SaveChanges();
+    plain.CloseDb();
+    }
+
+    AppModelDb db;
+    EXPECT_NE(BE_SQLITE_OK, db.OpenBeSQLiteDb(fileName.GetNameUtf8().c_str(), Db::OpenParams(Db::OpenMode::Readonly)))
+        << "A plain BeSQLite file (no AppModel profile) must be rejected";
+    }
+
+//---------------------------------------------------------------------------------------
+// Helper: count rows in a table.
+//+---------------+---------------+---------------+---------------+---------------+------
+static int CountRows(Db& db, Utf8CP table)
+    {
+    Statement stmt;
+    if (BE_SQLITE_OK != stmt.Prepare(db, Utf8PrintfString("SELECT COUNT(*) FROM %s", table).c_str()))
+        return -1;
+    stmt.Step();
+    return stmt.GetValueInt(0);
+    }
+
+//---------------------------------------------------------------------------------------
+// Change tracking is on by default; a SaveChanges that produced data changes writes one txn row.
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+------
+TEST(AppModelDb, SaveChangesRecordsDataTxn)
+    {
+    BeFileName fileName = GetOutputFile(L"appmodeldb_txn_data.db");
+
+    AppModelDb db;
+    ASSERT_EQ(BE_SQLITE_OK, db.CreateNewDb(fileName.GetNameUtf8().c_str()));
+    EXPECT_TRUE(db.GetTxns().IsTracking()) << "Change tracking should be active after create";
+    EXPECT_FALSE(db.GetTxns().HasPendingTxns()) << "Creating the profile must not record any txn";
+
+    ASSERT_EQ(BE_SQLITE_OK, db.ExecuteSql("INSERT INTO Dgns(Name,IsDgnLib) VALUES('dgn1',0)"));
+    db.SaveChanges();
+
+    ASSERT_EQ(1, CountRows(db, "appmodel_txns")) << "A data change should record exactly one txn";
+
+    Statement stmt;
+    ASSERT_EQ(BE_SQLITE_OK, stmt.Prepare(db, "SELECT Type,Ddl,(Change IS NOT NULL) FROM appmodel_txns"));
+    ASSERT_EQ(BE_SQLITE_ROW, stmt.Step());
+    EXPECT_EQ((int) TxnType::Data, stmt.GetValueInt(0));
+    EXPECT_TRUE(stmt.IsColumnNull(1)) << "A data-only txn has no DDL";
+    EXPECT_NE(0, stmt.GetValueInt(2)) << "A data-only txn has a Change blob";
+    db.CloseDb();
+    }
+
+//---------------------------------------------------------------------------------------
+// Metadata (description + JSON props) is stored on the next committed txn.
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+------
+TEST(AppModelDb, SaveChangesRecordsMetadata)
+    {
+    BeFileName fileName = GetOutputFile(L"appmodeldb_txn_meta.db");
+
+    AppModelDb db;
+    ASSERT_EQ(BE_SQLITE_OK, db.CreateNewDb(fileName.GetNameUtf8().c_str()));
+
+    db.GetTxns().SetTxnProps(R"({"author":"tester"})");
+    ASSERT_EQ(BE_SQLITE_OK, db.ExecuteSql("INSERT INTO Dgns(Name,IsDgnLib) VALUES('dgn1',0)"));
+    db.SaveChanges("added dgn1"); // the SaveChanges description is stored on the txn
+
+    Statement stmt;
+    ASSERT_EQ(BE_SQLITE_OK, stmt.Prepare(db, "SELECT Description,Props FROM appmodel_txns"));
+    ASSERT_EQ(BE_SQLITE_ROW, stmt.Step());
+    EXPECT_STREQ("added dgn1", stmt.GetValueText(0));
+    EXPECT_STREQ(R"({"author":"tester"})", stmt.GetValueText(1));
+    db.CloseDb();
+    }
+
+//---------------------------------------------------------------------------------------
+// A txn that contains DDL is recorded with Type=Schema and the DDL text in the Ddl column.
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+------
+TEST(AppModelDb, SaveChangesRecordsSchemaTxn)
+    {
+    BeFileName fileName = GetOutputFile(L"appmodeldb_txn_schema.db");
+
+    AppModelDb db;
+    ASSERT_EQ(BE_SQLITE_OK, db.CreateNewDb(fileName.GetNameUtf8().c_str()));
+
+    ASSERT_EQ(BE_SQLITE_OK, db.ExecuteDdl("CREATE TABLE app_Custom(Id INTEGER PRIMARY KEY, Val TEXT)"));
+    ASSERT_EQ(BE_SQLITE_OK, db.ExecuteSql("INSERT INTO app_Custom(Val) VALUES('x')"));
+    db.SaveChanges();
+
+    Statement stmt;
+    ASSERT_EQ(BE_SQLITE_OK, stmt.Prepare(db, "SELECT Type,Ddl FROM appmodel_txns"));
+    ASSERT_EQ(BE_SQLITE_ROW, stmt.Step());
+    EXPECT_EQ((int) TxnType::Schema, stmt.GetValueInt(0));
+    EXPECT_FALSE(stmt.IsColumnNull(1)) << "A txn with DDL stores the DDL text";
+    db.CloseDb();
+    }
+
+//---------------------------------------------------------------------------------------
+// AbandonChanges must not record a txn.
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+------
+TEST(AppModelDb, AbandonChangesRecordsNoTxn)
+    {
+    BeFileName fileName = GetOutputFile(L"appmodeldb_txn_abandon.db");
+
+    AppModelDb db;
+    ASSERT_EQ(BE_SQLITE_OK, db.CreateNewDb(fileName.GetNameUtf8().c_str()));
+    db.SaveChanges();
+
+    ASSERT_EQ(BE_SQLITE_OK, db.ExecuteSql("INSERT INTO Dgns(Name,IsDgnLib) VALUES('dgn1',0)"));
+    db.AbandonChanges();
+
+    EXPECT_EQ(0, CountRows(db, "appmodel_txns"));
+    EXPECT_EQ(0, CountRows(db, "Dgns"));
+    db.CloseDb();
+    }
+
+//---------------------------------------------------------------------------------------
+// Recorded txns can be combined into a single AppModel changeset file, with a SHA1 id.
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+------
+TEST(AppModelDb, CreateChangesetWritesFileAndComputesId)
+    {
+    BeFileName fileName = GetOutputFile(L"appmodeldb_cs_source.db");
+    BeFileName changesetFile = GetOutputFile(L"appmodeldb.changeset");
+
+    AppModelDb db;
+    ASSERT_EQ(BE_SQLITE_OK, db.CreateNewDb(fileName.GetNameUtf8().c_str()));
+    ASSERT_EQ(BE_SQLITE_OK, db.ExecuteSql("INSERT INTO Dgns(Name,IsDgnLib) VALUES('dgn1',0)"));
+    db.SaveChanges();
+
+    ChangesetProps props;
+    ASSERT_EQ(BE_SQLITE_OK, db.GetTxns().BeginCreateChangeset(props, changesetFile));
+    ASSERT_EQ(BE_SQLITE_OK, db.GetTxns().EndCreateChangeset());
+    EXPECT_TRUE(BeFileName::DoesPathExist(changesetFile));
+    EXPECT_EQ(40u, props.GetChangesetId().length()) << "changeset id should be a 40-char SHA1 hex string";
+    EXPECT_TRUE(props.GetParentId().empty()) << "first changeset has no parent";
+    EXPECT_STREQ(db.GetDbGuid().ToString().c_str(), props.GetDbGuid().c_str());
+
+    // The props validate against this db (correct db guid + recomputed SHA1 id).
+    EXPECT_EQ(BE_SQLITE_OK, props.ValidateContent(db));
+
+    // Tampering with the recorded id must fail validation.
+    ChangesetProps bad = props;
+    bad.m_id = "0000000000000000000000000000000000000000";
+    EXPECT_EQ(BE_SQLITE_ERROR_InvalidChangeSetVersion, bad.ValidateContent(db));
+    db.CloseDb();
+    }
+
+//---------------------------------------------------------------------------------------
+// BeginCreateChangeset writes the file but keeps the captured txns and does not advance the changeset id;
+// EndCreateChangeset deletes the captured txns and advances the changeset id, so a changeset created afterward
+// chains onto the previous one.
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+------
+TEST(AppModelDb, BeginEndCreateChangesetClearsTxnsAndChains)
+    {
+    BeFileName fileName = GetOutputFile(L"appmodeldb_beginend.db");
+    BeFileName cs1File = GetOutputFile(L"appmodeldb_beginend1.changeset");
+    BeFileName cs2File = GetOutputFile(L"appmodeldb_beginend2.changeset");
+
+    AppModelDb db;
+    ASSERT_EQ(BE_SQLITE_OK, db.CreateNewDb(fileName.GetNameUtf8().c_str()));
+
+    ASSERT_EQ(BE_SQLITE_OK, db.ExecuteSql("INSERT INTO Dgns(Name,IsDgnLib) VALUES('dgn1',0)"));
+    db.SaveChanges();
+    EXPECT_TRUE(db.GetTxns().HasPendingTxns());
+
+    ChangesetProps cs1;
+    ASSERT_EQ(BE_SQLITE_OK, db.GetTxns().BeginCreateChangeset(cs1, cs1File));
+    EXPECT_TRUE(cs1.GetParentId().empty()) << "first changeset has no parent";
+    EXPECT_TRUE(db.GetTxns().HasPendingTxns()) << "BeginCreateChangeset must not delete the captured txns";
+    EXPECT_TRUE(db.GetTxns().GetParentChangesetId().empty()) << "BeginCreateChangeset must not advance the changeset id";
+
+    ASSERT_EQ(BE_SQLITE_OK, db.GetTxns().EndCreateChangeset());
+    EXPECT_FALSE(db.GetTxns().HasPendingTxns()) << "EndCreateChangeset must delete the captured txns";
+    EXPECT_STREQ(cs1.GetChangesetId().c_str(), db.GetTxns().GetParentChangesetId().c_str()) << "EndCreateChangeset advances the changeset id";
+
+    // A second changeset created after the first chains onto it.
+    ASSERT_EQ(BE_SQLITE_OK, db.ExecuteSql("INSERT INTO Dgns(Name,IsDgnLib) VALUES('dgn2',0)"));
+    db.SaveChanges();
+    ChangesetProps cs2;
+    ASSERT_EQ(BE_SQLITE_OK, db.GetTxns().BeginCreateChangeset(cs2, cs2File));
+    EXPECT_STREQ(cs1.GetChangesetId().c_str(), cs2.GetParentId().c_str()) << "the second changeset chains onto the first";
+    EXPECT_STRNE(cs1.GetChangesetId().c_str(), cs2.GetChangesetId().c_str());
+    ASSERT_EQ(BE_SQLITE_OK, db.GetTxns().EndCreateChangeset());
+
+    // EndCreateChangeset with no create in progress is an error.
+    EXPECT_NE(BE_SQLITE_OK, db.GetTxns().EndCreateChangeset()) << "EndCreateChangeset without a matching Begin must fail";
+    db.CloseDb();
+    }
+
+//---------------------------------------------------------------------------------------
+// A changeset created from one copy of a db can be merged into another copy (same db guid),
+// and the merged db advances its parent changeset id.
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+------
+TEST(AppModelDb, CreateAndMergeChangeset)
+    {
+    BeFileName seed = GetOutputFile(L"appmodeldb_seed.db");
+    BeFileName source = GetOutputFile(L"appmodeldb_src.db");
+    BeFileName target = GetOutputFile(L"appmodeldb_tgt.db");
+    BeFileName changesetFile = GetOutputFile(L"appmodeldb_merge.changeset");
+
+    // Create an empty seed and copy it to source and target (both share the same db guid).
+    {
+    AppModelDb db;
+    ASSERT_EQ(BE_SQLITE_OK, db.CreateNewDb(seed.GetNameUtf8().c_str()));
+    db.SaveChanges();
+    db.CloseDb();
+    }
+    ASSERT_EQ(BeFileNameStatus::Success, BeFileName::BeCopyFile(seed, source));
+    ASSERT_EQ(BeFileNameStatus::Success, BeFileName::BeCopyFile(seed, target));
+
+    // Make a change on the source and produce a changeset.
+    ChangesetProps props;
+    {
+    AppModelDb db;
+    ASSERT_EQ(BE_SQLITE_OK, db.OpenBeSQLiteDb(source.GetNameUtf8().c_str(), Db::OpenParams(Db::OpenMode::ReadWrite)));
+    ASSERT_EQ(BE_SQLITE_OK, db.ExecuteSql("INSERT INTO Dgns(Name,IsDgnLib) VALUES('dgn1',0)"));
+    db.SaveChanges("add dgn1");
+    ASSERT_EQ(BE_SQLITE_OK, db.GetTxns().BeginCreateChangeset(props, changesetFile));
+    ASSERT_EQ(BE_SQLITE_OK, db.GetTxns().EndCreateChangeset());
+    db.CloseDb();
+    }
+
+    // Merge the changeset into the target and verify the change arrived and the parent advanced.
+    {
+    AppModelDb db;
+    ASSERT_EQ(BE_SQLITE_OK, db.OpenBeSQLiteDb(target.GetNameUtf8().c_str(), Db::OpenParams(Db::OpenMode::ReadWrite)));
+    EXPECT_EQ(0, CountRows(db, "Dgns"));
+    ASSERT_EQ(BE_SQLITE_OK, db.GetTxns().MergeChangeset(props));
+    EXPECT_EQ(1, CountRows(db, "Dgns")) << "the merged change should be present";
+    EXPECT_STREQ(props.GetChangesetId().c_str(), db.GetTxns().GetParentChangesetId().c_str()) << "parent id should advance to the merged changeset";
+    EXPECT_EQ(0, CountRows(db, "appmodel_txns")) << "merging must not record new txns";
+    db.CloseDb();
+    }
+    }
+
+//---------------------------------------------------------------------------------------
+// CreateChangeset with no recorded txns is an error (nothing to serialize).
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+------
+TEST(AppModelDb, CreateChangesetFailsWithNoTxns)
+    {
+    BeFileName fileName = GetOutputFile(L"appmodeldb_cs_empty.db");
+    BeFileName changesetFile = GetOutputFile(L"appmodeldb_empty.changeset");
+
+    AppModelDb db;
+    ASSERT_EQ(BE_SQLITE_OK, db.CreateNewDb(fileName.GetNameUtf8().c_str()));
+    db.SaveChanges();
+
+    ChangesetProps props;
+    EXPECT_NE(BE_SQLITE_OK, db.GetTxns().BeginCreateChangeset(props, changesetFile)) << "creating a changeset with no txns must fail";
+    EXPECT_FALSE(BeFileName::DoesPathExist(changesetFile)) << "no changeset file should be produced";
+    db.CloseDb();
+    }
+
+//---------------------------------------------------------------------------------------
+// A changeset whose txns include DDL is marked as a Schema changeset.
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+------
+TEST(AppModelDb, CreateChangesetMarksSchemaType)
+    {
+    BeFileName fileName = GetOutputFile(L"appmodeldb_cs_schema.db");
+    BeFileName changesetFile = GetOutputFile(L"appmodeldb_schema.changeset");
+
+    AppModelDb db;
+    ASSERT_EQ(BE_SQLITE_OK, db.CreateNewDb(fileName.GetNameUtf8().c_str()));
+    ASSERT_EQ(BE_SQLITE_OK, db.ExecuteDdl("CREATE TABLE app_Custom(Id INTEGER PRIMARY KEY, Val TEXT)"));
+    ASSERT_EQ(BE_SQLITE_OK, db.ExecuteSql("INSERT INTO app_Custom(Val) VALUES('x')"));
+    db.SaveChanges();
+
+    ChangesetProps props;
+    ASSERT_EQ(BE_SQLITE_OK, db.GetTxns().BeginCreateChangeset(props, changesetFile));
+    ASSERT_EQ(BE_SQLITE_OK, db.GetTxns().EndCreateChangeset());
+    EXPECT_EQ(ChangesetType::Schema, props.GetChangesetType()) << "a changeset containing DDL is a Schema changeset";
+    EXPECT_TRUE(props.ContainsSchemaChanges());
+    db.CloseDb();
+    }
+
+//---------------------------------------------------------------------------------------
+// A changeset can only be merged into a db that shares the originating db's guid.
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+------
+TEST(AppModelDb, MergeRejectsWrongDbGuid)
+    {
+    BeFileName source = GetOutputFile(L"appmodeldb_guid_src.db");
+    BeFileName other = GetOutputFile(L"appmodeldb_guid_other.db");
+    BeFileName changesetFile = GetOutputFile(L"appmodeldb_guid.changeset");
+
+    ChangesetProps props;
+    {
+    AppModelDb db;
+    ASSERT_EQ(BE_SQLITE_OK, db.CreateNewDb(source.GetNameUtf8().c_str()));
+    ASSERT_EQ(BE_SQLITE_OK, db.ExecuteSql("INSERT INTO Dgns(Name,IsDgnLib) VALUES('dgn1',0)"));
+    db.SaveChanges();
+    ASSERT_EQ(BE_SQLITE_OK, db.GetTxns().BeginCreateChangeset(props, changesetFile));
+    ASSERT_EQ(BE_SQLITE_OK, db.GetTxns().EndCreateChangeset());
+    db.CloseDb();
+    }
+
+    // An independently-created db has a different guid, so the merge must be rejected.
+    AppModelDb db;
+    ASSERT_EQ(BE_SQLITE_OK, db.CreateNewDb(other.GetNameUtf8().c_str()));
+    db.SaveChanges();
+    EXPECT_EQ(BE_SQLITE_MISMATCH, db.GetTxns().MergeChangeset(props)) << "a changeset from a different db must be rejected";
+    EXPECT_EQ(0, CountRows(db, "Dgns"));
+    db.CloseDb();
+    }
+
+//---------------------------------------------------------------------------------------
+// A changeset must chain onto the target's current changeset; re-merging one whose parent no longer
+// matches is rejected.
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+------
+TEST(AppModelDb, MergeRejectsWrongParent)
+    {
+    BeFileName seed = GetOutputFile(L"appmodeldb_par_seed.db");
+    BeFileName source = GetOutputFile(L"appmodeldb_par_src.db");
+    BeFileName target = GetOutputFile(L"appmodeldb_par_tgt.db");
+    BeFileName changesetFile = GetOutputFile(L"appmodeldb_par.changeset");
+
+    {
+    AppModelDb db;
+    ASSERT_EQ(BE_SQLITE_OK, db.CreateNewDb(seed.GetNameUtf8().c_str()));
+    db.SaveChanges();
+    db.CloseDb();
+    }
+    ASSERT_EQ(BeFileNameStatus::Success, BeFileName::BeCopyFile(seed, source));
+    ASSERT_EQ(BeFileNameStatus::Success, BeFileName::BeCopyFile(seed, target));
+
+    ChangesetProps props;
+    {
+    AppModelDb db;
+    ASSERT_EQ(BE_SQLITE_OK, db.OpenBeSQLiteDb(source.GetNameUtf8().c_str(), Db::OpenParams(Db::OpenMode::ReadWrite)));
+    ASSERT_EQ(BE_SQLITE_OK, db.ExecuteSql("INSERT INTO Dgns(Name,IsDgnLib) VALUES('dgn1',0)"));
+    db.SaveChanges();
+    ASSERT_EQ(BE_SQLITE_OK, db.GetTxns().BeginCreateChangeset(props, changesetFile));
+    ASSERT_EQ(BE_SQLITE_OK, db.GetTxns().EndCreateChangeset());
+    db.CloseDb();
+    }
+
+    AppModelDb db;
+    ASSERT_EQ(BE_SQLITE_OK, db.OpenBeSQLiteDb(target.GetNameUtf8().c_str(), Db::OpenParams(Db::OpenMode::ReadWrite)));
+    ASSERT_EQ(BE_SQLITE_OK, db.GetTxns().MergeChangeset(props)); // first merge advances parent to props.id
+    EXPECT_STREQ(props.GetChangesetId().c_str(), db.GetTxns().GetParentChangesetId().c_str());
+    // Re-merging the same changeset now fails: its parent ("") no longer matches the target's current changeset.
+    EXPECT_EQ(BE_SQLITE_MISMATCH, db.GetTxns().MergeChangeset(props));
+    EXPECT_EQ(1, CountRows(db, "Dgns")) << "the rejected re-merge must not change data";
+    db.CloseDb();
+    }
+
+//---------------------------------------------------------------------------------------
+// A changeset whose id does not match its contents is rejected on merge.
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+------
+TEST(AppModelDb, MergeRejectsTamperedId)
+    {
+    BeFileName seed = GetOutputFile(L"appmodeldb_tamper_seed.db");
+    BeFileName source = GetOutputFile(L"appmodeldb_tamper_src.db");
+    BeFileName target = GetOutputFile(L"appmodeldb_tamper_tgt.db");
+    BeFileName changesetFile = GetOutputFile(L"appmodeldb_tamper.changeset");
+
+    {
+    AppModelDb db;
+    ASSERT_EQ(BE_SQLITE_OK, db.CreateNewDb(seed.GetNameUtf8().c_str()));
+    db.SaveChanges();
+    db.CloseDb();
+    }
+    ASSERT_EQ(BeFileNameStatus::Success, BeFileName::BeCopyFile(seed, source));
+    ASSERT_EQ(BeFileNameStatus::Success, BeFileName::BeCopyFile(seed, target));
+
+    ChangesetProps props;
+    {
+    AppModelDb db;
+    ASSERT_EQ(BE_SQLITE_OK, db.OpenBeSQLiteDb(source.GetNameUtf8().c_str(), Db::OpenParams(Db::OpenMode::ReadWrite)));
+    ASSERT_EQ(BE_SQLITE_OK, db.ExecuteSql("INSERT INTO Dgns(Name,IsDgnLib) VALUES('dgn1',0)"));
+    db.SaveChanges();
+    ASSERT_EQ(BE_SQLITE_OK, db.GetTxns().BeginCreateChangeset(props, changesetFile));
+    ASSERT_EQ(BE_SQLITE_OK, db.GetTxns().EndCreateChangeset());
+    db.CloseDb();
+    }
+
+    props.m_id = "0000000000000000000000000000000000000000"; // wrong id for the contents
+
+    AppModelDb db;
+    ASSERT_EQ(BE_SQLITE_OK, db.OpenBeSQLiteDb(target.GetNameUtf8().c_str(), Db::OpenParams(Db::OpenMode::ReadWrite)));
+    EXPECT_EQ(BE_SQLITE_ERROR_InvalidChangeSetVersion, db.GetTxns().MergeChangeset(props));
+    EXPECT_EQ(0, CountRows(db, "Dgns")) << "a changeset with a bad id must not be applied";
+    db.CloseDb();
+    }
+
+//---------------------------------------------------------------------------------------
+// A conflicting change aborts the whole merge and rolls back; the target keeps its own data and its
+// parent changeset id does not advance.
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+------
+TEST(AppModelDb, MergeConflictAbortsAndRollsBack)
+    {
+    BeFileName seed = GetOutputFile(L"appmodeldb_conf_seed.db");
+    BeFileName source = GetOutputFile(L"appmodeldb_conf_src.db");
+    BeFileName target = GetOutputFile(L"appmodeldb_conf_tgt.db");
+    BeFileName changesetFile = GetOutputFile(L"appmodeldb_conf.changeset");
+
+    {
+    AppModelDb db;
+    ASSERT_EQ(BE_SQLITE_OK, db.CreateNewDb(seed.GetNameUtf8().c_str()));
+    db.SaveChanges();
+    db.CloseDb();
+    }
+    ASSERT_EQ(BeFileNameStatus::Success, BeFileName::BeCopyFile(seed, source));
+    ASSERT_EQ(BeFileNameStatus::Success, BeFileName::BeCopyFile(seed, target));
+
+    // Source inserts Dgns row with explicit ID=1 and produces a changeset.
+    ChangesetProps props;
+    {
+    AppModelDb db;
+    ASSERT_EQ(BE_SQLITE_OK, db.OpenBeSQLiteDb(source.GetNameUtf8().c_str(), Db::OpenParams(Db::OpenMode::ReadWrite)));
+    ASSERT_EQ(BE_SQLITE_OK, db.ExecuteSql("INSERT INTO Dgns(ID,Name,IsDgnLib) VALUES(1,'from-source',0)"));
+    db.SaveChanges();
+    ASSERT_EQ(BE_SQLITE_OK, db.GetTxns().BeginCreateChangeset(props, changesetFile));
+    ASSERT_EQ(BE_SQLITE_OK, db.GetTxns().EndCreateChangeset());
+    db.CloseDb();
+    }
+
+    // Target independently inserts a different row at the same primary key, then merging conflicts.
+    AppModelDb db;
+    ASSERT_EQ(BE_SQLITE_OK, db.OpenBeSQLiteDb(target.GetNameUtf8().c_str(), Db::OpenParams(Db::OpenMode::ReadWrite)));
+    ASSERT_EQ(BE_SQLITE_OK, db.ExecuteSql("INSERT INTO Dgns(ID,Name,IsDgnLib) VALUES(1,'from-target',0)"));
+    db.SaveChanges();
+
+    EXPECT_NE(BE_SQLITE_OK, db.GetTxns().MergeChangeset(props)) << "a primary-key conflict must abort the merge";
+    EXPECT_TRUE(db.GetTxns().GetParentChangesetId().empty()) << "an aborted merge must not advance the parent";
+
+    Statement stmt;
+    ASSERT_EQ(BE_SQLITE_OK, stmt.Prepare(db, "SELECT Name FROM Dgns WHERE ID=1"));
+    ASSERT_EQ(BE_SQLITE_ROW, stmt.Step());
+    EXPECT_STREQ("from-target", stmt.GetValueText(0)) << "the target's own data must be preserved after rollback";
+    db.CloseDb();
+    }
+

--- a/iModelCore/BeSQLite/Tests/NonPublished/BeSQLiteDb_Test.cpp
+++ b/iModelCore/BeSQLite/Tests/NonPublished/BeSQLiteDb_Test.cpp
@@ -4,6 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 #include "BeSQLiteNonPublishedTests.h"
 #include "BeSQLite/ChangeSet.h"
+#include "BeSQLite/ChangesetFile.h"
 #include <map>
 #include <vector>
 //---------------------------------------------------------------------------------------
@@ -2109,6 +2110,128 @@ TEST_F(BeSQLiteDbTests, ApplyTable_Filter) {
 
     anotherDb.SaveChanges();
     m_db.SaveChanges();
+}
+
+//---------------------------------------------------------------------------------------
+// Round-trips an AppModel changeset: create it from tracked changes on one db, apply it to
+// another, and verify that the "AppModelChangeset" header is rejected by an iModel-kind
+// reader and that re-applying (a conflict) aborts.
+// @bsimethod
+//---------------------------------------------------------------------------------------
+TEST_F(BeSQLiteDbTests, AppModelChangeset_CreateApplyAndKindIsolation) {
+    const auto kMainFile = "appmodel.db";
+    auto cloneDb = [&](DbR from, DbR out, Utf8CP name) {
+        ASSERT_EQ(BE_SQLITE_OK, from.SaveChanges());
+        Utf8String fileName = from.GetDbFileName();
+        fileName.ReplaceAll(kMainFile, name);
+        ASSERT_EQ(BeFileNameStatus::Success, BeFileName::BeCopyFile(BeFileName(from.GetDbFileName(), true), BeFileName(fileName.c_str(), true)));
+        ASSERT_EQ(BE_SQLITE_OK, out.OpenBeSQLiteDb(fileName.c_str(), Db::OpenParams(Db::OpenMode::ReadWrite)));
+    };
+
+    SetupDb(WString(kMainFile, true).c_str());
+    ASSERT_EQ(BE_SQLITE_OK, m_db.ExecuteSql("CREATE TABLE test1 (id INTEGER PRIMARY KEY, val TEXT)"));
+    m_db.SaveChanges();
+
+    Db targetDb;
+    cloneDb(m_db, targetDb, "appmodel_target.db");
+
+    // Track a couple of inserts on the source db.
+    MyChangeTracker tracker(m_db);
+    tracker.EnableTracking(true);
+    ASSERT_EQ(BE_SQLITE_OK, m_db.ExecuteSql("INSERT INTO test1(id,val) VALUES(1,'one')"));
+    ASSERT_EQ(BE_SQLITE_OK, m_db.ExecuteSql("INSERT INTO test1(id,val) VALUES(2,'two')"));
+    tracker.EnableTracking(false);
+
+    // Write them to an AppModel changeset file.
+    BeFileName csFile(m_db.GetDbFileName(), true);
+    csFile.ReplaceAll(L"appmodel.db", L"appmodel.changeset");
+    DdlChanges noDdl;
+    {
+        ChangesetFileWriter writer(csFile, false, noDdl, &m_db, LzmaEncoder::LzmaParams(), ChangesetKind::AppModel);
+        ASSERT_EQ(BE_SQLITE_OK, writer.Initialize());
+        ASSERT_EQ(BE_SQLITE_OK, writer.FromChangeTrack(tracker));
+    }
+    m_db.SaveChanges();
+    ASSERT_TRUE(csFile.DoesPathExist());
+
+    auto getRowCount = [](DbR db, Utf8CP table) -> int {
+        Statement stmt;
+        EXPECT_EQ(BE_SQLITE_OK, stmt.Prepare(db, SqlPrintfString("SELECT COUNT(*) FROM %s", table)));
+        EXPECT_EQ(BE_SQLITE_ROW, stmt.Step());
+        return stmt.GetValueInt(0);
+    };
+
+    // An iModel-kind reader must reject an AppModel changeset (wrong header marker).
+    {
+        ChangesetFileReaderBase imodelReader({csFile}, &targetDb, ChangesetKind::iModel);
+        bool hasSchema = false;
+        DdlChanges ddl;
+        EXPECT_EQ(BE_SQLITE_ERROR_InvalidChangeSetVersion, imodelReader.MakeReader()->GetSchemaChanges(hasSchema, ddl));
+    }
+
+    // Apply the AppModel changeset onto the target and verify the rows arrived.
+    ASSERT_EQ(0, getRowCount(targetDb, "test1"));
+    {
+        ChangesetFileReaderBase reader({csFile}, &targetDb, ChangesetKind::AppModel);
+        ASSERT_EQ(BE_SQLITE_OK, reader.ApplyChanges(targetDb, ApplyChangesArgs::Default().SetAbortOnAnyConflict(true)));
+    }
+    EXPECT_EQ(2, getRowCount(targetDb, "test1"));
+
+    // Re-applying the same changeset conflicts (rows already exist) and must not succeed.
+    {
+        ChangesetFileReaderBase reader({csFile}, &targetDb, ChangesetKind::AppModel);
+        EXPECT_NE(BE_SQLITE_OK, reader.ApplyChanges(targetDb, ApplyChangesArgs::Default().SetAbortOnAnyConflict(true)));
+    }
+    targetDb.AbandonChanges();
+
+    m_db.SaveChanges();
+    m_db.CloseDb();
+    targetDb.SaveChanges();
+    targetDb.CloseDb();
+}
+
+//---------------------------------------------------------------------------------------
+// Verifies iModel changesets remain byte-compatible: an iModel-kind changeset is still
+// readable by an iModel-kind reader and is rejected by an AppModel-kind reader.
+// @bsimethod
+//---------------------------------------------------------------------------------------
+TEST_F(BeSQLiteDbTests, AppModelChangeset_iModelBackwardsCompatible) {
+    const auto kMainFile = "imodelcs.db";
+    SetupDb(WString(kMainFile, true).c_str());
+    ASSERT_EQ(BE_SQLITE_OK, m_db.ExecuteSql("CREATE TABLE t (id INTEGER PRIMARY KEY)"));
+    m_db.SaveChanges();
+
+    MyChangeTracker tracker(m_db);
+    tracker.EnableTracking(true);
+    ASSERT_EQ(BE_SQLITE_OK, m_db.ExecuteSql("INSERT INTO t(id) VALUES(1)"));
+    tracker.EnableTracking(false);
+
+    BeFileName csFile(m_db.GetDbFileName(), true);
+    csFile.ReplaceAll(L"imodelcs.db", L"imodelcs.changeset");
+    DdlChanges noDdl;
+    {
+        // No ChangesetKind argument -> defaults to iModel (the pre-existing format).
+        ChangesetFileWriter writer(csFile, false, noDdl, &m_db);
+        ASSERT_EQ(BE_SQLITE_OK, writer.Initialize());
+        ASSERT_EQ(BE_SQLITE_OK, writer.FromChangeTrack(tracker));
+    }
+    m_db.SaveChanges();
+
+    // An iModel-kind reader accepts it.
+    {
+        ChangesetFileReaderBase reader({csFile}, &m_db, ChangesetKind::iModel);
+        bool hasSchema = false;
+        DdlChanges ddl;
+        EXPECT_EQ(BE_SQLITE_OK, reader.MakeReader()->GetSchemaChanges(hasSchema, ddl));
+    }
+    // An AppModel-kind reader rejects an iModel changeset.
+    {
+        ChangesetFileReaderBase reader({csFile}, &m_db, ChangesetKind::AppModel);
+        bool hasSchema = false;
+        DdlChanges ddl;
+        EXPECT_EQ(BE_SQLITE_ERROR_InvalidChangeSetVersion, reader.MakeReader()->GetSchemaChanges(hasSchema, ddl));
+    }
+    m_db.CloseDb();
 }
 //---------------------------------------------------------------------------------------
 // @bsimethod

--- a/iModelJsNodeAddon/IModelJsNative.cpp
+++ b/iModelJsNodeAddon/IModelJsNative.cpp
@@ -17,6 +17,7 @@
 #include "presentation/ECPresentationUtils.h"
 #include "presentation/UpdateRecordsHandler.h"
 #include <BeSQLite/Profiler.h>
+#include <BeSQLite/AppModelDb.h>
 #include <folly/BeFolly.h>
 #include "SchemaUtil.h"
 #include "JsLogger.h"
@@ -30,6 +31,9 @@ static BeMutex s_assertionMutex;
 static Utf8String s_mobileResourcesDir;
 static Utf8String s_mobileTempDir;
 static JsLogger s_jsLogger;
+
+// Alias for the native AppModel namespace so it doesn't collide with the IModelJsNative::AppModelDb peer.
+namespace AppModelNS = BeSQLite::AppModel;
 
 // DON'T change this flag directly. It is managed by BeObjectWrap only.
 bool s_BeObjectWrap_inDestructor = false;
@@ -832,6 +836,235 @@ public:
         });
 
         exports.Set("SQLiteDb", t);
+        SET_CONSTRUCTOR(t)
+    }
+};
+
+//=======================================================================================
+// Projects the BeSQLite::AppModel::AppModelDb class into JS.
+//
+// An AppModelDb is a SQLiteDb that carries the "AppModel" profile. Unlike the generic SQLiteDb,
+// it stamps a profile on create, creates the appmodel_txns table, and automatically records local
+// changes into that table on each saveChanges (when open read-write). Those recorded txns can be
+// combined into a self-describing AppModel *changeset* file (with a SHA1 id chained onto the db's
+// parent changeset) and merged into other AppModelDbs with full validation. This deliberately
+// bypasses the iModel changeset pipeline (TxnManager) and operates entirely within BeSQLite.
+//! @bsiclass
+//=======================================================================================
+struct AppModelDb : Napi::ObjectWrap<AppModelDb>, SQLiteOps<AppModelNS::AppModelDb> {
+private:
+    DEFINE_CONSTRUCTOR
+    AppModelNS::AppModelDb m_db;
+    AppModelNS::AppModelDb* _GetMyDb() override { return &m_db; }
+
+public:
+    AppModelDb(NapiInfoCR info) : Napi::ObjectWrap<AppModelDb>(info) {}
+    ~AppModelDb() { CloseDbIfOpen(true); }
+    AppModelNS::AppModelDb& GetDb() { return m_db; }
+
+    static bool InstanceOf(Napi::Value val) {
+        if (!val.IsObject())
+            return false;
+        Napi::HandleScope scope(val.Env());
+        return val.As<Napi::Object>().InstanceOf(Constructor().Value());
+    }
+
+    void useOpenParams(Db::OpenParams& params, BeJsValue args) {
+        if (args[JSON_NAME(openMode)].isNumeric())
+            params.m_openMode = (Db::OpenMode)args[JSON_NAME(openMode)].asInt();
+        params.m_skipFileCheck = args["skipFileCheck"].asBool();
+        if (args["immutable"].asBool())
+            params.SetImmutable();
+        if (args[JSON_NAME(defaultTxn)].isNumeric())
+            params.m_startDefaultTxn = (DefaultTxn)args[JSON_NAME(defaultTxn)].asInt();
+        if (args[JSON_NAME(queryParam)].isString())
+            params.AddQueryParam(args[JSON_NAME(queryParam)].asCString());
+    }
+
+    void CreateDb(NapiInfoCR info) {
+        REQUIRE_ARGUMENT_STRING(0, dbName);
+        Db::CreateParams params;
+        addContainerParams(Value(), dbName, params, info[1]);
+
+        if (info[2].IsObject()) {
+            auto args = BeJsValue(info[2]);
+            useOpenParams(params, args);
+            if (args[JSON_NAME(pageSize)].isNumeric())
+                params.m_pagesize = (Db::PageSize) args[JSON_NAME(pageSize)].asInt();
+        }
+
+        auto stat = m_db.CreateNewDb(dbName.c_str(), params);
+        if (stat != BE_SQLITE_OK)
+            JsInterop::throwSqlResult("cannot create AppModel database", dbName.c_str(), stat);
+    }
+
+    void OpenDb(NapiInfoCR info) {
+        REQUIRE_ARGUMENT_STRING(0, dbName);
+        Db::OpenParams params(Db::OpenMode::Readonly);
+        if (info[1].IsObject()) {
+            useOpenParams(params, info[1]);
+        } else {
+            REQUIRE_ARGUMENT_INTEGER(1, openMode);
+            params.m_openMode = (Db::OpenMode) openMode;
+        }
+
+        addContainerParams(Value(), dbName, params, info[2]);
+
+        auto stat = m_db.OpenBeSQLiteDb(dbName.c_str(), params);
+        if (stat != BE_SQLITE_OK)
+            JsInterop::throwSqlResult("cannot open AppModel database", dbName.c_str(), stat);
+    }
+
+    void CloseDbIfOpen(bool fromDestructor) {
+        if (m_db.IsDbOpen()) {
+            m_db.AbandonChanges();
+            m_db.CloseDb();
+            if (!fromDestructor)
+                Value().Set(JSON_NAME(cloudContainer), Env().Undefined());
+        }
+    }
+
+    void CloseDb(NapiInfoCR info) { CloseDbIfOpen(false); }
+    void Dispose(NapiInfoCR info) { CloseDbIfOpen(false); }
+
+    // saveChanges([description]). The optional description is stored as the txn's description in the
+    // appmodel_txns table (see AppModel::Txns::_OnCommit).
+    void SaveChanges(NapiInfoCR info) {
+        auto& db = GetOpenedDb(info);
+        OPTIONAL_ARGUMENT_STRING(0, description);
+        DbResult status = db.SaveChanges(description.empty() ? nullptr : description.c_str());
+        if (status != BE_SQLITE_OK)
+            JsInterop::throwSqlResult("error in saveChanges", db.GetDbFileName(), status);
+    }
+
+    void AbandonChanges(NapiInfoCR info) {
+        auto& db = GetOpenedDb(info);
+        DbResult status = db.AbandonChanges();
+        if (status != BE_SQLITE_OK)
+            JsInterop::throwSqlResult("error in abandonChanges", db.GetDbFileName(), status);
+    }
+
+    // Build a JS object describing an AppModel changeset from its native ChangesetProps.
+    Napi::Object toChangesetPropsObject(AppModelNS::ChangesetProps const& props) {
+        auto ret = Napi::Object::New(Env());
+        ret.Set("id", Napi::String::New(Env(), props.GetChangesetId().c_str()));
+        ret.Set("parentId", Napi::String::New(Env(), props.GetParentId().c_str()));
+        ret.Set("dbGuid", Napi::String::New(Env(), props.GetDbGuid().c_str()));
+        ret.Set("changesetType", Napi::Number::New(Env(), (int) props.GetChangesetType()));
+        ret.Set("fileName", Napi::String::New(Env(), props.GetFileName().GetNameUtf8().c_str()));
+        return ret;
+    }
+
+    // beginCreateChangeset(changesetFileName) -> AppModelChangesetProps
+    // Combine all recorded txns into a single changeset file and return its properties. Does not yet delete the
+    // captured txns or advance the changeset id; call endCreateChangeset once the file is safely persisted.
+    Napi::Value BeginCreateChangeset(NapiInfoCR info) {
+        auto& db = GetWritableDb(info);
+        REQUIRE_ARGUMENT_STRING(0, changesetFileName);
+
+        BeFileName fileName(changesetFileName.c_str(), true);
+        AppModelNS::ChangesetProps props;
+        DbResult stat = db.GetTxns().BeginCreateChangeset(props, fileName);
+        if (BE_SQLITE_OK != stat)
+            JsInterop::throwSqlResult("error creating AppModel changeset", changesetFileName.c_str(), stat);
+
+        return toChangesetPropsObject(props);
+    }
+
+    // endCreateChangeset() - finalize the changeset started by beginCreateChangeset: delete the captured txns and
+    // advance this db's current changeset id.
+    void EndCreateChangeset(NapiInfoCR info) {
+        auto& db = GetWritableDb(info);
+        DbResult stat = db.GetTxns().EndCreateChangeset();
+        if (BE_SQLITE_OK != stat)
+            JsInterop::throwSqlResult("error finalizing AppModel changeset", db.GetDbFileName(), stat);
+    }
+
+    // applyChangeset(props) - validate (db guid, parent chain, SHA1 id) then merge the changeset into
+    // this db, advancing this db's parent changeset id. Any conflict aborts and rolls back.
+    void ApplyChangeset(NapiInfoCR info) {
+        auto& db = GetWritableDb(info);
+        REQUIRE_ARGUMENT_ANY_OBJ(0, propsObj);
+        BeJsValue props(propsObj);
+        if (!props["fileName"].isString())
+            THROW_JS_IMODEL_NATIVE_EXCEPTION(info.Env(), "changeset props must include a fileName", IModelJsNativeErrorKey::BadArg);
+
+        BeFileName fileName(props["fileName"].asCString(), true);
+        AppModelNS::ChangesetType changesetType = props["changesetType"].isNumeric() ?
+            (AppModelNS::ChangesetType) props["changesetType"].asInt() : AppModelNS::ChangesetType::Regular;
+        AppModelNS::ChangesetProps changesetProps(
+            props["id"].asString(), props["parentId"].asString(), props["dbGuid"].asString(), fileName, changesetType);
+
+        DbResult stat = db.GetTxns().MergeChangeset(changesetProps);
+        switch (stat) {
+            case BE_SQLITE_OK:
+                return;
+            case BE_SQLITE_MISMATCH:
+                THROW_JS_IMODEL_NATIVE_EXCEPTION(info.Env(), "AppModel changeset did not originate from this db or does not chain onto its current changeset", IModelJsNativeErrorKey::ChangesetError);
+            case BE_SQLITE_ERROR_InvalidChangeSetVersion:
+                THROW_JS_IMODEL_NATIVE_EXCEPTION(info.Env(), "AppModel changeset has an incorrect id for its contents", IModelJsNativeErrorKey::ChangesetError);
+            default:
+                JsInterop::throwSqlResult("error applying AppModel changeset", fileName.GetNameUtf8().c_str(), stat);
+        }
+    }
+
+    // getParentChangesetId() -> string ("" if no changeset has been created/merged yet).
+    Napi::Value GetParentChangesetId(NapiInfoCR info) {
+        auto& db = GetOpenedDb(info);
+        return Napi::String::New(Env(), db.GetTxns().GetParentChangesetId().c_str());
+    }
+
+    // hasPendingTxns() -> boolean. True when local changes have been recorded but not yet serialized.
+    Napi::Value HasPendingTxns(NapiInfoCR info) {
+        auto& db = GetOpenedDb(info);
+        return Napi::Boolean::New(Env(), db.GetTxns().HasPendingTxns());
+    }
+
+    // setTxnProps(propsJson) - stage a JSON properties string to store on the next committed txn.
+    void SetTxnProps(NapiInfoCR info) {
+        auto& db = GetWritableDb(info);
+        OPTIONAL_ARGUMENT_STRING(0, propsJson);
+        db.GetTxns().SetTxnProps(propsJson.empty() ? nullptr : propsJson.c_str());
+    }
+
+    static void Init(Napi::Env env, Napi::Object exports) {
+        Napi::HandleScope scope(env);
+        Napi::Function t = DefineClass(env, "AppModelDb", {
+            InstanceMethod("abandonChanges", &AppModelDb::AbandonChanges),
+            InstanceMethod("applyChangeset", &AppModelDb::ApplyChangeset),
+            InstanceMethod("beginCreateChangeset", &AppModelDb::BeginCreateChangeset),
+            InstanceMethod("closeDb", &AppModelDb::CloseDb),
+            InstanceMethod("createDb", &AppModelDb::CreateDb),
+            InstanceMethod("dispose", &AppModelDb::Dispose),
+            InstanceMethod("embedFile", &AppModelDb::EmbedFile),
+            InstanceMethod("embedFontFile", &AppModelDb::EmbedFontFile),
+            InstanceMethod("endCreateChangeset", &AppModelDb::EndCreateChangeset),
+            InstanceMethod("extractEmbeddedFile", &AppModelDb::ExtractEmbeddedFile),
+            InstanceMethod("getFilePath", &AppModelDb::GetFilePath),
+            InstanceMethod("getLastInsertRowId", &AppModelDb::GetLastInsertRowId),
+            InstanceMethod("getLastError", &AppModelDb::GetLastError),
+            InstanceMethod("getParentChangesetId", &AppModelDb::GetParentChangesetId),
+            InstanceMethod("hasPendingTxns", &AppModelDb::HasPendingTxns),
+            InstanceMethod("isOpen", &AppModelDb::IsOpen),
+            InstanceMethod("isReadonly", &AppModelDb::IsReadonly),
+            InstanceMethod("openDb", &AppModelDb::OpenDb),
+            InstanceMethod("queryEmbeddedFile", &AppModelDb::QueryEmbeddedFile),
+            InstanceMethod("queryFileProperty", &AppModelDb::QueryFileProperty),
+            InstanceMethod("queryNextAvailableFileProperty", &AppModelDb::QueryNextAvailableFileProperty),
+            InstanceMethod("removeEmbeddedFile", &AppModelDb::RemoveEmbeddedFile),
+            InstanceMethod("replaceEmbeddedFile", &AppModelDb::ReplaceEmbeddedFile),
+            InstanceMethod("restartDefaultTxn", &AppModelDb::RestartDefaultTxn),
+            InstanceMethod("saveChanges", &AppModelDb::SaveChanges),
+            InstanceMethod("saveFileProperty", &AppModelDb::SaveFileProperty),
+            InstanceMethod("setTxnProps", &AppModelDb::SetTxnProps),
+            InstanceMethod("vacuum", &AppModelDb::Vacuum),
+            InstanceMethod("analyze", &AppModelDb::Analyze),
+            InstanceMethod("enableWalMode", &AppModelDb::EnableWalMode),
+            InstanceMethod("performCheckpoint", &AppModelDb::PerformCheckpoint),
+            InstanceMethod("setAutoCheckpointThreshold", &AppModelDb::SetAutoCheckpointThreshold),
+        });
+
+        exports.Set("AppModelDb", t);
         SET_CONSTRUCTOR(t)
     }
 };
@@ -5763,6 +5996,8 @@ public:
             db = &NativeECDb::Unwrap(dbObj)->GetECDb();
         } else if (SQLiteDb::InstanceOf(dbObj)) {
             db = &SQLiteDb::Unwrap(dbObj)->GetDb();
+        } else if (AppModelDb::InstanceOf(dbObj)) {
+            db = &AppModelDb::Unwrap(dbObj)->GetDb();
         } else {
             THROW_JS_DGN_DB_EXCEPTION(info.Env(), "requires an open database", DgnDbStatus::NotOpen);
         }
@@ -5893,6 +6128,9 @@ public:
         } else if (SQLiteDb::InstanceOf(dbObj)) {
             if (auto sqliteDb = SQLiteDb::Unwrap(dbObj); sqliteDb)
                 db = &sqliteDb->GetDb();
+        } else if (AppModelDb::InstanceOf(dbObj)) {
+            if (auto appModelDb = AppModelDb::Unwrap(dbObj); appModelDb)
+                db = &appModelDb->GetDb();
         } else if (NativeECDb::InstanceOf(dbObj)) {
             if (auto ecdb = NativeECDb::Unwrap(dbObj); ecdb)
                 db = &ecdb->GetECDb();
@@ -7826,6 +8064,7 @@ static Napi::Object registerModule(Napi::Env env, Napi::Object exports) {
     JsInterop::Initialize(addondir, env, tempdir);
 
     SQLiteDb::Init(env, exports);
+    AppModelDb::Init(env, exports);
     NativeBlobIo::Init(env, exports);
     NativeDgnDb::Init(env, exports);
     NativeGeoServices::Init(env, exports);

--- a/iModelJsNodeAddon/api_package/ts/src/NativeLibrary.ts
+++ b/iModelJsNodeAddon/api_package/ts/src/NativeLibrary.ts
@@ -1083,6 +1083,62 @@ export declare namespace IModelJsNative {
     public setAutoCheckpointThreshold(frames: number): void;
   }
 
+  /** The kind of change carried by an AppModel changeset file. */
+  const enum AppModelChangesetType {
+    /** Contains data changes only. */
+    Regular = 0,
+    /** Contains schema (DDL) changes, possibly along with data changes. */
+    Schema = 1,
+  }
+
+  /** Properties that describe an AppModel changeset file produced by [[AppModelDb.beginCreateChangeset]]. */
+  interface AppModelChangesetProps {
+    /** The SHA1 id of this changeset, computed from its parent id and its file contents. */
+    id: string;
+    /** The id of the parent changeset this changeset chains onto ("" for the first changeset). */
+    parentId: string;
+    /** The guid of the AppModelDb this changeset originated from. */
+    dbGuid: string;
+    /** Whether this changeset carries schema (DDL) changes or data-only changes. */
+    changesetType: AppModelChangesetType;
+    /** The full path of the changeset file. */
+    fileName: string;
+  }
+
+  /**
+   * A [[SQLiteDb]] that carries the "AppModel" profile. It automatically records local changes into an
+   * internal txns table on each [[saveChanges]] (when open read-write) and can combine them into self-describing
+   * AppModel *changeset* files (SHA1-identified and chained onto a parent) that can be validated and merged
+   * into other AppModelDbs. This is independent of the iModel changeset pipeline.
+   */
+  class AppModelDb extends SQLiteDb {
+    /** saveChanges, optionally recording a description on the resulting txn. */
+    public saveChanges(description?: string): void;
+    /** Begin creating an AppModel changeset: combine all recorded txns into a single changeset file and return its
+     * properties. Does not yet delete the captured txns or advance the changeset id - call [[endCreateChangeset]]
+     * once the file has been safely persisted to finalize.
+     * @throws if there are no recorded changes or the file could not be written.
+     */
+    public beginCreateChangeset(changesetFileName: string): AppModelChangesetProps;
+    /** Finalize the changeset started by [[beginCreateChangeset]]: delete the captured txns and advance this db's
+     * current changeset id.
+     * @throws if there is no changeset creation in progress.
+     */
+    public endCreateChangeset(): void;
+    /** Validate and merge an AppModel changeset into this db, advancing this db's parent changeset id.
+     * DDL and data changes are applied atomically; any conflict aborts and rolls back the whole changeset.
+     * @throws if the changeset did not originate from this db, does not chain onto its current changeset,
+     * has an incorrect id, or conflicts with existing data.
+     */
+    public applyChangeset(props: AppModelChangesetProps): void;
+    /** The id of this db's current changeset ("" if none has been created/merged yet). */
+    public getParentChangesetId(): string;
+    /** True when local changes have been recorded but not yet serialized into a changeset. */
+    public hasPendingTxns(): boolean;
+    /** Stage a JSON properties string to store on the next committed txn. */
+    public setTxnProps(propsJson: string): void;
+  }
+
   class SqliteStatement implements IDisposable {
     constructor();
     public bindBlob(param: number | string, val: Uint8Array | ArrayBuffer | SharedArrayBuffer): DbResult;


### PR DESCRIPTION
## Branch summary

One commit (`55493e74d1`, +2295 lines) adds a brand-new **AppModelDb** database type plus its own changeset pipeline, all self-contained in **BeSQLite** and projected to JS.

### Where it sits: the BeSQLite::Db profile hierarchy

Every Bentley database is a `BeSQLite::Db` carrying the base BeSQLite profile. Higher layers *stack their own profile* on top by overriding the same virtual hooks — `_OnDbCreated`, `_OnDbOpened`, `_CheckProfileVersion`, `_UpgradeProfile`. `ECDb` does this (EC profile), `DgnDb` extends `ECDb` (BisCore/Dgn profile), and this branch adds **`AppModelDb` as a *sibling* of `ECDb`** — a peer layer, not part of the iTwin.js/iModel stack.

```mermaid
classDiagram
    class Db {
        <<BeSQLite base profile>>
        #_OnDbCreated()
        #_OnDbOpened()
        #_CheckProfileVersion()
        #_UpgradeProfile()
    }
    class ECDb {
        <<EC profile>>
    }
    class DgnDb {
        <<BisCore / Dgn profile>>
    }
    class AppModelDb {
        <<AppModel profile — NEW>>
        +GetTxns()
        +QueryProfileVersion()
    }

    Db <|-- ECDb : iTwin.js path
    ECDb <|-- DgnDb : RefCounted~ECDb~
    Db <|-- AppModelDb : NEW, independent path

    class ChangeTracker
    class Txns {
        <<AppModel — NEW>>
        +BeginCreateChangeset()
        +EndCreateChangeset()
        +MergeChangeset()
    }
    ChangeTracker <|-- Txns
    AppModelDb "1" --> "1" Txns : owns tracker

    note for AppModelDb "Sibling of ECDb.\nDepends ONLY on base BeSQLite Db.\nNot tied to iTwinjs platform."
```

### Purpose

`AppModelDb` is the storage for **multi-user collaboration on a project** (the "Norse" project context). Each user has a briefcase-like AppModelDb; edits are captured as **AppModel changesets** that are validated and merged into peers' dbs. It deliberately **bypasses the iModel/`TxnManager` pipeline** and has no direct dependency on the iTwin.js platform (ecobjects/ECDb/iModelPlatform) — it needs only base `Db`. Its schema models DGN concepts (`Dgns`, `Models`, `Elements`, streams, references, embedded schemas, raster images).

### Key pieces added

**1. Profile + migration support** (`AppModelDb.cpp`, mirrors ECDb's `BeSQLiteProfileManager`)
- `ProfileManager` stamps version `1.0.0.0` into `be_Prop` (`appmodel_Db` namespace), stores both current and *initial* version, and creates all tables on `_OnDbCreated`.
- `_CheckProfileVersion` rejects a plain BeSQLite file lacking the AppModel profile (intentionally *not* using `ProfileState::Merge`).
- `_UpgradeProfile` runs an ordered `ProfileMigrator` sequence in-situ. No migrators exist yet (v1 initial), but the extension point (`GetMigratorSequence`) and additive-DDL contract are scaffolded.

**2. Changeset tracking** (`Txns : ChangeTracker`)
- On each `SaveChanges` (read-write only), captures DDL + data changes into one row of `appmodel_txns` (Snappy-compressed blob). `_FilterTable` excludes `be_Local` and the txns table itself. Optional per-txn JSON props/description.

**3. Changeset creation & merge** (SHA1-chained, like iModel changesets)
- `BeginCreateChangeset` squashes all txns into one file → `EndCreateChangeset` deletes captured txns and advances the parent id (two-phase for safe persistence).
- `MergeChangeset` validates db-guid + parent chain + recomputed SHA1 id, applies DDL then data atomically, aborts/rolls back on any conflict.
- Parent changeset id stored in `be_Local` (`appmodel_ParentChangesetId`).

**4. Special changeset header** (`ChangesetFile.cpp/.h`)
- New `ChangesetKind` enum and `AppModelChangesetHeader` with a distinct marker `"AppModelChangeset"` (vs iModel's `"ChangeSetLzma"`). Same LZMA body, but the header is deliberately separate so the two kinds **can't be cross-applied** — and the immutable iModel header stays backwards-compatible. A test asserts this isolation.

**5. N-API + TS bindings** (`IModelJsNative.cpp`, `NativeLibrary.ts`)
- `IModelJsNative.AppModelDb extends SQLiteDb` with `beginCreateChangeset`/`endCreateChangeset`/`applyChangeset`/`getParentChangesetId`/`hasPendingTxns`/`setTxnProps`, plus `AppModelChangesetProps` and `AppModelChangesetType`.

**6. Tests** — 16 `AppModelDb_Test.cpp` cases (profile stamping, reopen/upgrade, txn recording, create/merge, guid/parent/tampered-id rejection, conflict rollback) + `BeSQLiteDb_Test.cpp` cases proving iModel/AppModel changeset kind isolation and iModel backwards-compatibility.
