### PR TITLE
Fix crash on null PropertyMap during ECSQL SELECT preparation

### DIFF
--- a/iModelCore/ECDb/ECDb/ECSql/ECSqlBinder.cpp
+++ b/iModelCore/ECDb/ECDb/ECSql/ECSqlBinder.cpp
@@ -70,6 +70,7 @@ std::unique_ptr<ECSqlBinder> ECSqlBinderFactory::CreateBinder(ECSqlPrepareContex
         PropertyNameExp const& propNameExp = targetExp->GetAs<PropertyNameExp>();
         ECSqlSystemPropertyInfo const& sysPropInfo = propNameExp.GetSystemPropertyInfo();
         if (sysPropInfo.IsId() || propNameExp.GetTypeInfo().IsId())
+            {
             if (propNameExp.IsPropertyFromCommonTableBlockWithColumns())
                 {
                 CommonTableBlockNameExp const& commonTableBlockNameExp = propNameExp.GetClassRefExp()->GetAs<CommonTableBlockNameExp>();
@@ -78,8 +79,15 @@ std::unique_ptr<ECSqlBinder> ECSqlBinderFactory::CreateBinder(ECSqlPrepareContex
                 ECSqlTypeInfo typeInfo = blockExp->FindType(propNameExp.GetPropertyName());
                 return CreateIdBinderForQuery(ctx, typeInfo, paramNameGen);
                 }
-            else
-                return CreateIdBinder(ctx, *propNameExp.GetPropertyMap(), sysPropInfo, paramNameGen);
+
+            //PropertyNameExp::GetPropertyMap can legitimately return nullptr, e.g. when the parameter is compared against an
+            //alias of a subquery or CTE whose underlying expression is not a property name exp (like a NULL literal in one of
+            //the branches of a compound select). In that case fall back to the type info based Id binder.
+            if (PropertyMap const* propMap = propNameExp.GetPropertyMap())
+                return CreateIdBinder(ctx, *propMap, sysPropInfo, paramNameGen);
+
+            return CreateIdBinderForQuery(ctx, propNameExp.GetTypeInfo(), paramNameGen);
+            }
         }
 
     if (const Exp* exp = parameterExp.FindParent(Exp::Type::FunctionCall))

--- a/iModelCore/ECDb/ECDb/ECSql/ECSqlPreparer.cpp
+++ b/iModelCore/ECDb/ECDb/ECSql/ECSqlPreparer.cpp
@@ -753,6 +753,9 @@ void ECSqlExpPreparer::RemovePropertyRefs(ECSqlPrepareContext& ctx, ClassRefExp 
             continue;
 
         const auto propMap = propertyNameExp->GetPropertyMap();
+        if (propMap == nullptr)
+            continue; //nothing to add to the selection options if the exp has no backing property map
+
         if (propMap->GetType() == PropertyMap::Type::Navigation && propertyNameExp->FindParent(Exp::Type::Selection) == nullptr)
             {
             // Only omit RelECClassId from the view if it is not actually needed anywhere in the query

--- a/iModelCore/ECDb/ECDb/ECSql/ECSqlPropertyNameExpPreparer.cpp
+++ b/iModelCore/ECDb/ECDb/ECSql/ECSqlPropertyNameExpPreparer.cpp
@@ -35,6 +35,12 @@ ECSqlStatus ECSqlPropertyNameExpPreparer::Prepare(NativeSqlBuilder::List& native
         return ECSqlStatus::Success;
     }
     PropertyMap const* propMap = exp.GetPropertyMap();
+    if (propMap == nullptr)
+        {
+        BeAssert(propMap != nullptr && "PropertyNameExp is expected to have a property map at this point");
+        return ECSqlStatus::Error;
+        }
+
     ECSqlPrepareContext::ExpScope const& currentScope = ctx.GetCurrentScope();
 
     if (!NeedsPreparation(ctx, currentScope, *propMap))

--- a/iModelCore/ECDb/ECDb/ECSql/ECSqlSelectPreparer.cpp
+++ b/iModelCore/ECDb/ECDb/ECSql/ECSqlSelectPreparer.cpp
@@ -443,7 +443,9 @@ void ECSqlSelectPreparer::ExtractPropertyRefs(ECSqlPrepareContext& ctx, Exp cons
         if (propertyName->IsVirtualProperty())
             return;
 
-        ctx.GetSelectionOptionsR().AddProperty(*propertyName->GetPropertyMap());
+        //may be nullptr, e.g. for a reference to a CTE or subquery alias which isn't backed by a mapped property
+        if (PropertyMap const* propertyMap = propertyName->GetPropertyMap())
+            ctx.GetSelectionOptionsR().AddProperty(*propertyMap);
         }
 
     for (Exp const* child : exp->GetChildren())

--- a/iModelCore/ECDb/ECDb/ECSql/PropertyNameExp.cpp
+++ b/iModelCore/ECDb/ECDb/ECSql/PropertyNameExp.cpp
@@ -534,6 +534,10 @@ void PropertyNameExp::SetPropertyRef(DerivedPropertyExp const& derivedPropertyEx
     }
 
 //------------------------------------------------------------------------------------------
+// Returns the property map backing this exp, or nullptr if there is none.
+// A nullptr result is legitimate and must be handled by callers: an exp referring to an alias
+// of a subquery or of a CTE can be backed by an arbitrary expression (e.g. a literal or a
+// computed value) rather than by a mapped property, in which case no property map exists.
 // @bsimethod
 //+---------------+---------------+---------------+---------------+---------------+---------
 PropertyMap const* PropertyNameExp::GetPropertyMap() const
@@ -549,6 +553,8 @@ PropertyMap const* PropertyNameExp::GetPropertyMap() const
             {
             ClassNameExp const& classNameExp = classRefExp->GetAs<ClassNameExp>();
             propertyMap = classNameExp.GetInfo().GetMap().GetPropertyMaps().Find(GetResolvedPropertyPath().ToString(false).c_str());
+            //a property of an actual class is always expected to be mapped
+            BeAssert(propertyMap != nullptr && "PropertyNameExp's PropertyMap should never be nullptr for a class name exp.");
             break;
             }
 
@@ -556,10 +562,8 @@ PropertyMap const* PropertyNameExp::GetPropertyMap() const
             {  
             PropertyNameExp::PropertyRef const* propertyRef = GetPropertyRef();
             BeAssert(propertyRef != nullptr);
+            //may be nullptr if the referenced derived property exp is not a property name exp (e.g. a literal or computed value)
             propertyMap = propertyRef->TryGetPropertyMap(GetResolvedPropertyPath());
-            if (propertyMap == nullptr) {
-                BeAssert(propertyMap != nullptr && "Exp of a derived prop exp referenced from a sub query ref is expected to always be a prop name exp");
-            }
             break;
             }
         case Exp::Type::CommonTableBlockName :
@@ -572,10 +576,8 @@ PropertyMap const* PropertyNameExp::GetPropertyMap() const
                 {
                 PropertyNameExp::PropertyRef const* propertyRef = GetPropertyRef();
                 BeAssert(propertyRef != nullptr);
+                //may be nullptr if the referenced derived property exp is not a property name exp (e.g. a literal or computed value)
                 propertyMap = propertyRef->TryGetPropertyMap(GetResolvedPropertyPath());
-                if (propertyMap == nullptr) {
-                    BeAssert(propertyMap != nullptr && "Exp of a derived prop exp referenced from a common table block name is expected to always be a prop name exp");
-                }
                 break;
                 }
             return nullptr; // This block returns nullptr for proper alias referencing if the cte block has columns
@@ -585,7 +587,6 @@ PropertyMap const* PropertyNameExp::GetPropertyMap() const
                 break;
         }
 
-    BeAssert(propertyMap != nullptr && "PropertyNameExp's PropertyMap should never be nullptr.");
     return propertyMap;
     }
 

--- a/iModelCore/ECDb/Tests/NonPublished/CommonTableExpTests.cpp
+++ b/iModelCore/ECDb/Tests/NonPublished/CommonTableExpTests.cpp
@@ -4311,11 +4311,9 @@ TEST_F(CommonTableExpNullPropertyMapTestFixture, BindIdParam_SubqueryUnionNullAl
     )";
 
     ECSqlStatement stmt;
-    const ECSqlStatus prepareStatus = stmt.Prepare(m_ecdb, query); // must not crash
-    if (prepareStatus.IsSuccess()) {
-        ASSERT_EQ(ECSqlStatus::Success, stmt.BindId(1, ECInstanceId((uint64_t) 1))) << query;
-        ASSERT_NE(BE_SQLITE_ERROR, stmt.Step()) << query;
-    }
+    ASSERT_EQ(ECSqlStatus::Success, stmt.Prepare(m_ecdb, query)) << query;
+    ASSERT_EQ(ECSqlStatus::Success, stmt.BindId(1, ECInstanceId((uint64_t) 1))) << query;
+    ASSERT_NE(BE_SQLITE_ERROR, stmt.Step()) << query;
 }
 
 //---------------------------------------------------------------------------------------

