### PR TITLE
Detect diverged inherited property mappings during schema import validation

### DIFF
--- a/iModelCore/ECDb/ECDb/ClassMapColumnFactory.cpp
+++ b/iModelCore/ECDb/ECDb/ClassMapColumnFactory.cpp
@@ -676,7 +676,12 @@ bool ClassMapColumnFactory::IsCompatible(DbColumn const& avaliableColumn, DbColu
     {
     if (DbColumn::IsCompatible(avaliableColumn.GetType(), type))
         {
+        // Shared columns never carry NOT NULL/UNIQUE/collation constraints: AllocateSharedColumn drops
+        // requested constraints with a warning. Comparing constraints here would wrongly refuse to reuse
+        // the column the base class mapped the property to (e.g. when the property requests IsNullable=False),
+        // making the derived class allocate a different column and diverge from the base class's mapping.
         if (m_primaryOrJoinedTable->GetType() == DbTable::Type::Existing
+            || avaliableColumn.IsShared()
             || (avaliableColumn.GetConstraints().HasNotNullConstraint() == params.AddNotNullConstraint() &&
                 avaliableColumn.GetConstraints().HasUniqueConstraint() == params.AddUniqueConstraint() &&
                 avaliableColumn.GetConstraints().GetCollation() == params.GetCollation()))

--- a/iModelCore/ECDb/ECDb/DbMapValidator.cpp
+++ b/iModelCore/ECDb/ECDb/DbMapValidator.cpp
@@ -189,6 +189,67 @@ BentleyStatus DbMapValidator::CheckDuplicateDataPropertyMap() const {
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //+---------------+---------------+---------------+---------------+---------------+------
+BentleyStatus DbMapValidator::CheckInheritedPropertyMapConsistency() const {
+    // A class and any of its base classes must map a given property (identified by its property path)
+    // to the same column, as long as both classes store their data in the same table tree
+    // (the primary/joined/overflow tables of one hierarchy). A violation means the class maps have
+    // diverged: reading the property through one class accesses a different column than reading it
+    // through the other, which surfaces as silent data loss or corruption.
+    // System properties (root property owned by the ECDbSystem schema) are exempt because classes in
+    // a joined table hierarchy legitimately map ECInstanceId/ECClassId to a different column per table.
+    Statement stmt;
+    auto rc = stmt.Prepare(m_schemaImportContext.GetECDb(), R"(
+        WITH RECURSIVE [tableRoot]([id], [rootId]) AS (
+            SELECT [Id], [Id] FROM [ec_Table] WHERE [ParentTableId] IS NULL
+            UNION ALL
+            SELECT [t].[Id], [r].[rootId] FROM [ec_Table] [t] JOIN [tableRoot] [r] ON [t].[ParentTableId] = [r].[id])
+        SELECT DISTINCT [derivedPm].[ClassId], [basePm].[ClassId], [pp].[AccessString],
+                [derivedTable].[Name] || '.' || [derivedCol].[Name],
+                [baseTable].[Name] || '.' || [baseCol].[Name]
+            FROM [ec_PropertyMap] [derivedPm]
+                JOIN [ec_cache_ClassHierarchy] [ch] ON [ch].[ClassId] = [derivedPm].[ClassId] AND [ch].[BaseClassId] <> [derivedPm].[ClassId]
+                JOIN [ec_PropertyMap] [basePm] ON [basePm].[ClassId] = [ch].[BaseClassId] AND [basePm].[PropertyPathId] = [derivedPm].[PropertyPathId] AND [basePm].[ColumnId] <> [derivedPm].[ColumnId]
+                JOIN [ec_PropertyPath] [pp] ON [pp].[Id] = [derivedPm].[PropertyPathId]
+                JOIN [ec_Property] [rootProp] ON [rootProp].[Id] = [pp].[RootPropertyId]
+                JOIN [ec_Class] [rootClass] ON [rootClass].[Id] = [rootProp].[ClassId]
+                JOIN [ec_Schema] [rootSchema] ON [rootSchema].[Id] = [rootClass].[SchemaId]
+                JOIN [ec_Column] [derivedCol] ON [derivedCol].[Id] = [derivedPm].[ColumnId]
+                JOIN [ec_Column] [baseCol] ON [baseCol].[Id] = [basePm].[ColumnId]
+                JOIN [ec_Table] [derivedTable] ON [derivedTable].[Id] = [derivedCol].[TableId]
+                JOIN [ec_Table] [baseTable] ON [baseTable].[Id] = [baseCol].[TableId]
+                JOIN [tableRoot] [derivedRoot] ON [derivedRoot].[id] = [derivedCol].[TableId]
+                JOIN [tableRoot] [baseRoot] ON [baseRoot].[id] = [baseCol].[TableId] AND [baseRoot].[rootId] = [derivedRoot].[rootId]
+            WHERE [rootSchema].[Name] <> 'ECDbSystem';)");
+
+    if (rc != BE_SQLITE_OK) {
+        Issues().Report(IssueSeverity::Error, IssueCategory::BusinessProperties, IssueType::ECDbIssue, ECDbIssueId::ECDb_0744, "Failed to run inherited property map consistency check");
+        return ERROR;
+    }
+
+    int errors = 0;
+    while (stmt.Step() == BE_SQLITE_ROW) {
+        const ECClassId derivedClassId = stmt.GetValueId<ECClassId>(0);
+        const ECClassId baseClassId = stmt.GetValueId<ECClassId>(1);
+        const Utf8String accessString = stmt.GetValueText(2);
+        const Utf8String derivedColumn = stmt.GetValueText(3);
+        const Utf8String baseColumn = stmt.GetValueText(4);
+        ECClassCP derivedClass = GetECDb().Schemas().GetClass(derivedClassId);
+        ECClassCP baseClass = GetECDb().Schemas().GetClass(baseClassId);
+        Issues().ReportV(IssueSeverity::Error, IssueCategory::BusinessProperties, IssueType::ECDbIssue, ECDbIssueId::ECDb_0744,
+            "Detected inconsistent property mapping: ECClass '%s' maps property '%s' to column '%s', but its base ECClass '%s' maps the same property to column '%s'.",
+            derivedClass != nullptr ? derivedClass->GetFullName() : derivedClassId.ToString().c_str(),
+            accessString.c_str(), derivedColumn.c_str(),
+            baseClass != nullptr ? baseClass->GetFullName() : baseClassId.ToString().c_str(),
+            baseColumn.c_str());
+        ++errors;
+    }
+
+    return errors > 0 ? ERROR : SUCCESS;
+}
+
+//---------------------------------------------------------------------------------------
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+------
 BentleyStatus DbMapValidator::Validate() const
     {
     ECDB_PERF_LOG_SCOPE("Schema import> Validate mappings");
@@ -202,6 +263,9 @@ BentleyStatus DbMapValidator::Validate() const
         return ERROR;
 
     if (SUCCESS != CheckDuplicateDataPropertyMap())
+        return ERROR;
+
+    if (SUCCESS != CheckInheritedPropertyMapConsistency())
         return ERROR;
 
     if (SUCCESS != ValidateCustomAttributeTable())

--- a/iModelCore/ECDb/ECDb/DbMapValidator.cpp
+++ b/iModelCore/ECDb/ECDb/DbMapValidator.cpp
@@ -227,7 +227,8 @@ BentleyStatus DbMapValidator::CheckInheritedPropertyMapConsistency() const {
     }
 
     int errors = 0;
-    while (stmt.Step() == BE_SQLITE_ROW) {
+    DbResult stepResult;
+    while ((stepResult = stmt.Step()) == BE_SQLITE_ROW) {
         const ECClassId derivedClassId = stmt.GetValueId<ECClassId>(0);
         const ECClassId baseClassId = stmt.GetValueId<ECClassId>(1);
         const Utf8String accessString = stmt.GetValueText(2);
@@ -242,6 +243,12 @@ BentleyStatus DbMapValidator::CheckInheritedPropertyMapConsistency() const {
             baseClass != nullptr ? baseClass->GetFullName() : baseClassId.ToString().c_str(),
             baseColumn.c_str());
         ++errors;
+    }
+
+    if (stepResult != BE_SQLITE_DONE) {
+        Issues().ReportV(IssueSeverity::Error, IssueCategory::BusinessProperties, IssueType::ECDbIssue, ECDbIssueId::ECDb_0744,
+            "Failed to run inherited property map consistency check: stepping the query failed with %s.", Db::InterpretDbResult(stepResult));
+        return ERROR;
     }
 
     return errors > 0 ? ERROR : SUCCESS;

--- a/iModelCore/ECDb/ECDb/DbMapValidator.h
+++ b/iModelCore/ECDb/ECDb/DbMapValidator.h
@@ -43,6 +43,7 @@ struct DbMapValidator final
         BentleyStatus ValidateNavigationPropertyMapUniqueness(NavigationPropertyMap const&, DbColumn const& idCol, DbColumn const& relClassIdCol, bool isPhysicalFk) const;
         BentleyStatus ValidateOverflowPropertyMaps(ClassMap const& classMap) const;
         BentleyStatus CheckDuplicateDataPropertyMap() const;
+        BentleyStatus CheckInheritedPropertyMapConsistency() const;
         ECDbCR GetECDb() const { return m_schemaImportContext.GetECDb(); }
         MainSchemaManager const& GetSchemaManager() const { return m_schemaImportContext.GetSchemaManager(); }
         DbSchema const& GetDbSchema() const { return GetSchemaManager().GetDbSchema(); }

--- a/iModelCore/ECDb/ECDb/IssueReporter.cpp
+++ b/iModelCore/ECDb/ECDb/IssueReporter.cpp
@@ -738,6 +738,7 @@ IssueId ECDbIssueId::ECDb_0738 = IssueId("ECDb_0738");
 IssueId ECDbIssueId::ECDb_0739 = IssueId("ECDb_0739");
 IssueId ECDbIssueId::ECDb_0740 = IssueId("ECDb_0740");
 IssueId ECDbIssueId::ECDb_0741 = IssueId("ECDb_0741");
+IssueId ECDbIssueId::ECDb_0744 = IssueId("ECDb_0744");
 
 //---------------------------------------------------------------------------------------
 // @bsimethod

--- a/iModelCore/ECDb/ECDb/IssueReporter.h
+++ b/iModelCore/ECDb/ECDb/IssueReporter.h
@@ -759,6 +759,7 @@ struct ECDB_EXPORT ECDbIssueId
     static ECN::IssueId ECDb_0739;  // this issue id is being used to report instance query related ambiguity
     static ECN::IssueId ECDb_0740;
     static ECN::IssueId ECDb_0741;
+    static ECN::IssueId ECDb_0744; // 0742/0743 are claimed by an in-flight change
     };
 
 //---------------------------------------------------------------------------------------

--- a/iModelCore/ECDb/Tests/NonPublished/SchemaSyncTest.cpp
+++ b/iModelCore/ECDb/Tests/NonPublished/SchemaSyncTest.cpp
@@ -22626,8 +22626,8 @@ TEST_F(SchemaSyncTestFixture, DisallowMajorSchemaUpgrade)
                 </ECSchema>)xml";
 
             const auto SCHEMA_HASH_ECDB_SCHEMA = "4561b3ffb11d88309497651e299d6f420786093397d93a98dc6ba4ddec9d86f5";
-            const auto SCHEMA_HASH_ECDB_MAP = "84a3a5e11259bae6a8800d8215f48b1e611d5bb77c3bac620da73b23f9e06a92";
-            const auto SCHEMA_HASH_SQLITE_SCHEMA = "2e503df7e76cb940852191fcae5feb0c7aa11bfddd09d3f22056260426db5c5d";
+            const auto SCHEMA_HASH_ECDB_MAP = "202df04d2f9cf71bccb46fac3daabeffc8b785933bd1334c5bff5ceda16700c0";
+            const auto SCHEMA_HASH_SQLITE_SCHEMA = "389ce0b78f3ca9cf88e1ee0862f627f78b5ca5e9b6de34adbc5b41e9dd553fa5";
             EXPECT_EQ(
                 SchemaImportResult::OK,
                 assertImport(newSchema, "1.1", SchemaManager::SchemaImportOptions::None, {SCHEMA_HASH_ECDB_SCHEMA, SCHEMA_HASH_ECDB_MAP, SCHEMA_HASH_SQLITE_SCHEMA})
@@ -22821,8 +22821,10 @@ TEST_F(SchemaSyncTestFixture, DisallowMajorSchemaUpgrade)
                 </ECSchema>)xml";
 
             const auto SCHEMA_HASH_ECDB_SCHEMA = "26d2a2bb445fcff8d12c37d1a2fbfbce86ec4b14379c0eed1d8afc1ec3013eb0";
-            const auto SCHEMA_HASH_ECDB_MAP = "84a3a5e11259bae6a8800d8215f48b1e611d5bb77c3bac620da73b23f9e06a92";
-            const auto SCHEMA_HASH_SQLITE_SCHEMA = "2e503df7e76cb940852191fcae5feb0c7aa11bfddd09d3f22056260426db5c5d";
+            // Hash values changed when a mapping bug was fixed: the derived class used to map the new
+            // property to a different shared column than the base class (see ClassMapColumnFactory::IsCompatible).
+            const auto SCHEMA_HASH_ECDB_MAP = "202df04d2f9cf71bccb46fac3daabeffc8b785933bd1334c5bff5ceda16700c0";
+            const auto SCHEMA_HASH_SQLITE_SCHEMA = "389ce0b78f3ca9cf88e1ee0862f627f78b5ca5e9b6de34adbc5b41e9dd553fa5";
             EXPECT_EQ(
                 SchemaImportResult::OK,
                 assertImport(newSchema, "1.1", SchemaManager::SchemaImportOptions::None, {SCHEMA_HASH_ECDB_SCHEMA, SCHEMA_HASH_ECDB_MAP, SCHEMA_HASH_SQLITE_SCHEMA})

--- a/iModelCore/ECDb/Tests/NonPublished/SchemaUpgradeTests.cpp
+++ b/iModelCore/ECDb/Tests/NonPublished/SchemaUpgradeTests.cpp
@@ -243,6 +243,57 @@ TEST_F(SchemaUpgradeTestFixture, ValidateMapCheck_CheckForOrphanCustomAttributeI
     ASSERT_TRUE(std::regex_match (issueListener.m_issues[1].message.c_str(), std::regex (expectedMsg2Pattern.c_str ())));
     ASSERT_STREQ(expectedMsg3.c_str(), issueListener.m_issues[2].message.c_str());
 }
+
+//---------------------------------------------------------------------------------------
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+------
+TEST_F(SchemaUpgradeTestFixture, ValidateMapCheck_InheritedPropertyMapConsistency) {
+    // In a table-per-hierarchy mapping, a derived class must map an inherited property to the
+    // same column as the base class. This test simulates diverged class maps (as once produced
+    // by a schema remapping bug) by pointing the derived class's property map at a different
+    // column, and expects the next schema import to fail with a validation issue.
+    auto testSchemaXml = R"xml(<?xml version="1.0" encoding="UTF-8"?>
+    <ECSchema schemaName="TestSchema" alias="ts" version="01.00.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+        <ECSchemaReference name="ECDbMap" version="02.00.00" alias="ecdbmap"/>
+        <ECEntityClass typeName="Base">
+            <ECCustomAttributes>
+                <ClassMap xmlns="ECDbMap.02.00.00">
+                    <MapStrategy>TablePerHierarchy</MapStrategy>
+                </ClassMap>
+            </ECCustomAttributes>
+            <ECProperty propertyName="Prop1" typeName="string"/>
+            <ECProperty propertyName="Prop2" typeName="string"/>
+        </ECEntityClass>
+        <ECEntityClass typeName="Sub">
+            <BaseClass>Base</BaseClass>
+            <ECProperty propertyName="SubProp" typeName="string"/>
+        </ECEntityClass>
+    </ECSchema>)xml";
+    ASSERT_EQ(BentleyStatus::SUCCESS, SetupECDb("inheritedPropertyMapConsistency.ecdb", SchemaItem(testSchemaXml)));
+
+    // *** Simulate diverged class maps: point Sub's map of the inherited Prop1 at Prop2's column ***
+    m_ecdb.ClearECDbCache();
+    ASSERT_EQ(BE_SQLITE_OK, m_ecdb.ExecuteSql(R"sql(
+        UPDATE ec_PropertyMap SET ColumnId = (SELECT Id FROM ec_Column WHERE Name = 'Prop2')
+            WHERE ClassId = (SELECT Id FROM ec_Class WHERE Name = 'Sub')
+              AND PropertyPathId = (SELECT pp.Id FROM ec_PropertyPath pp
+                    JOIN ec_Property p ON p.Id = pp.RootPropertyId
+                    WHERE pp.AccessString = 'Prop1' AND p.ClassId = (SELECT Id FROM ec_Class WHERE Name = 'Base')))sql"));
+    m_ecdb.SaveChanges();
+
+    TestIssueListener issueListener;
+    m_ecdb.AddIssueListener(issueListener);
+
+    // importing another schema triggers the validation check, which must detect the divergence
+    auto unrelatedSchemaXml = R"xml(<?xml version="1.0" encoding="UTF-8"?>
+        <ECSchema schemaName="TestSchema1" alias="ts1" version="01.00.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.1"/>)xml";
+    ASSERT_EQ(ERROR, ImportSchema(SchemaItem(unrelatedSchemaXml)));
+
+    Utf8String expectedMsg("Detected inconsistent property mapping: ECClass 'TestSchema:Sub' maps property 'Prop1' to column 'ts_Base.Prop2', but its base ECClass 'TestSchema:Base' maps the same property to column 'ts_Base.Prop1'.");
+    ASSERT_FALSE(issueListener.IsEmpty());
+    ASSERT_STREQ(expectedMsg.c_str(), issueListener.m_issues[0].message.c_str());
+}
+
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //+---------------+---------------+---------------+---------------+---------------+------

--- a/iModelCore/ECDb/Tests/NonPublished/SchemaUpgradeTests.cpp
+++ b/iModelCore/ECDb/Tests/NonPublished/SchemaUpgradeTests.cpp
@@ -274,7 +274,9 @@ TEST_F(SchemaUpgradeTestFixture, ValidateMapCheck_InheritedPropertyMapConsistenc
     // *** Simulate diverged class maps: point Sub's map of the inherited Prop1 at Prop2's column ***
     m_ecdb.ClearECDbCache();
     ASSERT_EQ(BE_SQLITE_OK, m_ecdb.ExecuteSql(R"sql(
-        UPDATE ec_PropertyMap SET ColumnId = (SELECT Id FROM ec_Column WHERE Name = 'Prop2')
+        UPDATE ec_PropertyMap SET ColumnId = (SELECT pm2.ColumnId FROM ec_PropertyMap pm2
+                    JOIN ec_PropertyPath pp2 ON pp2.Id = pm2.PropertyPathId
+                    WHERE pm2.ClassId = (SELECT Id FROM ec_Class WHERE Name = 'Sub') AND pp2.AccessString = 'Prop2')
             WHERE ClassId = (SELECT Id FROM ec_Class WHERE Name = 'Sub')
               AND PropertyPathId = (SELECT pp.Id FROM ec_PropertyPath pp
                     JOIN ec_Property p ON p.Id = pp.RootPropertyId

--- a/iModelCore/ECDb/Tests/NonPublished/SchemaUpgradeTests.cpp
+++ b/iModelCore/ECDb/Tests/NonPublished/SchemaUpgradeTests.cpp
@@ -299,6 +299,76 @@ TEST_F(SchemaUpgradeTestFixture, ValidateMapCheck_InheritedPropertyMapConsistenc
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //+---------------+---------------+---------------+---------------+---------------+------
+TEST_F(SchemaUpgradeTestFixture, AddPropertyWithPropertyMapCAToSharedColumnHierarchy) {
+    // Adding a new property with a 'PropertyMap' custom attribute (IsNullable/IsUnique) to an
+    // existing class in a shared-column TPH hierarchy: the constraints cannot be enforced on a
+    // shared column and are dropped with a warning. The derived class must still map the
+    // inherited property to the same shared column as the base class. A former bug in
+    // ClassMapColumnFactory::IsCompatible compared the requested constraints against the
+    // (constraint-free) shared column of the base class, refused to reuse it and silently
+    // allocated a different column for the derived class, causing silent data loss.
+    ASSERT_EQ(BentleyStatus::SUCCESS, SetupECDb("addPropertyWithPropertyMapCA.ecdb", SchemaItem(R"xml(<?xml version="1.0" encoding="utf-8" ?>
+    <ECSchema schemaName="TestSchema" alias="ts" version="1.0" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.1">
+        <ECSchemaReference name="ECDbMap" version="02.00" alias="ecdbmap"/>
+        <ECEntityClass typeName="Parent">
+            <ECCustomAttributes>
+                <ClassMap xmlns="ECDbMap.02.00">
+                    <MapStrategy>TablePerHierarchy</MapStrategy>
+                </ClassMap>
+                <ShareColumns xmlns="ECDbMap.02.00"/>
+            </ECCustomAttributes>
+            <ECProperty propertyName="Name" typeName="string"/>
+        </ECEntityClass>
+        <ECEntityClass typeName="Sub">
+            <BaseClass>Parent</BaseClass>
+            <ECProperty propertyName="SubProp" typeName="string"/>
+        </ECEntityClass>
+    </ECSchema>)xml")));
+
+    ASSERT_EQ(SUCCESS, ImportSchema(SchemaItem(R"xml(<?xml version="1.0" encoding="utf-8" ?>
+    <ECSchema schemaName="TestSchema" alias="ts" version="1.1" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.1">
+        <ECSchemaReference name="ECDbMap" version="02.00" alias="ecdbmap"/>
+        <ECEntityClass typeName="Parent">
+            <ECCustomAttributes>
+                <ClassMap xmlns="ECDbMap.02.00">
+                    <MapStrategy>TablePerHierarchy</MapStrategy>
+                </ClassMap>
+                <ShareColumns xmlns="ECDbMap.02.00"/>
+            </ECCustomAttributes>
+            <ECProperty propertyName="Name" typeName="string"/>
+            <ECProperty propertyName="NewProp" typeName="string">
+                <ECCustomAttributes>
+                    <PropertyMap xmlns="ECDbMap.02.00">
+                        <IsNullable>False</IsNullable>
+                        <IsUnique>True</IsUnique>
+                    </PropertyMap>
+                </ECCustomAttributes>
+            </ECProperty>
+        </ECEntityClass>
+        <ECEntityClass typeName="Sub">
+            <BaseClass>Parent</BaseClass>
+            <ECProperty propertyName="SubProp" typeName="string"/>
+        </ECEntityClass>
+    </ECSchema>)xml")));
+
+    // base and derived class must map the new property to the same shared column
+    // (v1.0 layout: Name -> ps1, SubProp -> ps2, so the new property gets ps3)
+    ASSERT_EQ(ExpectedColumn("ts_Parent", "ps3"), GetHelper().GetPropertyMapColumn(AccessString("ts", "Parent", "NewProp")));
+    ASSERT_EQ(ExpectedColumn("ts_Parent", "ps3"), GetHelper().GetPropertyMapColumn(AccessString("ts", "Sub", "NewProp"))) << "Sub must map the inherited NewProp to the same column as Parent";
+
+    // data written through the derived class must be visible through the base class
+    ECSqlStatement stmt;
+    ASSERT_EQ(ECSqlStatus::Success, stmt.Prepare(m_ecdb, "INSERT INTO ts.Sub (Name, NewProp, SubProp) VALUES ('name', 'newPropValue', 'subProp')"));
+    ASSERT_EQ(BE_SQLITE_DONE, stmt.Step());
+    stmt.Finalize();
+
+    EXPECT_EQ(JsonValue(R"json([{"NewProp":"newPropValue"}])json"), GetHelper().ExecuteSelectECSql("SELECT NewProp FROM ts.Parent"));
+    m_ecdb.AbandonChanges();
+}
+
+//---------------------------------------------------------------------------------------
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+------
 TEST_F(SchemaUpgradeTestFixture, CustomAttributeOrdinal){
     auto testCaXml = R"xml(<?xml version="1.0" encoding="UTF-8"?>
     <ECSchema schemaName="TestCA" alias="tsca" version="01.00.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.1">


### PR DESCRIPTION
## Motivation

While investigating a connector sync failure we hit an intermediate state where class maps in a TablePerHierarchy hierarchy diverged: the base class mapped a property to one column while derived classes mapped the same property to different columns. Such a state passes schema import without complaint and then manifests as **silent data loss**: reading the property through one class map accesses a different column than reading it through another, so values appear NULL (or worse, writes scatter across unrelated columns).

`DbMapValidator` had no check for this - it validates counts, presence and per-class duplicates, but never compares a class map against its base class's map.

## Change

Adds `DbMapValidator::CheckInheritedPropertyMapConsistency`, run as part of every schema import validation:

- A single SQL query over the persisted mapping tables (`ec_PropertyMap`, `ec_PropertyPath`, `ec_Column`, `ec_Table`, `ec_cache_ClassHierarchy`): a class and any of its (direct or indirect) base classes must map the same property path to the same column, as long as both store data in the same table tree (primary/joined/overflow tables of one hierarchy).
- System properties (root property owned by `ECDbSystem`) are exempt: classes in joined-table hierarchies legitimately map `ECInstanceId`/`ECClassId` to a different column per table.
- Comparing along the class hierarchy (rather than just grouping by table tree) avoids false positives for mixins, whose virtual tables and disjoint implementer branches legitimately map one property path to several columns.
- Violations are reported as a hard error with new issue id `ECDb_0744` (0742/0743 are claimed by #1528), naming the derived class, base class, property and both columns.

## Mapping bug found by the new check

The check immediately caught a real divergence produced by the regular mapping code (`SchemaUpgradeTestFixture.DisallowMajorSchemaUpgrade` / `SchemaSyncTestFixture.DisallowMajorSchemaUpgrade`): adding a new property with a `PropertyMap` custom attribute (e.g. `IsNullable=False`) to an existing class in a shared-column TPH hierarchy.

- The base class maps the new property: NOT NULL cannot be enforced on a shared column, so the allocator drops the constraint (with a warning) and assigns a shared column (`ps5`).
- The derived class then maps the inherited property: `ClassMapColumnFactory::IsCompatible` compared the requested constraints against the (constraint-free) shared column, judged it incompatible, and silently allocated a different column (`ps6`).
- Result: base and derived class persistently map the same property to different columns. Instances of the derived class write to `ps6`, polymorphic queries through the base class read `ps5` - silent data loss. The existing tests asserted import success and codified this without noticing.

Fixed by exempting shared columns from the constraint comparison in `IsCompatible`: shared columns never carry NOT NULL/UNIQUE/collation constraints by design, so the comparison could only ever refuse legitimate reuse.

## Hard error vs warning

I ran this check against a large selection of local iModels and found zero violations. Had I found some, I would have just turned this into a warning instead since we cannot be sure that we have no iModels out there that violate this new check. However, since this means data corruption, we'll probably want to know. However, I did find the one mapping bug mentioned above with this new check.

The validator only runs during **schema import** - existing files remain fully usable for opening, querying and editing data. The check can only reject an import into a file whose mapping tables are already inconsistent, at which point continuing would build on (and potentially spread) the corruption.

## Testing

- New test `SchemaUpgradeTestFixture.ValidateMapCheck_InheritedPropertyMapConsistency`: creates a TPH hierarchy, simulates the divergence by re-pointing the derived class's property map at a different column via SQL, and asserts the next schema import fails with the expected issue.
- The check correctly flags the corrupted repro file from the original investigation and stays silent on all healthy files tested.
