### PR TITLE
Update skill to add libsrc/README.md version bump

### DIFF
--- a/.github/skills/update-third-party-lib/SKILL.md
+++ b/.github/skills/update-third-party-lib/SKILL.md
@@ -98,13 +98,18 @@ git commit  # or let the merge auto-commit if clean
 
 `iModelCore/libsrc/README.md` contains a table listing every third-party library and its version. Update the `Version` cell for the library you're updating to the new version. This is a Bentley file, so like every other Bentley change it is authored on `libsrc-Main` (not `libsrc-Vendor`); it will reach `main` via the PR branch merge in step 5.
 
-```
-| Directory | Library | Version | vcpkg? |
-|-----------|---------|---------|--------|
-| `compress/snappy` | Google Snappy | 1.2.2 | No |
-```
+     | Directory | Library | Version | vcpkg? |
+     |-----------|---------|---------|--------|
+     | `compress/snappy` | Google Snappy | 1.2.2 | No |
 
 Match the existing version format for that row (some entries include extra detail like a sub-library version, revision number, or SONAME).
+
+Commit the change on `libsrc-Main` so it's included in the step 5 merge (a merge only picks up committed content):
+
+```bash
+git add iModelCore/libsrc/README.md
+git commit -m "Update <library> version in libsrc/README.md"
+```
 
 ### 5. Create PR branch and merge libsrc-Main
 

--- a/.github/skills/update-third-party-lib/SKILL.md
+++ b/.github/skills/update-third-party-lib/SKILL.md
@@ -94,6 +94,18 @@ git add .
 git commit  # or let the merge auto-commit if clean
 ```
 
+### 4a. Update the version in libsrc/README.md
+
+`iModelCore/libsrc/README.md` contains a table listing every third-party library and its version. Update the `Version` cell for the library you're updating to the new version. This is a Bentley file, so like every other Bentley change it is authored on `libsrc-Main` (not `libsrc-Vendor`); it will reach `main` via the PR branch merge in step 5.
+
+```
+| Directory | Library | Version | vcpkg? |
+|-----------|---------|---------|--------|
+| `compress/snappy` | Google Snappy | 1.2.2 | No |
+```
+
+Match the existing version format for that row (some entries include extra detail like a sub-library version, revision number, or SONAME).
+
 ### 5. Create PR branch and merge libsrc-Main
 
 ```bash
@@ -130,3 +142,5 @@ Snappy had never been on `libsrc-Vendor` before (it was committed directly to ma
 1. **Vendor files** (on `libsrc-Vendor`): `snappy.cpp`, `snappy-internal.h`, `snappy-stubs-internal.h`, `snappy-sinksource.cpp`, `snappy-stubs-internal.cpp`, `snappy-notice.txt` - all raw from upstream, `.cc` renamed to `.cpp`
 2. **Bentley files** (on PR branch / main only): `config.h` (hand-written replacement for CMake config), `snappy.mke` (Bentley build), 3-line `#include` append at end of `snappy.cpp` to fold compilation units for bmake
 3. Conflicts were add/add (new to vendor branch), resolved by taking `--theirs` (vendor version)
+
+(Note: `iModelCore/libsrc/README.md` did not exist at the time of this snappy update, so there was no version-table bump for it. For any update today, remember to update that table per step 4a.)


### PR DESCRIPTION
This pull request updates the documentation for updating third-party libraries, specifically clarifying the process for updating version information and handling historical cases. The most important changes are:

**Documentation improvements:**

* Added a new step (4a) instructing maintainers to update the version table in `iModelCore/libsrc/README.md` when updating a third-party library, including details on where and how to make the change.
* Clarified that the version table in `iModelCore/libsrc/README.md` did not exist at the time of the initial Snappy update and emphasized the need to update it for future changes.