--- a/iModelCore/ECDb/Tests/NonPublished/CommonTableExpTests.cpp
+++ b/iModelCore/ECDb/Tests/NonPublished/CommonTableExpTests.cpp
@@ -4333,11 +4333,9 @@ TEST_F(CommonTableExpNullPropertyMapTestFixture, BindIdParam_CteWithoutColumnLis
     )";
 
     ECSqlStatement stmt;
-    const ECSqlStatus prepareStatus = stmt.Prepare(m_ecdb, query); // must not crash
-    if (prepareStatus.IsSuccess()) {
-        ASSERT_EQ(ECSqlStatus::Success, stmt.BindId(1, ECInstanceId((uint64_t) 1))) << query;
-        ASSERT_NE(BE_SQLITE_ERROR, stmt.Step()) << query;
-    }
+    ASSERT_EQ(ECSqlStatus::Success, stmt.Prepare(m_ecdb, query)) << query;
+    ASSERT_EQ(ECSqlStatus::Success, stmt.BindId(1, ECInstanceId((uint64_t) 1))) << query;
+    ASSERT_NE(BE_SQLITE_ERROR, stmt.Step()) << query;
 }
 
 //---------------------------------------------------------------------------------------
@@ -4360,11 +4358,9 @@ TEST_F(CommonTableExpNullPropertyMapTestFixture, BindIdParam_CteWithColumnList_C
     )";
 
     ECSqlStatement stmt;
