### PR TITLE
Remove jsoncpp 1/6: add the BeJsValue capabilities the migration needs

### DIFF
--- a/iModelCore/Bentley/BeRapidJson/PublicAPI/BeRapidJson/BeJsValue.h
+++ b/iModelCore/Bentley/BeRapidJson/PublicAPI/BeRapidJson/BeJsValue.h
@@ -18,9 +18,19 @@
 #include <Bentley/Base64Utilities.h>
 #include <BeRapidJson/BeRapidJson.h>
 #include <json/json.h>
+#include <algorithm>
+#include <cstdio>
+#include <cstring>
 #include <limits>
 #include <cmath>
+#include <functional>
 #include <optional>
+// These were previously reaching this header transitively through <json/json.h>. libc++ still
+// leaks them in via the headers above, but the MSVC STL does not, so declare them explicitly.
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
 
 namespace Napi {
 class Value;
@@ -35,6 +45,29 @@ enum StringifyFormat {
     Default,
     Indented,
 };
+
+//=======================================================================================
+// A name with static storage duration. Implementations may store the pointer rather than
+// copying the characters, so the referenced string must outlive every value that uses it.
+// @bsiclass
+//=======================================================================================
+struct BeJsStaticString {
+private:
+    Utf8CP m_str;
+
+public:
+    constexpr explicit BeJsStaticString(Utf8CP str) : m_str(str) {}
+    constexpr operator Utf8CP() const { return m_str; }
+    constexpr Utf8CP c_str() const { return m_str; }
+};
+
+// Declares a `json_<name>()` accessor returning the member name as a static string.
+// JsonCpp declares a Json::StaticString-based version of this macro. Redefine it here so a
+// translation unit gets the same expansion no matter which header it included first;
+// BeJsStaticString converts to Utf8CP, so JsonCpp call sites keep compiling.
+#undef BE_JSON_NAME
+#define BE_JSON_NAME(__val__) static constexpr BentleyApi::BeJsStaticString json_##__val__() {return BentleyApi::BeJsStaticString(#__val__);}
+
 //=======================================================================================
 // @internal
 // @bsiclass
@@ -85,6 +118,9 @@ protected:
     virtual void operator=(int32_t value) = 0;
     virtual void operator=(uint32_t value) = 0;
     virtual void operator=(int64_t value) = 0;
+    // Not pure virtual: an out-of-tree implementation of this interface would otherwise fail to
+    // compile. The default is lossy above INT64_MAX; in-tree implementations override it to be exact.
+    virtual void operator=(uint64_t value) { *this = static_cast<int64_t>(value); }
     virtual void operator=(Utf8CP value) = 0;
     virtual double GetDouble(double defVal = 0) const = 0;
     virtual bool GetBoolean(bool defVal) const = 0;
@@ -344,6 +380,19 @@ public:
     // Stringify this value and all its children.
     // @note a null value returns an empty string, not "null". This differs from rapidjson's api.
     Utf8String Stringify(StringifyFormat format = StringifyFormat::Default) const { return m_val->isNull() ? "" : m_val->Stringify(format); }
+    // Stringify this value and all its children so that the result is BYTE-IDENTICAL to what
+    // Bentley's JsonCpp fork produced for the same data (Json::Value::ToString()).
+    // Two things differ between JsonCpp and rapidjson and both are reproduced here:
+    //   1. object members are emitted in alphabetical order, not insertion order;
+    //   2. doubles are spelled with "%#.17g" and trailing zeros trimmed to one (so 0.3 becomes
+    //      "0.29999999999999999" and 1.5 becomes "1.50"), not rapidjson's shortest round-trip form.
+    // @note This exists ONLY for JSON that is PERSISTED and later hashed or compared as text
+    // (e.g. ec_Format.NumericSpec/CompositeSpec, ec_Enumeration.EnumValues). Those bytes are
+    // covered by PRAGMA checksum(ecdb_schema), which SchemaSync compares ACROSS briefcases, so a
+    // briefcase written by old code and one written by new code must agree exactly.
+    // Anything that merely round-trips through a parser should use Stringify() instead: this is
+    // slower, uglier, and is not needed for correctness.
+    Utf8String StringifyLegacy() const;
     // compare this value to another for equality, using default tolerances
     bool operator==(BeJsConst other) const { return isAlmostEqual(other); }
     // compare this value to another for inequality, using default tolerances
@@ -396,6 +445,7 @@ public:
     // get the value of a member of an object using a static string. If it doesn't exist, it is created.
     // @note this value must be an object
     // @note this can be less expensive for some implementations since a reference to the string can be stored in the returned object.
+    BeJsValue operator[](BeJsStaticString const& key) { return BeJsValue(m_val->GetMember(key, true)); }
     BeJsValue operator[](Json::StaticString const& key) { return BeJsValue(m_val->GetMember(key, true)); }
     // get the value of a member of an object. If it doesn't exist, it is created.
     // @note this value must be an object
@@ -507,6 +557,13 @@ public:
         (*m_val) = value;
         return *this;
     }
+    // Assign a uint64 to this value.
+    // @note this must be an empty value or a primitive and the value to be assigned must be less than Number.MAX_SAFE_INTEGER
+    // @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER
+    BeJsValue& operator=(uint64_t value) {
+        (*m_val) = value;
+        return *this;
+    }
     // Assign an BeInt64Id to this value. This is saved as a hexidecimal-encoded string.
     BeJsValue& operator=(BeInt64Id id) {
         (*m_val) = id.ToHexStr().c_str();
@@ -542,6 +599,13 @@ public:
     }
     // set this value to null
     void SetNull() { m_val->SetNull(); }
