### PR TITLE
Presentation: Fix invalid content query being produced when getting content for a class with property whose name is "Null"

### DIFF
--- a/iModelCore/ECPresentation/Source/Content/ContentQueryContracts.cpp
+++ b/iModelCore/ECPresentation/Source/Content/ContentQueryContracts.cpp
@@ -124,7 +124,8 @@ static Utf8String GetPropertySelectClauseFromAccessString(Utf8StringCR accessStr
         {
         if (!clause.empty())
             clause.append(".");
-        clause.append(QueryHelpers::Wrap(token));
+        // access string tokens are always identifiers, so escape them even if they look like a keyword/literal (e.g. a property named "Null")
+        clause.append("[").append(token).append("]");
         }
     return clause;
     }
@@ -294,8 +295,8 @@ ECClassCR ContentQueryContract::GetSelectClass(ContentDescriptor::RelatedContent
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/
 bool ContentQueryContract::CreateContractFields(
-    bvector<PresentationQueryContractFieldCPtr>& contractFields, 
-    bvector<ContentDescriptor::Field*> const& fields, 
+    bvector<PresentationQueryContractFieldCPtr>& contractFields,
+    bvector<ContentDescriptor::Field*> const& fields,
     ContentDescriptor::RelatedContentField const* parentField,
     bool skipFields
 ) const

--- a/iModelCore/ECPresentation/Tests/NonPublished/Integration/Content/ContentIntegrationTests.cpp
+++ b/iModelCore/ECPresentation/Tests/NonPublished/Integration/Content/ContentIntegrationTests.cpp
@@ -508,6 +508,50 @@ TEST_F(RulesDrivenECPresentationManagerContentTests, SelectedNodeInstances_GetsV
     }
 
 /*---------------------------------------------------------------------------------**//**
+* @bsitest
++---------------+---------------+---------------+---------------+---------------+------*/
+DEFINE_SCHEMA(SelectedNodeInstances_GetsValidContentForClassWithNullProperty, R"*(
+    <ECEntityClass typeName="A">
+        <ECProperty propertyName="Null" typeName="string" />
+    </ECEntityClass>
+)*");
+TEST_F(RulesDrivenECPresentationManagerContentTests, SelectedNodeInstances_GetsValidContentForClassWithNullProperty)
+    {
+    // set up the dataset
+    ECEntityClassCP classA = GetClass("A")->GetEntityClassCP();
+    IECInstancePtr instanceA = RulesEngineTestHelpers::InsertInstance(s_project->GetECDb(), *classA, [](IECInstanceR instance) { instance.SetValue("Null", ECValue("stringVal")); });
+
+    // set up input
+    KeySetPtr input = KeySet::Create(bvector<IECInstancePtr>{instanceA});
+
+    // create the rule set
+    PresentationRuleSetPtr rules = PresentationRuleSet::CreateInstance(BeTest::GetNameOfCurrentTest());
+    m_locater->AddRuleSet(*rules);
+
+    ContentRuleP contentRule = new ContentRule("", 1, false);
+    contentRule->AddSpecification(*new SelectedNodeInstancesSpecification());
+    rules->AddPresentationRule(*contentRule);
+
+    // validate descriptor
+    ContentDescriptorCPtr descriptor = GetValidatedResponse(m_manager->GetContentDescriptor(AsyncContentDescriptorRequestParams::Create(s_project->GetECDb(), rules->GetRuleSetId(), RulesetVariables(), nullptr, 0, *input)));
+    ASSERT_TRUE(descriptor.IsValid());
+    EXPECT_EQ(1, descriptor->GetVisibleFields().size());
+
+    // request for content
+    ContentCPtr content = GetVerifiedContent(*descriptor);
+    ASSERT_TRUE(content.IsValid());
+
+    // validate content set
+    DataContainer<ContentSetItemCPtr> contentSet = content->GetContentSet();
+    ASSERT_EQ(1, contentSet.GetSize());
+
+    rapidjson::Document jsonDoc = contentSet.Get(0)->AsJson();
+    RapidJsonValueCR jsonValues = jsonDoc["Values"];
+    EXPECT_TRUE(jsonValues.HasMember(FIELD_NAME(classA, "Null")));
+    EXPECT_STREQ("stringVal", jsonValues[FIELD_NAME(classA, "Null")].GetString());
+    }
+
+/*---------------------------------------------------------------------------------**//**
 // @betest
 +---------------+---------------+---------------+---------------+---------------+------*/
 DEFINE_SCHEMA(DescriptorOverride_WithSortingFieldAndOrder, R"*(
@@ -5661,7 +5705,7 @@ TEST_F(RulesDrivenECPresentationManagerContentTests, SelectedNodeInstancesSpecif
         new RelationshipStepSpecification(relationshipAHasB->GetFullName(), RequiredRelationDirection_Forward, classB->GetFullName())
         }), { new PropertySpecification("*") }, RelationshipMeaning::RelatedInstance, true));
     rules->AddPresentationRule(*relatedPropertiesModifier);
-    
+
     ContentModifierP calculatedPropertiesModifierApplyOnNestedB = new ContentModifier(GetSchema()->GetName(), classB->GetName());
     calculatedPropertiesModifierApplyOnNestedB->AddCalculatedProperty(*new CalculatedPropertiesSpecification("Test calculated property", 1000, "this.PropertyB"));
     calculatedPropertiesModifierApplyOnNestedB->SetApplyOnNestedContent(true);
@@ -5677,7 +5721,7 @@ TEST_F(RulesDrivenECPresentationManagerContentTests, SelectedNodeInstancesSpecif
     ContentDescriptor::Field* relatedContentField = descriptor->GetVisibleFields()[0];
     ContentDescriptor::Field* calculatedField = relatedContentField->AsNestedContentField()->GetFields()[1];
     EXPECT_STREQ("Test calculated property", calculatedField->GetLabel().c_str());
-    
+
     // request for content
     ContentCPtr content = GetVerifiedContent(*descriptor);
     ASSERT_TRUE(content.IsValid());
@@ -6559,7 +6603,7 @@ TEST_F(RulesDrivenECPresentationManagerContentTests, SelectedNodeInstancesSpecif
 
     // insert some instances
     IECInstancePtr instanceA = RulesEngineTestHelpers::InsertInstance(s_project->GetECDb(), *classA);
-    
+
     // set up input
     KeySetPtr input = KeySet::Create(*instanceA);
 


### PR DESCRIPTION
Fixes https://github.com/iTwin/imodel-native/issues/1549