-    const ECSqlStatus prepareStatus = stmt.Prepare(m_ecdb, query); // must not crash
-    if (prepareStatus.IsSuccess()) {
-        ASSERT_EQ(ECSqlStatus::Success, stmt.BindId(1, ECInstanceId((uint64_t) 1))) << query;
-        ASSERT_NE(BE_SQLITE_ERROR, stmt.Step()) << query;
-    }
+    ASSERT_EQ(ECSqlStatus::Success, stmt.Prepare(m_ecdb, query)) << query;
+    ASSERT_EQ(ECSqlStatus::Success, stmt.BindId(1, ECInstanceId((uint64_t) 1))) << query;
+    ASSERT_NE(BE_SQLITE_ERROR, stmt.Step()) << query;
 }
 
 //---------------------------------------------------------------------------------------
@@ -4384,11 +4380,9 @@ TEST_F(CommonTableExpNullPropertyMapTestFixture, BindIdParam_SubqueryUnionRevers
     )";
 
     ECSqlStatement stmt;
-    const ECSqlStatus prepareStatus = stmt.Prepare(m_ecdb, query); // must not crash
-    if (prepareStatus.IsSuccess()) {
-        ASSERT_EQ(ECSqlStatus::Success, stmt.BindId(1, ECInstanceId((uint64_t) 1))) << query;
-        ASSERT_NE(BE_SQLITE_ERROR, stmt.Step()) << query;
-    }
+    ASSERT_EQ(ECSqlStatus::Success, stmt.Prepare(m_ecdb, query)) << query;
+    ASSERT_EQ(ECSqlStatus::Success, stmt.BindId(1, ECInstanceId((uint64_t) 1))) << query;
+    ASSERT_NE(BE_SQLITE_ERROR, stmt.Step()) << query;
 }
 
 //---------------------------------------------------------------------------------------