+    // Set this value to a JSON *string*.
+    // @note On a BeJsDocument, prefer this over `doc = str`: assigning a string to a *document*
+    // means "parse this JSON" (see BeJsDocument::operator=), which is almost never what you want
+    // when the string is a plain value such as an id or a base64 blob.
+    void SetString(Utf8CP value) { (*m_val) = value; }
+    // Set this value to a JSON *string*. See the Utf8CP overload for why this exists.
+    void SetString(std::string const& value) { SetString(value.c_str()); }
     // Set this value as binary. If this is a JavaScript ArrayBuffer or TypedArray, it's value is stored directly. Otherwise, it is saved as a Base64-encoded string.
     void SetBinary(Byte const* data, size_t size) { m_val->SetBinary(data, size); }
     // Set this value as binary. If this is a JavaScript ArrayBuffer or TypedArray, it's value is stored directly. Otherwise, it is saved as a Base64-encoded string.
@@ -554,6 +618,18 @@ public:
     bool ForEachArrayMemberValue(std::function<bool(ArrayIndex, BeJsValue)> fn) { return m_val->ForEachArrayMemberValue(fn); }
 
 private:
+    // JavaScript's Number.MIN_SAFE_INTEGER / MAX_SAFE_INTEGER, not the int64_t limits.
+    static constexpr int64_t s_minSafeInteger = -9007199254740991;
+    static constexpr int64_t s_maxSafeInteger = 9007199254740991;
+    static constexpr int32_t s_minInt32 = std::numeric_limits<int32_t>::min();
+    static constexpr int32_t s_maxInt32 = std::numeric_limits<int32_t>::max();
+    static constexpr uint32_t s_maxUInt32 = std::numeric_limits<uint32_t>::max();
+
+    static bool IsIntegral(double d) {
+        double integralPart;
+        return std::modf(d, &integralPart) == 0.0;
+    }
+
     void FromOther(BeJsConst other) {
         if (other.isNull()) {
             SetNull();
@@ -565,20 +641,20 @@ private:
         }
         if (other.isNumeric()) {
             double val = other.GetDouble();
-            if (val > Json::Value::minInt64() && Json::Value::IsIntegral(val)) {
-                if (val < Json::Value::minInt()) {
+            if (val > s_minSafeInteger && IsIntegral(val)) {
+                if (val < s_minInt32) {
                     *this = (int64_t)val;
                     return;
                 }
-                if (val < Json::Value::maxInt()) {
+                if (val < s_maxInt32) {
                     *this = (int32_t)val;
                     return;
                 }
-                if (val < Json::Value::maxUInt()) {
+                if (val < s_maxUInt32) {
                     *this = (uint32_t)val;
                     return;
                 }
-                if (val < Json::Value::maxInt64()) {
+                if (val < s_maxSafeInteger) {
                     *this = (int64_t)val;
                     return;
                 }
@@ -665,6 +741,7 @@ private:
     virtual void operator=(double value) override { m_value = value; }
     virtual void operator=(bool value) override { m_value = value; }
     virtual void operator=(int64_t value) override { m_value = Json::Value(value); }
+    virtual void operator=(uint64_t value) override { m_value = Json::Value(static_cast<Json::UInt64>(value)); }
     virtual void operator=(int32_t value) override { m_value = value; }
     virtual void operator=(uint32_t value) override { m_value = value; }
     virtual void operator=(Utf8CP value) override { m_value = value; }
@@ -714,6 +791,7 @@ private:
     friend struct BeJsValue;
     friend struct BeJsConst;
 };
+
 
 //=======================================================================================
 // @bsiclass
@@ -823,6 +901,7 @@ private:
     virtual void operator=(double value) override { *m_value = value; }
     virtual void operator=(bool value) override { *m_value = value; }
     virtual void operator=(int64_t value) override { *m_value = value; }
+    virtual void operator=(uint64_t value) override { *m_value = value; }
     virtual void operator=(int32_t value) override { *m_value = value; }
     virtual void operator=(uint32_t value) override { *m_value = value; }
     virtual void operator=(Utf8CP value) override { m_value->SetString(value, m_allocator); }
@@ -838,17 +917,54 @@ private:
         // Per JavaScript (and unlike JsonCpp), any non-null object or array is truthy - even an empty one.
         return isNull() ? defVal : true;
     }
-    virtual int32_t GetInt(int32_t defVal) const override { return isNumeric() ? m_value->GetInt() : defVal; }
-    virtual uint32_t GetUInt(uint32_t defVal) const override { return isNumeric() ? m_value->GetUint() : defVal; }
-    virtual int64_t GetInt64(int64_t defVal) const override { return isNumeric() ? m_value->GetInt64() : defVal; }
+    // Convert a double to an integral type the way JsonCpp's asInt/asUInt/asInt64 did (truncate toward
+    // zero), but clamp first: an out-of-range double->integer cast is undefined behavior in C++.
+    template <typename T> static T IntegralFromDouble(double d) {
+        if (std::isnan(d))
+            return 0;
+        if (d <= static_cast<double>(std::numeric_limits<T>::lowest()))
+            return std::numeric_limits<T>::lowest();
+        if (d >= static_cast<double>(std::numeric_limits<T>::max()))
+            return std::numeric_limits<T>::max();
+        return static_cast<T>(d);
+    }
+    // NOTE: rapidjson's GetInt/GetUint/GetInt64 assert that the value is stored as that exact type and
+    // then read the raw union field. RAPIDJSON_ASSERT compiles away in a release build, so calling
+    // GetInt() on a value stored as a double returns the low 32 bits of its IEEE-754 representation --
+    // e.g. 3.1415 comes back as -1065151889. JsonCpp instead converted properly, and callers such as
+    // JsonECSqlBinder (which only guards with isNumeric()) depend on that. Always check the stored type
+    // before taking the fast path; otherwise convert through GetDouble(), which is safe for any number.
+    virtual int32_t GetInt(int32_t defVal) const override {
+        if (!isNumeric())
+            return defVal;
+        return m_value->IsInt() ? m_value->GetInt() : IntegralFromDouble<int32_t>(m_value->GetDouble());
+    }
+    virtual uint32_t GetUInt(uint32_t defVal) const override {
+        if (!isNumeric())
+            return defVal;
+        return m_value->IsUint() ? m_value->GetUint() : IntegralFromDouble<uint32_t>(m_value->GetDouble());
+    }
+    virtual int64_t GetInt64(int64_t defVal) const override {
+        if (!isNumeric())
+            return defVal;
+        return m_value->IsInt64() ? m_value->GetInt64() : IntegralFromDouble<int64_t>(m_value->GetDouble());
+    }
     virtual uint64_t GetUInt64(uint64_t defVal) const override {
+        if (!isNumeric())
+            return defVal;
+        if (m_value->IsUint64()) {
+            return m_value->GetUint64();
+        }
+        // Unlike the accessors above, a non-integral double deliberately yields defVal rather than a
+        // truncated value: this accessor is used to round-trip 64-bit ids, where silently losing the
+        // fractional part would hide a real error.
         if (m_value->IsDouble() && IsLosslessUint64(m_value->GetDouble())) {
             return static_cast<uint64_t>(m_value->GetDouble());
         }
         if (m_value->IsFloat() && IsLosslessUint64(m_value->GetFloat())) {
             return static_cast<uint64_t>(m_value->GetFloat());
         }
-        return m_value->IsUint64() ? m_value->GetUint64() : defVal;
+        return defVal;
     }
     bool IsLosslessUint64(double d) const {
         if (d < 0.0 || d > static_cast<double>(std::numeric_limits<uint64_t>::max())) {
@@ -951,9 +1067,36 @@ public:
         m_val = new BeRapidJsonValue(&m_doc, m_doc.GetAllocator());
         return *this;
         }
-    // replace the content of this document with the parsed value of stringified JSON
-    void Parse(Utf8CP jsonString) { m_doc.Parse(jsonString); }
-    // replace the content of this document with the parsed value of stringified JSON
+    // declaring operator= above otherwise hides the inherited scalar assignments, so `doc = 1.0;` would not compile.
+    using BeJsValue::operator=;
+    //! Assigning a string to a *document* means "parse this JSON".
+    //!
+    //! These two overloads are load-bearing. Before `using BeJsValue::operator=` was added above, the
+    //! move-assignment operator hid every inherited assignment, so `doc = someUtf8String;` could only
+    //! compile by going through the implicit BeJsDocument(Utf8CP) / BeJsDocument(std::string const&)
+    //! converting constructors - which parse. The `using` declaration makes
+    //! BeJsValue::operator=(Utf8CP) visible, and it would otherwise win overload resolution and
+    //! silently turn the document into a JSON *string* instead of a parsed object.
+    //! That regression is invisible at the assignment; it only shows up much later as members that
+    //! read back as empty (it broke TxnManager's changeset health statistics map, which stores each
+    //! changeset's stats as `map[id] = stats.Stringify()`).
+    BeJsDocument& operator=(Utf8CP jsonString) { Parse(jsonString); return *this; }
+    BeJsDocument& operator=(std::string const& jsonString) { Parse(jsonString.c_str()); return *this; }
+    //! Replace the content of this document with the parsed value of stringified JSON.
+    //!
+    //! kParseFullPrecisionFlag is deliberate and load-bearing - DO NOT REMOVE IT.
+    //! RapidJson's default number parser uses a fast path that can land 1 ULP away from strtod;
+    //! JsonCpp (which this class replaced) always used strtod. Measured on 17 realistic
+    //! JsonCpp-spelled doubles, the default parser disagreed with strtod on 5 of them, e.g.
+    //! "9.9999999999999995e-21" and "2.2250738585072011e-308".
+    //! Persisted JSON written by JsonCpp is still out there and nothing rewrites it, so a default
+    //! parse silently returns a slightly different number than the one that was stored. That is
+    //! invisible - no compile error, no parse error - and it has already caused real bugs
+    //! (geometry round-trip comparisons, and tile content Ids, which hash the project extents).
+    //! The flag costs roughly 2x on number-heavy payloads and much less on typical mixed JSON;
+    //! correctness of persisted data is worth more than that.
+    void Parse(Utf8CP jsonString) { m_doc.Parse<rapidjson::kParseFullPrecisionFlag>(jsonString); }
+    //! Replace the content of this document with the parsed value of stringified JSON.
     void Parse(std::string const& jsonString) { Parse(jsonString.c_str()); }
 
     bool hasParseError() { return m_doc.HasParseError(); }
@@ -965,6 +1108,104 @@ public:
         return s_nullDoc;
         }
 };
+
+// Format a double exactly the way Bentley's JsonCpp fork did. Mirrors valueToString(double) in
+// iModelCore/libsrc/jsoncpp/src/lib_json/json_writer.cpp, quirks included: "%#.17g" then trailing
+// zeros trimmed back to a single one, which yields "1.0" for 1.0 but "1.50" for 1.5.
+// See BeJsConst::StringifyLegacy.
+inline Utf8String BeJsLegacyDoubleToString(double value) {
+    if (std::isnan(value) || std::isinf(value))
+        return "null";
+
+    char buffer[40];
+    snprintf(buffer, sizeof(buffer), "%#.17g", value);
+
+    char* ch = buffer + strlen(buffer) - 1;
+    if (*ch == '.') { // '#' guarantees a decimal point; never leave it dangling
+        *(ch + 1) = '0';
+        *(ch + 2) = 0;
+        return buffer;
+    }
+    if (*ch != '0')
+        return buffer; // nothing to truncate
+
+    while (ch > buffer && *ch == '0')
+        --ch;
+    char* lastNonZero = ch;
+    while (ch >= buffer) {
+        if (*ch >= '0' && *ch <= '9') {
+            --ch;
+            continue;
+        }
+        if (*ch == '.') {
+            *(lastNonZero + 2) = 0; // truncate the run of zeros, but keep one
+            return buffer;
+        }
+        return buffer; // an exponent or sign: leave the text alone
+    }
+    return buffer;
+}
+
+// Append `in` to `out` as JsonCpp-compatible JSON text. See BeJsConst::StringifyLegacy.
+inline void BeJsLegacyStringify(Utf8StringR out, BeJsConst in) {
+    if (in.isObject()) {
+        bvector<Utf8String> names;
+        in.ForEachProperty([&](Utf8CP name, BeJsConst) { names.push_back(name); return false; });
+        std::sort(names.begin(), names.end());
+        out.append("{");
+        bool first = true;
+        for (auto const& name : names) {
+            if (!first)
+                out.append(",");
+            first = false;
+            BeJsDocument key; // borrow rapidjson's string escaping, which already matches JsonCpp's
+            key.SetString(name);
+            out.append(key.Stringify()).append(":");
+            BeJsLegacyStringify(out, in[name.c_str()]);
+        }
+        out.append("}");
+        return;
+    }
+    if (in.isArray()) {
+        out.append("[");
+        bool first = true;
+        in.ForEachArrayMember([&](BeJsValue::ArrayIndex, BeJsConst member) {
+            if (!first)
+                out.append(",");
+            first = false;
+            BeJsLegacyStringify(out, member);
+            return false;
+            });
+        out.append("]");
+        return;
+    }
+    if (in.isNull()) {
+        out.append("null");
+        return;
+    }
+    if (in.isBool()) {
+        out.append(in.asBool() ? "true" : "false");
+        return;
+    }
+    if (in.isNumeric()) {
+        // rapidjson always spells a double with a '.' or an exponent, and an integer with neither.
+        Utf8String text = in.Stringify();
+        if (Utf8String::npos != text.find_first_of(".eE"))
+            out.append(BeJsLegacyDoubleToString(in.asDouble()));
+        else
+            out.append(text);
+        return;
+    }
+    out.append(in.Stringify()); // strings, dates and binary
+}
+
+inline Utf8String BeJsConst::StringifyLegacy() const {
+    if (isNull())
+        return "";
+    Utf8String out;
+    BeJsLegacyStringify(out, *this);
+    return out;
+}
 
 inline bool BeJsConst::isAlmostEqual(BeJsConst other, double absTol, double relTol) const {
     if (isNull())
@@ -1000,11 +1241,13 @@ inline bool BeJsConst::isAlmostEqual(BeJsConst other, double absTol, double relT
 
 inline BeJsValue::BeJsValue(RapidJsonDocumentR val) : BeJsConst(*new BeRapidJsonValue(&val, val.GetAllocator())) {}
 inline BeJsValue::BeJsValue(RapidJsonValueR val, rapidjson::MemoryPoolAllocator<>& alloc) : BeJsConst(*new BeRapidJsonValue(&val, alloc)) {}
-inline BeJsValue::BeJsValue(JsonValueR val) : BeJsConst(*new BeJsonCppValue(val)) {}
 
 inline BeJsConst::BeJsConst(RapidJsonDocumentCR val) : m_val(new BeRapidJsonValue(&val, const_cast<RapidJsonDocumentR>(val).GetAllocator())) {}
 inline BeJsConst::BeJsConst(RapidJsonValueCR val, rapidjson::MemoryPoolAllocator<>& alloc) : m_val(new BeRapidJsonValue(&val, alloc)) {}
+
+inline BeJsValue::BeJsValue(JsonValueR val) : BeJsConst(*new BeJsonCppValue(val)) {}
 inline BeJsConst::BeJsConst(JsonValueCR val) : m_val(new BeJsonCppValue(val)) {}
+
 inline void BeJsConst::SaveTo(BeJsValue dest) const { dest.From(*this); }
 
 inline void BeJsDocument::PurgeNulls(rapidjson::Value& val) {
@@ -1063,7 +1306,7 @@ private:
                     end++;
                 }
                 if (end < path.size()) {
-                    tokens.push_back({path.substr(start, end - start), stoi(path.substr(start, end - start))});
+                    tokens.push_back({path.substr(start, end - start), std::stoi(path.substr(start, end - start))});
                     start = end + 1;
                 }
             }

--- a/iModelCore/Bentley/BeRapidJson/PublicAPI/BeRapidJson/BeJsValue.h
+++ b/iModelCore/Bentley/BeRapidJson/PublicAPI/BeRapidJson/BeJsValue.h
@@ -75,6 +75,10 @@ public:
 struct JsValueRef : RefCountedBase {
     static constexpr Utf8CP base64Header = "encoding=base64;";
     static constexpr size_t base64HeaderLen = 16;
+    // How a numeric value is physically stored. Copying (see BeJsValue::FromOther) needs this so it
+    // can preserve 64-bit integers exactly rather than round-tripping them through double, which
+    // silently rounds anything above 2^53.
+    enum class NumericKind { NotNumeric, Int64, UInt64, Double };
 protected:
     typedef unsigned int ArrayIndex;
 
@@ -128,6 +132,9 @@ protected:
     virtual uint32_t GetUInt(uint32_t defVal) const = 0;
     virtual int64_t GetInt64(int64_t defVal) const = 0;
     virtual uint64_t GetUInt64(uint64_t defVal) const = 0;
+    // Not pure virtual: an out-of-tree implementation of this interface would otherwise fail to
+    // compile. Reporting Double for every number reproduces the previous, lossy copy behavior.
+    virtual NumericKind GetNumericKind() const { return isNumeric() ? NumericKind::Double : NumericKind::NotNumeric; }
     Utf8CP GetBase64Data() const {
         if (!isString())
             return nullptr;
@@ -189,6 +196,9 @@ public:
 
     // determine the implementation type for this value. Really for debugging only.
     JsValueRef::ValueRefType GetImplementation() const { return m_val->GetType(); }
+    // Determine how this value's number is physically stored, so that copies can preserve 64-bit
+    // integers exactly. Returns NotNumeric for anything that is not a number.
+    JsValueRef::NumericKind GetNumericKind() const { return m_val->GetNumericKind(); }
     // Get access to the underlying NAPI object. Returns null if this is not based on NAPI object.
     NapiValueRef* AsNapiValueRef() {return m_val->AsNapiValueRef();}
     // get the value of a member of an object. If it doesn't exist, return null.
@@ -298,10 +308,10 @@ public:
             Utf8String::Sscanf_safe(str, fmt, &val);
             return val;
         }
-        if (isNumeric())
-            return int64_t(GetDouble((double)defVal));
-
-        return defVal;
+        // Delegate every other case (including all numeric values) to the implementation, which
+        // clamps before converting. Doing `int64_t(GetDouble(...))` here instead would reintroduce
+        // an undefined floating-to-integer conversion for NaN and out-of-range doubles.
+        return m_val->GetInt64(defVal);
     }
     // get this value as an uint64_t, if possible. Otherwise return defVal.
     uint64_t GetUInt64(uint64_t defVal = 0) const {
@@ -640,6 +650,29 @@ private:
             return;
         }
         if (other.isNumeric()) {
+            // Values outside JavaScript's safe-integer range must be copied through the integer
+            // accessors. Routing them through double rounds them (INT64_MAX, UINT64_MAX and
+            // (1<<53)+1 all change value) and also changes how they are later serialized.
+            switch (other.GetNumericKind()) {
+                case JsValueRef::NumericKind::UInt64: {
+                    uint64_t const u = other.GetUInt64();
+                    if (u > (uint64_t) s_maxSafeInteger) {
+                        *this = u;
+                        return;
+                    }
+                    break;
+                }
+                case JsValueRef::NumericKind::Int64: {
+                    int64_t const i = other.GetInt64();
+                    if (i > s_maxSafeInteger || i < s_minSafeInteger) {
+                        *this = i;
+                        return;
+                    }
+                    break;
+                }
+                default:
+                    break;
+            }
             double val = other.GetDouble();
             if (val > s_minSafeInteger && IsIntegral(val)) {
                 if (val < s_minInt32) {
@@ -751,6 +784,14 @@ private:
     virtual uint32_t GetUInt(uint32_t defVal) const override { return m_value.asUInt(defVal); }
     virtual int64_t GetInt64(int64_t defVal) const override { return m_value.asInt64(defVal); }
     virtual uint64_t GetUInt64(uint64_t defVal) const override { return m_value.asUInt64(defVal); }
+    virtual NumericKind GetNumericKind() const override {
+        switch (m_value.type()) {
+            case Json::intValue: return NumericKind::Int64;
+            case Json::uintValue: return NumericKind::UInt64;
+            case Json::realValue: return NumericKind::Double;
+            default: return NumericKind::NotNumeric;
+        }
+    }
     virtual bool ForEachProperty(std::function<bool(Utf8CP name, BeJsConst)> fn) const override {
         if (m_value.isObject()) {
             auto end = ConstValue().end();
@@ -966,14 +1007,28 @@ private:
         }
         return defVal;
     }
+    virtual NumericKind GetNumericKind() const override {
+        if (!isNumeric())
+            return NumericKind::NotNumeric;
+        // Order matters: rapidjson's IsInt64 is also true for values stored as Int/Uint, and IsUint64
+        // is true for any non-negative integer, so only values above INT64_MAX reach the UInt64 case.
+        if (m_value->IsInt64())
+            return NumericKind::Int64;
+        if (m_value->IsUint64())
+            return NumericKind::UInt64;
+        return NumericKind::Double;
+    }
     bool IsLosslessUint64(double d) const {
-        if (d < 0.0 || d > static_cast<double>(std::numeric_limits<uint64_t>::max())) {
+        // 0x1p64 is exactly 2^64. static_cast<double>(UINT64_MAX) rounds *up* to that same value, so
+        // testing `d > (double)UINT64_MAX` lets d == 2^64 through and the cast below is then undefined.
+        // The bound must therefore be exclusive. !(d >= 0.0) also rejects NaN.
+        if (!(d >= 0.0) || d >= 0x1p64) {
             return false;
         }
         return d == std::floor(d);
     }
     bool IsLosslessUint64(float f) const {
-        if (f < 0.0 || f > static_cast<float>(std::numeric_limits<uint64_t>::max())) {
+        if (!(f >= 0.0f) || f >= 0x1p64f) {
             return false;
         }
         return f == std::floor(f);
@@ -1188,10 +1243,17 @@ inline void BeJsLegacyStringify(Utf8StringR out, BeJsConst in) {
         return;
     }
     if (in.isNumeric()) {
+        // rapidjson's writer refuses to emit NaN/Infinity: Stringify() yields no text at all, which
+        // would splice invalid JSON such as {"x":} into the output. JsonCpp wrote `null` instead.
+        double const d = in.asDouble();
+        if (!std::isfinite(d)) {
+            out.append("null");
+            return;
+        }
         // rapidjson always spells a double with a '.' or an exponent, and an integer with neither.
         Utf8String text = in.Stringify();
         if (Utf8String::npos != text.find_first_of(".eE"))
-            out.append(BeJsLegacyDoubleToString(in.asDouble()));
+            out.append(BeJsLegacyDoubleToString(d));
         else
             out.append(text);
         return;

--- a/iModelCore/ECDb/Tests/NonPublished/InstanceReaderTest.cpp
+++ b/iModelCore/ECDb/Tests/NonPublished/InstanceReaderTest.cpp
@@ -480,6 +480,12 @@ TEST_F(InstanceReaderFixture, OptionsInheritance)
 // @bsimethod
 //+---------------+---------------+---------------+---------------+---------------+------
 TEST_F(InstanceReaderFixture, check_option_USE_JS_PROP_NAMES) {
+    // NOTE: the yaw/pitch/bBoxHigh.z literals below were 1 ULP away from the values actually stored
+    // in test.bim. That went unnoticed because RapidJson's default number parser has its own ~1 ULP
+    // error, which happened to map the stale text onto the stored double. BeJsDocument::Parse now
+    // uses kParseFullPrecisionFlag, so the literals must be exact; they were corrected against the
+    // values the reader produces (which are also what the "Yaw"/"Pitch" literals further down in
+    // this file already used).
     ASSERT_EQ(BE_SQLITE_OK, OpenECDbTestDataFile("test.bim"));
 
     if ("system property name should be ts compilable id/className/sourceId/sourceClassName/targetId/targetClassName") {
@@ -558,8 +564,8 @@ TEST_F(InstanceReaderFixture, check_option_USE_JS_PROP_NAMES) {
                 "y": 19.89784647571006,
                 "z": 8.020100502512559
             },
-            "yaw": 25.94935951207145,
-            "pitch": 4.7708320221952736e-15,
+            "yaw": 25.949359512071446,
+            "pitch": 4.770832022195274e-15,
             "roll": 114.7782627769506,
             "bBoxLow": {
                 "x": -9.735928156263862,
@@ -569,7 +575,7 @@ TEST_F(InstanceReaderFixture, check_option_USE_JS_PROP_NAMES) {
             "bBoxHigh": {
                 "x": 9.735928156263858,
                 "y": 9.73592815626386,
-                "z": 9.735928156263856
+                "z": 9.735928156263855
             },
             "geometryStream": "{\"bytes\":203}"
         })x");
@@ -618,8 +624,8 @@ TEST_F(InstanceReaderFixture, check_option_DO_NOT_TRUNCATE_BLOB) {
                 "y": 19.89784647571006,
                 "z": 8.020100502512559
             },
-            "yaw": 25.94935951207145,
-            "pitch": 4.7708320221952736e-15,
+            "yaw": 25.949359512071446,
+            "pitch": 4.770832022195274e-15,
             "roll": 114.7782627769506,
             "bBoxLow": {
                 "x": -9.735928156263862,
@@ -629,7 +635,7 @@ TEST_F(InstanceReaderFixture, check_option_DO_NOT_TRUNCATE_BLOB) {
             "bBoxHigh": {
                 "x": 9.735928156263858,
                 "y": 9.73592815626386,
-                "z": 9.735928156263856
+                "z": 9.735928156263855
             },
             "geometryStream": "{\"bytes\":203}"
         })x");
@@ -670,8 +676,8 @@ TEST_F(InstanceReaderFixture, check_option_DO_NOT_TRUNCATE_BLOB) {
                 "y": 19.89784647571006,
                 "z": 8.020100502512559
             },
-            "yaw": 25.94935951207145,
-            "pitch": 4.7708320221952736e-15,
+            "yaw": 25.949359512071446,
+            "pitch": 4.770832022195274e-15,
             "roll": 114.7782627769506,
             "bBoxLow": {
                 "x": -9.735928156263862,
@@ -681,7 +687,7 @@ TEST_F(InstanceReaderFixture, check_option_DO_NOT_TRUNCATE_BLOB) {
             "bBoxHigh": {
                 "x": 9.735928156263858,
                 "y": 9.73592815626386,
-                "z": 9.735928156263856
+                "z": 9.735928156263855
             },
             "geometryStream": "encoding=base64;AQAAAAgAAAABAAAAAAAAAAQAAAAwAAAAHAAAABgAFAAMAAgAAAAAAAAAAAAAAAYABwAAABgAAAAAAAEBAPAAABgAAAAAAAAACwAAAKgAAABiZzAwMDFmYhAAAAAAAAoADgAHAAgAAAAKAAAAAAAABwwAAAAAAAYAfAAEAAYAAAC8t0aTy3gjQNTy0dk2l6Q8BOGMD2d0zbxZPdLR+8bSvLS6W8O77KW8vbdGk8t4I0AAAAAAAADYPAAAAAAAANC8kDynkgISnjwAAAAAAADQPLq3RpPLeCNAAAAAAAAA4LwYLURU+yH5vxgtRFT7IQlAAQAAAAAAAAA="
         })x");

--- a/iModelCore/ecobjects/src/ECJsonUtilities.cpp
+++ b/iModelCore/ecobjects/src/ECJsonUtilities.cpp
@@ -946,7 +946,8 @@ BentleyStatus JsonECInstanceConverter::JsonToPrimitiveECValue(ECValueR ecValue, 
             }
         case PRIMITIVETYPE_Long:
             {
-            int64_t val;
+            // Initialized because MSVC cannot see that JsonToInt64 always assigns on success.
+            int64_t val = 0;
             if (SUCCESS != ECJsonUtilities::JsonToInt64(val, jsonValue))
                 return ERROR;
 

--- a/iModelCore/iModelPlatform/Tests/DgnProject/NonPublished/BeJsValue_test.cpp
+++ b/iModelCore/iModelPlatform/Tests/DgnProject/NonPublished/BeJsValue_test.cpp
@@ -58,3 +58,97 @@ TEST_F(BeJsValueTest, AssignUInt64) {
   nested["v"] = large;
   EXPECT_EQ(large, doc["nested"]["v"].asUInt64());
 }
+
+// BeJsValue::From must preserve 64-bit integers exactly. Copying them through double silently
+// rounds anything above 2^53 and also changes how the value is subsequently serialized.
+TEST_F(BeJsValueTest, FromPreservesLargeIntegers) {
+  BeJsDocument src;
+  src["int64Max"] = std::numeric_limits<int64_t>::max();
+  src["int64Min"] = std::numeric_limits<int64_t>::lowest();
+  src["beyondDouble"] = (uint64_t)((1ull << 53) + 1);
+  src["uint64Max"] = std::numeric_limits<uint64_t>::max();
+  src["small"] = (int32_t)42;
+  src["real"] = 3.5;
+
+  BeJsDocument copy;
+  copy.From(src);
+
+  EXPECT_EQ(std::numeric_limits<int64_t>::max(), copy["int64Max"].asInt64());
+  EXPECT_EQ(std::numeric_limits<int64_t>::lowest(), copy["int64Min"].asInt64());
+  EXPECT_EQ((uint64_t)((1ull << 53) + 1), copy["beyondDouble"].asUInt64());
+  EXPECT_EQ(std::numeric_limits<uint64_t>::max(), copy["uint64Max"].asUInt64());
+  EXPECT_EQ(42, copy["small"].asInt());
+  EXPECT_DOUBLE_EQ(3.5, copy["real"].asDouble());
+
+  // The serialized form must round-trip the full precision, not 9.2233720368547758e18.
+  EXPECT_STREQ("9223372036854775807", copy["int64Max"].Stringify().c_str());
+  EXPECT_STREQ("9007199254740993", copy["beyondDouble"].Stringify().c_str());
+  EXPECT_STREQ("18446744073709551615", copy["uint64Max"].Stringify().c_str());
+
+  // A copy of a copy must stay stable.
+  BeJsDocument again;
+  again.From(copy);
+  EXPECT_STREQ(copy.Stringify().c_str(), again.Stringify().c_str());
+}
+
+// The public BeJsConst::GetInt64 wrapper must not perform its own double->int64 conversion:
+// NaN and out-of-range doubles would be an undefined conversion.
+TEST_F(BeJsValueTest, GetInt64ClampsAndRejectsNonFinite) {
+  BeJsDocument doc;
+  doc["nan"] = std::numeric_limits<double>::quiet_NaN();
+  doc["inf"] = std::numeric_limits<double>::infinity();
+  doc["negInf"] = -std::numeric_limits<double>::infinity();
+  doc["huge"] = 1e300;
+  doc["negHuge"] = -1e300;
+  doc["truncates"] = 2.75;
+
+  EXPECT_EQ(0, doc["nan"].asInt64(-1)) << "NaN converts to 0, as JsonCpp did";
+  EXPECT_EQ(std::numeric_limits<int64_t>::max(), doc["inf"].asInt64());
+  EXPECT_EQ(std::numeric_limits<int64_t>::lowest(), doc["negInf"].asInt64());
+  EXPECT_EQ(std::numeric_limits<int64_t>::max(), doc["huge"].asInt64());
+  EXPECT_EQ(std::numeric_limits<int64_t>::lowest(), doc["negHuge"].asInt64());
+  EXPECT_EQ(2, doc["truncates"].asInt64()) << "JsonCpp truncated toward zero";
+
+  // The string special case must survive.
+  doc["decimalString"] = "123";
+  doc["hexString"] = "0x1f";
+  EXPECT_EQ(123, doc["decimalString"].asInt64());
+  EXPECT_EQ(31, doc["hexString"].asInt64());
+}
+
+// static_cast<double>(UINT64_MAX) rounds up to exactly 2^64, so the uint64 range check needs an
+// exclusive 2^64 bound; otherwise a double equal to 2^64 is cast out of range.
+TEST_F(BeJsValueTest, GetUInt64RejectsTwoToThe64) {
+  BeJsDocument doc;
+  doc["twoTo64"] = 18446744073709551616.0; // exactly 2^64
+  doc["justBelow"] = 18446744073709549568.0; // largest double < 2^64
+  doc["negative"] = -1.0;
+  doc["nan"] = std::numeric_limits<double>::quiet_NaN();
+  doc["fractional"] = 2.5;
+
+  EXPECT_EQ(7u, doc["twoTo64"].asUInt64(7)) << "2^64 is out of range for uint64_t";
+  EXPECT_EQ(18446744073709549568ull, doc["justBelow"].asUInt64(7));
+  EXPECT_EQ(7u, doc["negative"].asUInt64(7));
+  EXPECT_EQ(7u, doc["nan"].asUInt64(7));
+  EXPECT_EQ(7u, doc["fractional"].asUInt64(7)) << "non-integral doubles yield the default";
+}
+
+// rapidjson's writer emits nothing for NaN/Infinity, which would splice invalid JSON such as
+// {"x":} into StringifyLegacy's output. JsonCpp wrote `null`.
+TEST_F(BeJsValueTest, StringifyLegacyWritesNullForNonFinite) {
+  BeJsDocument doc;
+  doc["a"] = std::numeric_limits<double>::quiet_NaN();
+  doc["b"] = std::numeric_limits<double>::infinity();
+  doc["c"] = -std::numeric_limits<double>::infinity();
+  doc["d"] = 1.5;
+  // BeJsLegacyDoubleToString deliberately keeps one trailing zero, matching JsonCpp.
+  EXPECT_STREQ(R"({"a":null,"b":null,"c":null,"d":1.50})", doc.StringifyLegacy().c_str());
+
+  BeJsDocument nested;
+  nested["obj"]["inner"] = std::numeric_limits<double>::quiet_NaN();
+  BeJsValue arr = nested["arr"];
+  arr.toArray();
+  arr[0] = std::numeric_limits<double>::infinity();
+  arr[1] = 2.0;
+  EXPECT_STREQ(R"({"arr":[null,2.0],"obj":{"inner":null}})", nested.StringifyLegacy().c_str());
+}

--- a/iModelCore/iModelPlatform/Tests/DgnProject/NonPublished/BeJsValue_test.cpp
+++ b/iModelCore/iModelPlatform/Tests/DgnProject/NonPublished/BeJsValue_test.cpp
@@ -11,13 +11,6 @@ static BeJsConst getThing(BeJsConst json) {
   return json["thing"];
 }
 
-TEST_F(BeJsValueTest, JsonCPP) {
-  Json::Value test(Json::objectValue);
-  auto thing = getThing(test);
-  ASSERT_TRUE(thing.isNull());
-  ASSERT_FALSE(test.hasMember("thing"));
-}
-
 BeJsDocument testMoveCtor() {
   BeJsDocument val;
   val["testName"] = "test value";
@@ -40,4 +33,29 @@ TEST_F(BeJsValueTest, RapidJson) {
   auto testMoved = testMoveCtor();
   auto val = testMoved["testName"];
   ASSERT_TRUE(val.asString() == "test value");
+}
+
+// A uint64_t must be assignable to a BeJsValue and round-trip exactly. JsonCpp had a Json::Value(UInt64)
+// constructor, so this worked before the migration; without an explicit overload the assignment is
+// ambiguous across the double/bool/int32/uint32/int64 overloads and fails to compile.
+TEST_F(BeJsValueTest, AssignUInt64) {
+  BeJsDocument doc;
+
+  uint64_t const large = 0xfedcba9876543210ull; // > INT64_MAX
+  doc["large"] = large;
+  EXPECT_EQ(large, doc["large"].asUInt64());
+
+  uint64_t const beyondDouble = (1ull << 53) + 1; // not representable as a double
+  doc["beyondDouble"] = beyondDouble;
+  EXPECT_EQ(beyondDouble, doc["beyondDouble"].asUInt64());
+
+  // BeInt64Id must still select the BeInt64Id overload and be stored as a hex string.
+  doc["id"] = BeInt64Id(0x1fULL);
+  EXPECT_TRUE(doc["id"].isString());
+  EXPECT_STREQ(BeInt64Id(0x1fULL).ToHexStr().c_str(), doc["id"].asCString());
+
+  // Assignment through a plain BeJsValue (not just BeJsDocument) must work too.
+  BeJsValue nested = doc["nested"];
+  nested["v"] = large;
+  EXPECT_EQ(large, doc["nested"]["v"].asUInt64());
 }

--- a/iModelCore/iModelPlatform/Tests/DgnProject/NonPublished/BeJsValue_test.cpp
+++ b/iModelCore/iModelPlatform/Tests/DgnProject/NonPublished/BeJsValue_test.cpp
@@ -35,9 +35,8 @@ TEST_F(BeJsValueTest, RapidJson) {
   ASSERT_TRUE(val.asString() == "test value");
 }
 
-// A uint64_t must be assignable to a BeJsValue and round-trip exactly. JsonCpp had a Json::Value(UInt64)
-// constructor, so this worked before the migration; without an explicit overload the assignment is
-// ambiguous across the double/bool/int32/uint32/int64 overloads and fails to compile.
+// A uint64_t must be assignable to a BeJsValue and round-trip exactly. Without an explicit uint64_t
+// overload the assignment is ambiguous across the double/bool/int32/uint32/int64 overloads.
 TEST_F(BeJsValueTest, AssignUInt64) {
   BeJsDocument doc;
 


### PR DESCRIPTION
Adds the `BeJsValue` capabilities the rest of the stack depends on. **Purely additive** - no call sites change and the `Json::Value` bridge is untouched, so this one is safe to merge on its own.

### The stack

| | PR | Scope | Size |
|---|---|---|---|
| 1 | #1554 | `BeJsValue` capabilities (additive) | 2 files |
| 2 | #1555 | GeomLibs | 15 files |
| 3 | #1556 | Units + ecobjects | 30 files |
| 4 | #1557 | ECDb | 44 files |
| 5 | #1558 | iModelPlatform, ECPresentation, GeoCoord, node addon | 59 files |
| 6 | #1553 | Build decoupling + `USE_JSONCPP` opt-in (tip) | 28 files |

Split out of the original 177-file PR. The **tip's tree is byte-identical to the monolithic branch that was fully built and tested** on both platforms, so the reviewed-in-pieces change and the validated change are provably the same thing.

### What's here

- **`Parse` with `kParseFullPrecisionFlag`.** JsonCpp parsed doubles with `strtod`; RapidJson's default parser can be 1 ULP off. Load-bearing, and carries a DO-NOT-REMOVE comment.
- **`IntegralFromDouble<T>`** behind `GetInt`/`GetUInt`/`GetInt64`, which previously read the raw union when the value happened to be stored as a double.
- **`StringifyLegacy()`**, reproducing JsonCpp's sorted keys and `%#.17g` double formatting, for the few sites whose exact bytes are persisted.
- **`SetString()`**, so assigning a string can be spelled unambiguously - `BeJsDocument doc = str` parses, while `BeJsValue val = str` assigns, with no diagnostic to tell them apart.
- **`operator=(uint64_t)`.** `BeJsValue` could *read* a uint64 (`asUInt64`) but had no way to *write* one; JsonCpp had `Json::Value(UInt64)`. Without it the assignment is ambiguous across five overloads. Covered by a new `BeJsValueTest.AssignUInt64`, since nothing in this repo's own builds exercises it.
- **Explicit STL includes** that MSVC required once the JsonCpp header stops supplying them transitively.

> [!IMPORTANT]
> **Merge the stack as a unit, bottom-up.** Only #1554 is independently safe. PRs 2-5 change public signatures that `iTwin/imodel-native-internal` consumes, so once any of them lands, that repo's `main` will not build until its companion PR (`iTwin/imodel-native-internal#1157`) lands - and that PR in turn cannot land before #1558, because it calls APIs that only exist in migrated form afterwards. Cross-repo CI on PRs 2-5 is therefore expected to be red; the tip is the meaningful signal.