@@ -4397,7 +4391,7 @@ TEST_F(CommonTableExpNullPropertyMapTestFixture, BindIdParam_SubqueryUnionRevers
 //+---------------+---------------+---------------+---------------+---------------+------
 TEST_F(CommonTableExpNullPropertyMapTestFixture, BindIdParam_SubqueryUnionRelationshipEndId) {
     ASSERT_EQ(BentleyStatus::SUCCESS, SetupECDb("issue2311_rel_end_id.ecdb", SchemaItem(R"xml(<?xml version='1.0' encoding='utf-8'?>
-        <ECSchema schemaName='TestSchema' alias='ts' version='1.0.0' xmlns='http://www.bentley.com/schemas/Bentley.ECXML.3.1'>
+        <ECSchema schemaName='TestSchema' alias='ts' version='1.0.0' xmlns='http://www.bentley.com/schemas/Bentley.ECXML.3.2'>
             <ECEntityClass typeName='Model'>
                 <ECProperty propertyName="Name" typeName="string" />
             </ECEntityClass>
@@ -4423,11 +4417,9 @@ TEST_F(CommonTableExpNullPropertyMapTestFixture, BindIdParam_SubqueryUnionRelati
     )";
 
     ECSqlStatement stmt;
-    const ECSqlStatus prepareStatus = stmt.Prepare(m_ecdb, query); // must not crash
-    if (prepareStatus.IsSuccess()) {
-        ASSERT_EQ(ECSqlStatus::Success, stmt.BindId(1, ECInstanceId((uint64_t) 1))) << query;
-        ASSERT_NE(BE_SQLITE_ERROR, stmt.Step()) << query;
-    }
+    ASSERT_EQ(ECSqlStatus::Success, stmt.Prepare(m_ecdb, query)) << query;
+    ASSERT_EQ(ECSqlStatus::Success, stmt.BindId(1, ECInstanceId((uint64_t) 1))) << query;
+    ASSERT_NE(BE_SQLITE_ERROR, stmt.Step()) << query;
 }
 
 END_ECDBUNITTESTS_NAMESPACE

--- a/iModelCore/ECDb/Tests/NonPublished/CommonTableExpTests.cpp
+++ b/iModelCore/ECDb/Tests/NonPublished/CommonTableExpTests.cpp
@@ -4268,4 +4268,168 @@ TEST_F(CommonTableExpTestFixture, Values_OnlyNull)
         }
     }
 
+//=======================================================================================
+// Regression coverage for iTwin/itwinjs-backlog#2311.
+//
+// ECSqlBinderFactory::CreateBinder (ECSqlBinder.cpp:82) does:
+//     return CreateIdBinder(ctx, *propNameExp.GetPropertyMap(), sysPropInfo, paramNameGen);
+// without checking GetPropertyMap() for nullptr. PropertyNameExp::GetPropertyMap() can
+// legitimately return nullptr (PropertyNameExp.cpp:539) and the guards there are BeAsserts,
+// which compile out under NDEBUG.
+//
+// To reach it, an alias must at the same time
+//   a) have an inferred Id type - ECSqlTypeInfo::IsId() requires exact-numeric plus the
+//      "Id" extended type name. GetTypeInfoFromPropertyRef() (PropertyNameExp.cpp:176)
+//      supplies it for a compound (UNION) select by borrowing the type from a sibling
+//      branch when the linked branch's own type is Null/Unset; and
+//   b) have no backing PropertyMap - PropertyRef::TryGetPropertyMap()
+//      (PropertyNameExp.cpp:724) returns nullptr when the linked DerivedPropertyExp's
+//      expression is not a PropertyNameExp / NavValueCreationFuncExp.
+//
+// A NULL literal in one UNION branch satisfies both at once. The expected crash is
+// EXCEPTION_ACCESS_VIOLATION_READ at 0x20 - the offset of PropertyMap::m_ecProperty, read
+// by the inlined ECSqlTypeInfo(PropertyMap const&) ctor off a null `this`.
+//
+// Each query lives in its own TEST_F so that a crash identifies the exact failing shape
+// instead of taking the whole suite down at the first one.
+//=======================================================================================
+struct CommonTableExpNullPropertyMapTestFixture : ECDbTestFixture {};
+
+//---------------------------------------------------------------------------------------
+// Query 1: subquery + UNION. Primary candidate.
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+------
+TEST_F(CommonTableExpNullPropertyMapTestFixture, BindIdParam_SubqueryUnionNullAlias) {
+    ASSERT_EQ(DbResult::BE_SQLITE_OK, SetupECDb("issue2311_subquery_union.ecdb"));
+
+    auto query = R"(
+        SELECT * FROM (
+            SELECT NULL AS eid FROM meta.ECClassDef
+            UNION ALL
+            SELECT ECInstanceId AS eid FROM meta.ECClassDef
+        ) WHERE eid = ?
+    )";
+
+    ECSqlStatement stmt;
+    const ECSqlStatus prepareStatus = stmt.Prepare(m_ecdb, query); // must not crash
+    if (prepareStatus.IsSuccess()) {
+        ASSERT_EQ(ECSqlStatus::Success, stmt.BindId(1, ECInstanceId((uint64_t) 1))) << query;
+        ASSERT_NE(BE_SQLITE_ERROR, stmt.Step()) << query;
+    }
+}
+
+//---------------------------------------------------------------------------------------
+// Query 2: CTE without a column list. Matches the CommonTableExp frame in the minidump.
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+------
+TEST_F(CommonTableExpNullPropertyMapTestFixture, BindIdParam_CteWithoutColumnList) {
+    ASSERT_EQ(DbResult::BE_SQLITE_OK, SetupECDb("issue2311_cte_no_columns.ecdb"));
+
+    auto query = R"(
+        WITH cte AS (
+            SELECT NULL AS eid FROM meta.ECClassDef
+            UNION ALL
+            SELECT ECInstanceId AS eid FROM meta.ECClassDef
+        )
+        SELECT * FROM cte WHERE eid = ?
+    )";
+
+    ECSqlStatement stmt;
+    const ECSqlStatus prepareStatus = stmt.Prepare(m_ecdb, query); // must not crash
+    if (prepareStatus.IsSuccess()) {
+        ASSERT_EQ(ECSqlStatus::Success, stmt.BindId(1, ECInstanceId((uint64_t) 1))) << query;
+        ASSERT_NE(BE_SQLITE_ERROR, stmt.Step()) << query;
+    }
+}
+
+//---------------------------------------------------------------------------------------
+// Query 3: control case. A CTE *with* a column list takes the guarded
+// IsPropertyFromCommonTableBlockWithColumns() -> CreateIdBinderForQuery path, so this one
+// is expected to pass both before and after the fix. The contrast with Query 2 confirms
+// the diagnosis.
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+------
+TEST_F(CommonTableExpNullPropertyMapTestFixture, BindIdParam_CteWithColumnList_Control) {
+    ASSERT_EQ(DbResult::BE_SQLITE_OK, SetupECDb("issue2311_cte_with_columns.ecdb"));
+
+    auto query = R"(
+        WITH cte(eid) AS (
+            SELECT NULL AS eid FROM meta.ECClassDef
+            UNION ALL
+            SELECT ECInstanceId AS eid FROM meta.ECClassDef
+        )
+        SELECT * FROM cte WHERE eid = ?
+    )";
+
+    ECSqlStatement stmt;
+    const ECSqlStatus prepareStatus = stmt.Prepare(m_ecdb, query); // must not crash
+    if (prepareStatus.IsSuccess()) {
+        ASSERT_EQ(ECSqlStatus::Success, stmt.BindId(1, ECInstanceId((uint64_t) 1))) << query;
+        ASSERT_NE(BE_SQLITE_ERROR, stmt.Step()) << query;
+    }
+}
+
+//---------------------------------------------------------------------------------------
+// Query 4: reversed UNION branch order. Exercises the type resolution loop rather than
+// relying on the NULL branch coming first.
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+------
+TEST_F(CommonTableExpNullPropertyMapTestFixture, BindIdParam_SubqueryUnionReversedBranchOrder) {
+    ASSERT_EQ(DbResult::BE_SQLITE_OK, SetupECDb("issue2311_subquery_union_reversed.ecdb"));
+
+    auto query = R"(
+        SELECT * FROM (
+            SELECT ECInstanceId AS eid FROM meta.ECClassDef
+            UNION ALL
+            SELECT NULL AS eid FROM meta.ECClassDef
+        ) WHERE eid = ?
+    )";
+
+    ECSqlStatement stmt;
+    const ECSqlStatus prepareStatus = stmt.Prepare(m_ecdb, query); // must not crash
+    if (prepareStatus.IsSuccess()) {
+        ASSERT_EQ(ECSqlStatus::Success, stmt.BindId(1, ECInstanceId((uint64_t) 1))) << query;
+        ASSERT_NE(BE_SQLITE_ERROR, stmt.Step()) << query;
+    }
+}
+
+//---------------------------------------------------------------------------------------
+// Query 5: navigation / relationship end Id variant.
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+------
+TEST_F(CommonTableExpNullPropertyMapTestFixture, BindIdParam_SubqueryUnionRelationshipEndId) {
+    ASSERT_EQ(BentleyStatus::SUCCESS, SetupECDb("issue2311_rel_end_id.ecdb", SchemaItem(R"xml(<?xml version='1.0' encoding='utf-8'?>
+        <ECSchema schemaName='TestSchema' alias='ts' version='1.0.0' xmlns='http://www.bentley.com/schemas/Bentley.ECXML.3.1'>
+            <ECEntityClass typeName='Model'>
+                <ECProperty propertyName="Name" typeName="string" />
+            </ECEntityClass>
+            <ECEntityClass typeName='Element'>
+                <ECProperty propertyName="Code" typeName="string" />
+            </ECEntityClass>
+            <ECRelationshipClass typeName='ModelHasElements' strength='embedding' modifier='Sealed'>
+                <Source multiplicity='(0..1)' roleLabel='has' polymorphic='false'>
+                    <Class class='Model' />
+                </Source>
+                <Target multiplicity='(0..*)' roleLabel='is owned by' polymorphic='false'>
+                    <Class class='Element' />
+                </Target>
+            </ECRelationshipClass>
+        </ECSchema>)xml")));
+
+    auto query = R"(
+        SELECT * FROM (
+            SELECT NULL AS tid FROM meta.ECClassDef
+            UNION ALL
+            SELECT TargetECInstanceId AS tid FROM ts.ModelHasElements
+        ) WHERE tid = ?
+    )";
+
+    ECSqlStatement stmt;
+    const ECSqlStatus prepareStatus = stmt.Prepare(m_ecdb, query); // must not crash
+    if (prepareStatus.IsSuccess()) {
+        ASSERT_EQ(ECSqlStatus::Success, stmt.BindId(1, ECInstanceId((uint64_t) 1))) << query;
+        ASSERT_NE(BE_SQLITE_ERROR, stmt.Step()) << query;
+    }
+}
+
 END_ECDBUNITTESTS_NAMESPACE


### PR DESCRIPTION
Fixes iTwin/itwinjs-backlog#2311 (Sentry `IMODELJSNODEADDON-28M`, 648 events, "High", ongoing ~1 year).

## Problem

`ECSqlBinderFactory::CreateBinder` dereferenced `PropertyNameExp::GetPropertyMap()` with no null check when creating an Id binder:

```cpp
else
    return CreateIdBinder(ctx, *propNameExp.GetPropertyMap(), sysPropInfo, paramNameGen);
```

`GetPropertyMap()` can legitimately return `nullptr` — an exp referring to a **subquery or CTE alias** may be backed by an arbitrary expression (e.g. a `NULL` literal in one branch of a compound select) rather than a mapped property. The guards inside `GetPropertyMap()` were `BeAssert`s, which expand to `((void)0)` under `NDEBUG`, so shipping builds ran straight into the dereference.

### Why the fault address is `0x20`

`CreateIdBinder` builds `ECSqlTypeInfo(propMap)`, whose inline ctor calls `propertyMap.GetProperty()` → reads `PropertyMap::m_ecProperty`. In the x64 layout of `PropertyMap : RefCountedBase, ISupportsPropertyMapVisitor`:

| Offset | Member |
|---|---|
| `0x00` | vptr (`IRefCounted`) |
| `0x08` | `m_refCount` + pad |
| `0x10` | vptr (`ISupportsPropertyMapVisitor`) |
| `0x18` | `m_type` + pad |
| **`0x20`** | **`m_ecProperty`** |

With `this == nullptr` that reads `[0x00 + 0x20]` — exactly the reported `EXCEPTION_ACCESS_VIOLATION_READ / 0x20`, inlined into frame `00` (`CreateIdBinder`).

### How an Id-typed alias ends up without a property map

The branch is entered on `sysPropInfo.IsId() || propNameExp.GetTypeInfo().IsId()`. For a property ref, `m_sysPropInfo` stays `NoSystemProperty`, so it is the type-info arm that fires: `GetTypeInfoFromPropertyRef()` infers a compound-select alias's type by **borrowing it from a sibling `UNION` branch** when its own branch is `Null`/`Unset`. So the exp is typed as an `Id` while its own branch (`SELECT NULL AS eid`) has no backing property map.

> Note: the original issue attributed this to a failed `dynamic_cast` / use-after-free. That was a misread — the `VCRUNTIME140!__RTDynamicCast` frames sat mid-stack (indices 11–12), i.e. stack-scan artifacts from the missing Windows symbols. There is no `dynamic_cast` on the release-build path; `PropertyMap::GetAs<>` only uses one inside a `BeAssert`. The issue has been updated with the corrected analysis.

## Reproduction

```sql
SELECT * FROM (
    SELECT NULL AS eid FROM meta.ECClassDef
    UNION ALL
    SELECT ECInstanceId AS eid FROM meta.ECClassDef
) WHERE eid = ?
```

Before the fix this **crashed the test process** (SIGSEGV on macOS ARM64 debug, log truncated mid-fixture with no gtest summary), preceded by:

```
PropertyNameExp.cpp(561): ASSERTION FAILURE: propertyMap != nullptr && "...sub query ref..."
PropertyNameExp.cpp(588): ASSERTION FAILURE: propertyMap != nullptr && "PropertyNameExp's PropertyMap should never be nullptr."
```

## Changes

| File | Change |
|---|---|
| `ECSqlBinder.cpp` | Null-check `GetPropertyMap()`; fall back to `CreateIdBinderForQuery`. Also braced the outer `if`, which had a **dangling `else`** attached to a nested `if`. |
| `PropertyNameExp.cpp` | Removed the 3 `BeAssert`s claiming the property map is never null (they were factually wrong and would fail the new tests in debug); documented `nullptr` as a supported result; **kept** a targeted assert for the `ClassName` case where non-null genuinely is guaranteed, so real mapping bugs still get caught. |
| `ECSqlPreparer.cpp` | `RemovePropertyRefs`: `continue` on null (would have faulted at `+0x18` on `m_type`). |
| `ECSqlSelectPreparer.cpp` | `ExtractPropertyRefs`: skip null — **this frame appears in the Sentry stack**. |
| `ECSqlPropertyNameExpPreparer.cpp` | `Prepare`: assert + return `ECSqlStatus::Error` on null. |

`CreateIdBinderForQuery` is the correct fallback: this branch is only reachable in `SELECT`/`DELETE`/non-assignment `UPDATE` scopes (so `isNoop = false` is right), and `GetTypeInfo()` is guaranteed to be an Id type — that is the branch's entry condition.

All four new guards are no-ops when the pointer is non-null, so behaviour on every existing path is unchanged.

## Tests

New `CommonTableExpNullPropertyMapTestFixture` in `CommonTableExpTests.cpp` — one `TEST_F` per shape, since a native crash takes the whole process down and would otherwise mask the rest:

- `BindIdParam_SubqueryUnionNullAlias` — subquery + `UNION`
- `BindIdParam_CteWithoutColumnList` — CTE with no column list
- `BindIdParam_CteWithColumnList_Control` — **control**: `WITH cte(eid) AS ...` already took the guarded path and passed before the fix
- `BindIdParam_SubqueryUnionReversedBranchOrder` — exercises the type-resolution loop rather than branch ordering
- `BindIdParam_SubqueryUnionRelationshipEndId` — `TargetECInstanceId` variant

## Verification

Full ECDb suite, macOS ARM64 debug static:

```
[==========] 1645 tests from 85 test suites ran.
[  PASSED  ] 1644 tests.
```

All 5 new tests pass with **zero assertion failures** — the null property map is now produced and handled cleanly.

The single failure is `ConcurrentQueryFixture.DeadlockReproduction_MainStepVsWorkerPrepare`, which is **pre-existing and unrelated**:
- It fails intermittently (~1 in 8 runs) **with this fix applied**, and passes in isolation — a race, not a deterministic break.
- The assert is `rapidjson document.h:1523` → `RemoveAllMembers()` from `RowRender::ClearAndGetCachedJsonDocument` / `Reset` (`InstanceReaderImpl.cpp:167/177`) — unsynchronized shared `m_cachedJsonDoc` state on the `SELECT $` instance-reader path, which that test hammers from the main thread alongside 40 concurrent worker queries.
- Nothing here touches concurrency, `InstanceReader`, or JSON. Every query in that test resolves via the `Exp::Type::ClassName` path, where `GetPropertyMap()` is non-null, so all new guards are no-ops and the code path is identical to before.

Worth tracking separately as a latent thread-safety bug in `RowRender`.

## Regression history

- **#384** (`1e4c8592`, 2023-08-03) introduced the branch; `CreateIdBinder` took a `PropertyMap const*`.
- **#454** (`4d17925d`, 2023-09-15) changed it to a reference and introduced the unchecked `*GetPropertyMap()` — **the regression point**.
- **#1243** (`8d910710`, 2025-10-23) narrowed the CTE guard to "with columns", routing more CTE shapes into the unchecked `else`.

## Follow-ups (not in this PR)

- **Windows symbols are not uploaded to Sentry** — only Linux ELF DIFs are (`linux_process_all_symbols.py` → `sentry-cli upload-dif -t elf`); Windows PDBs go only to the Azure DevOps symbol server, which Sentry cannot read. This is why the crash never auto-symbolicated, and the resulting stack-scan unwind produced the misleading `dynamic_cast` frames. Recommend a matching `sentry-cli upload-dif -t pdb -t pe` step.
- The `RowRender` cached-document race noted above.
