### PR TITLE
Do not fail changeset apply on historical orphan custom attributes

### DIFF
--- a/iModelCore/ECDb/ECDb/DbMapValidator.cpp
+++ b/iModelCore/ECDb/ECDb/DbMapValidator.cpp
@@ -77,12 +77,16 @@ BentleyStatus DbMapValidator::ValidateCustomAttributeTable() const {
         BeAssert(false);
         return ERROR;
     }
+    // Orphan rows can only originate from history written by older versions of the software. When replaying
+    // already accepted timeline changes we must not fail, but we still report the rows so the condition stays
+    // diagnosable. See https://github.com/iTwin/itwinjs-backlog/issues/2331
+    const auto severity = m_mode == DbMapValidationMode::ChangesetApply ? IssueSeverity::Warning : IssueSeverity::Error;
     int nOrphanRows = 0;
     int remainingIssuesToReport = 3;
     while (caStmt.Step() == BE_SQLITE_ROW) {
         if (remainingIssuesToReport > 0 ) {
             Issues().ReportV(
-                IssueSeverity::Error,
+                severity,
                 IssueCategory::BusinessProperties,
                 IssueType::ECDbIssue,
                 ECDbIssueId::ECDb_0110,
@@ -95,8 +99,8 @@ BentleyStatus DbMapValidator::ValidateCustomAttributeTable() const {
         ++nOrphanRows;
     }
     if (nOrphanRows > 0) {
-        Issues().ReportV(IssueSeverity::Error, IssueCategory::BusinessProperties, IssueType::ECDbIssue, ECDbIssueId::ECDb_0111, "Detected %d orphan rows in ec_CustomAttributes.", nOrphanRows);
-        return ERROR;
+        Issues().ReportV(severity, IssueCategory::BusinessProperties, IssueType::ECDbIssue, ECDbIssueId::ECDb_0111, "Detected %d orphan rows in ec_CustomAttributes.", nOrphanRows);
+        return m_mode == DbMapValidationMode::ChangesetApply ? SUCCESS : ERROR;
     }
     return SUCCESS;
 }

--- a/iModelCore/ECDb/ECDb/DbMapValidator.h
+++ b/iModelCore/ECDb/ECDb/DbMapValidator.h
@@ -14,6 +14,7 @@ struct DbMapValidator final
     {
     private:
         SchemaImportContext& m_schemaImportContext;
+        DbMapValidationMode m_mode;
 
         mutable bmap<DbColumnId, bset<DbIndex const*>> m_indexesByColumnCache;
 
@@ -49,7 +50,7 @@ struct DbMapValidator final
         IssueDataSource const& Issues() const { return GetSchemaManager().Issues(); }
 
     public:
-        explicit DbMapValidator(SchemaImportContext& ctx) : m_schemaImportContext(ctx) {}
+        explicit DbMapValidator(SchemaImportContext& ctx, DbMapValidationMode mode = DbMapValidationMode::SchemaImport) : m_schemaImportContext(ctx), m_mode(mode) {}
         ~DbMapValidator() {}
 
         BentleyStatus Validate() const;

--- a/iModelCore/ECDb/ECDb/ECDb.cpp
+++ b/iModelCore/ECDb/ECDb/ECDb.cpp
@@ -112,7 +112,10 @@ DbResult ECDb::_OnDbOpened(OpenParams const& params)
 //---------------+---------------+---------------+---------------+---------------+------
 DbResult ECDb::_AfterSchemaChangeSetApplied() const
     {
-    auto rc = GetImpl().Schemas().Main().UpdateDbSchema(true);
+    // Applying a changeset replays already accepted timeline changes, so historical inconsistencies written by
+    // older software (orphan ec_CustomAttribute rows) must not fail the apply. The sqlite schema which was just
+    // updated above is still validated. See https://github.com/iTwin/itwinjs-backlog/issues/2331
+    auto rc = GetImpl().Schemas().Main().UpdateDbSchema(true, DbMapValidationMode::ChangesetApply);
     if (rc != SUCCESS)
         return BE_SQLITE_ERROR;
 

--- a/iModelCore/ECDb/ECDb/SchemaManagerDispatcher.cpp
+++ b/iModelCore/ECDb/ECDb/SchemaManagerDispatcher.cpp
@@ -13,7 +13,7 @@ Utf8String ECSchemaOwnershipClaimAppData::s_key = "ecdb.owned_by";
 /*---------------------------------------------------------------------------------------
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/
-BentleyStatus MainSchemaManager::UpdateDbSchema(bool doNotTrackDDLChanges) const{
+BentleyStatus MainSchemaManager::UpdateDbSchema(bool doNotTrackDDLChanges, DbMapValidationMode validationMode) const{
     ECDB_PERF_LOG_SCOPE("Updating sqlite schema");
     STATEMENT_DIAGNOSTICS_LOGCOMMENT("Begin MainSchemaManager::UpdateDbSchema");
 
@@ -45,7 +45,7 @@ BentleyStatus MainSchemaManager::UpdateDbSchema(bool doNotTrackDDLChanges) const
         return ERROR;
     }
 
-    if (SUCCESS != DbMapValidator(ctx).Validate()) {
+    if (SUCCESS != DbMapValidator(ctx, validationMode).Validate()) {
         return ERROR;
     }
 

--- a/iModelCore/ECDb/ECDb/SchemaManagerDispatcher.h
+++ b/iModelCore/ECDb/ECDb/SchemaManagerDispatcher.h
@@ -15,6 +15,22 @@
 BEGIN_BENTLEY_SQLITE_EC_NAMESPACE
 
 //=======================================================================================
+//! Determines how strict DbMapValidator is.
+// @bsiclass
+//+===============+===============+===============+===============+===============+======
+enum class DbMapValidationMode
+    {
+    //! Full validation. Any detected inconsistency fails the operation.
+    SchemaImport,
+    //! Used when replaying already accepted timeline changes (changeset apply).
+    //! Inconsistencies which can only originate from history written by older software - currently orphan rows
+    //! in ec_CustomAttribute - are logged as a warning instead of failing the operation. Everything else (in
+    //! particular the sqlite schema which the apply path just updated) is still validated strictly.
+    //! See https://github.com/iTwin/itwinjs-backlog/issues/2331
+    ChangesetApply
+    };
+
+//=======================================================================================
 // @bsiclass
 //+===============+===============+===============+===============+===============+======
 struct TableSpaceSchemaManager
@@ -235,7 +251,11 @@ public:
     SchemaChangeEvent& OnBeforeSchemaChanges() const { return m_onBeforeSchemaChanged;}
     SchemaChangeEvent& OnAfterSchemaChanges() const { return m_onAfterSchemaCHanged;};
     ECDbSystemSchemaHelper const& GetSystemSchemaHelper() const { return m_systemSchemaHelper; }
-    BentleyStatus UpdateDbSchema(bool doNotTrackDDLChanges) const;
+    //! Syncs the sqlite schema (tables/indexes) with the ec_* meta tables and validates the resulting map.
+    //! @param[in] doNotTrackDDLChanges if true, DDL changes are not tracked
+    //! @param[in] validationMode use DbMapValidationMode::ChangesetApply when replaying already accepted
+    //! timeline changes so that historical inconsistencies do not fail the apply.
+    BentleyStatus UpdateDbSchema(bool doNotTrackDDLChanges, DbMapValidationMode validationMode) const;
     };
 
 //=======================================================================================

--- a/iModelCore/ECDb/ECDb/SchemaSync.cpp
+++ b/iModelCore/ECDb/ECDb/SchemaSync.cpp
@@ -962,7 +962,9 @@ SchemaSync::Status SchemaSync::Pull(SyncDbUri const& syncDbUri, SchemaImportToke
 //+---------------+---------------+---------------+---------------+---------------+------
 SchemaSync::Status SchemaSync::UpdateDbSchema() {
     const auto kDoNotTrackDdlChanges = true;
-    const auto rc = m_conn.Schemas().Main().UpdateDbSchema(kDoNotTrackDdlChanges);
+    // SchemaSync::Pull also replays changes which were already accepted by another briefcase, so the same
+    // leniency as for changeset apply applies here. See https://github.com/iTwin/itwinjs-backlog/issues/2331
+    const auto rc = m_conn.Schemas().Main().UpdateDbSchema(kDoNotTrackDdlChanges, DbMapValidationMode::ChangesetApply);
     if (rc != SUCCESS) {
         LOG.error("SchemaSync::UpdateDbSchema(): Failed to update db schema.");
         return Status::ERROR;

--- a/iModelCore/ECDb/Tests/NonPublished/SchemaChangesetTests.cpp
+++ b/iModelCore/ECDb/Tests/NonPublished/SchemaChangesetTests.cpp
@@ -298,7 +298,8 @@ TEST_F(SchemaChangesetTestFixture, ApplySchemaChangesetWithOrphanCustomAttribute
     int orphanWarnings = 0;
     for (ReportedIssue const& issue : issueListener.m_issues)
         {
-        if (issue.id == ECDbIssueId::ECDb_0110 || issue.id == ECDbIssueId::ECDb_0111)
+        const auto issueIdString = Utf8String(issue.id.m_issueId);
+        if (issueIdString.CompareToIAscii("ECDb_0110") == 0 || issueIdString.CompareToIAscii("ECDb_0111") == 0)
             {
             ASSERT_EQ(ECN::IssueSeverity::Warning, issue.severity) << "Orphan custom attribute rows must only be a warning while applying a changeset: " << issue.message.c_str();
             ++orphanWarnings;
@@ -328,7 +329,8 @@ TEST_F(SchemaChangesetTestFixture, ApplySchemaChangesetWithOrphanCustomAttribute
     bool reportedAsError = false;
     for (ReportedIssue const& issue : issueListener.m_issues)
         {
-        if (issue.id == ECDbIssueId::ECDb_0111 && issue.severity == ECN::IssueSeverity::Error)
+        const auto issueIdString = Utf8String(issue.id.m_issueId);
+        if (issueIdString.CompareToIAscii("ECDb_0111") == 0 && issue.severity == ECN::IssueSeverity::Error)
             reportedAsError = true;
         }
     ASSERT_TRUE(reportedAsError) << "schema import must report orphan custom attribute rows as an error";

--- a/iModelCore/ECDb/Tests/NonPublished/SchemaChangesetTests.cpp
+++ b/iModelCore/ECDb/Tests/NonPublished/SchemaChangesetTests.cpp
@@ -6,6 +6,7 @@
 #include <set>
 #include <ECObjects/SchemaComparer.h>
 #include "../BackDoor/PublicAPI/BackDoor/ECDb/BackDoor.h"
+#include "MockHubApi.h"
 
 USING_NAMESPACE_BENTLEY_EC
 USING_NAMESPACE_BENTLEY_SQLITE_EC
@@ -222,5 +223,114 @@ TEST_F(SchemaChangesetTestFixture, RevertAndReinstateSchemaChange)
     ASSERT_EQ(JsonValue(R"json([{"A":"1A3","B":"1B3","C":"1C3","D":"1D3"}])json"), GetHelper().ExecuteSelectECSql("SELECT A,B,C,D FROM TestSchema.Class1"));
     ASSERT_EQ(JsonValue(R"json([{"A":"2A3","B":"2B3","C":"2C3","D":"2D3"}])json"), GetHelper().ExecuteSelectECSql("SELECT A,B,C,D FROM TestSchema.Class2"));
     ASSERT_EQ(JsonValue(R"json([{"A":"3A3","B":"3B3","C":"3C3","D":"3D3"}])json"), GetHelper().ExecuteSelectECSql("SELECT A,B,C,D FROM TestSchema.Class3"));
+    }
+
+//---------------------------------------------------------------------------------------
+// Two briefcases: b1 pushes a schema changeset which also carries orphan rows in ec_CustomAttribute
+// (custom attributes whose ECProperty container no longer exists, as written by older software).
+// b2 must be able to merge that changeset. Map validation must only reject such rows on schema import.
+// See https://github.com/iTwin/itwinjs-backlog/issues/2331
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+------
+TEST_F(SchemaChangesetTestFixture, ApplySchemaChangesetWithOrphanCustomAttributeRows)
+    {
+    ECDbHub hub;
+    auto b1 = hub.CreateBriefcase();
+    auto b2 = hub.CreateBriefcase();
+    ASSERT_EQ(BE_SQLITE_OK, b1->PullMergePush("init"));
+    ASSERT_EQ(BE_SQLITE_OK, b2->PullMergePush("init"));
+
+    SchemaItem schemaV1(R"schema(<?xml version='1.0' encoding='utf-8' ?>
+        <ECSchema schemaName="TestSchema" alias="ts" version="01.00.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+          <ECEntityClass typeName="Class1">
+            <ECProperty propertyName="A" typeName="string" />
+          </ECEntityClass>
+        </ECSchema>
+        )schema");
+    ASSERT_EQ(SUCCESS, TestHelper(*b1).ImportSchema(schemaV1));
+    ASSERT_EQ(BE_SQLITE_OK, b1->PullMergePush("schema v1"));
+    ASSERT_EQ(BE_SQLITE_OK, b2->PullMergePush("pull schema v1"));
+
+    // b1 imports the next schema version ...
+    SchemaItem schemaV2(R"schema(<?xml version='1.0' encoding='utf-8' ?>
+        <ECSchema schemaName="TestSchema" alias="ts" version="01.00.01" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+          <ECEntityClass typeName="Class1">
+            <ECProperty propertyName="A" typeName="string" />
+            <ECProperty propertyName="B" typeName="string" />
+          </ECEntityClass>
+        </ECSchema>
+        )schema");
+    ASSERT_EQ(SUCCESS, TestHelper(*b1).ImportSchema(schemaV2));
+
+    // ... and the same changeset carries orphan custom attribute rows, i.e. custom attributes applied to an
+    // ECProperty (container type 992) which doesn't exist. Older versions of the software produced those when
+    // a schema was deleted, because there is no foreign key on ec_CustomAttribute.ContainerId.
+    ECClassId classId = b1->Schemas().GetClassId("TestSchema", "Class1");
+    ASSERT_TRUE(classId.IsValid());
+    const int64_t orphanContainerIds[] = {INT64_C(0x7ffffff1), INT64_C(0x7ffffff2)};
+    for (int64_t orphanContainerId : orphanContainerIds)
+        {
+        Statement stmt;
+        ASSERT_EQ(BE_SQLITE_OK, stmt.Prepare(*b1, "INSERT INTO ec_CustomAttribute(ClassId,ContainerId,ContainerType,Ordinal,Instance) VALUES(?,?,992,0,'<Dummy xmlns=\"TestSchema.01.00.01\"/>')"));
+        stmt.BindId(1, classId);
+        stmt.BindInt64(2, orphanContainerId);
+        ASSERT_EQ(BE_SQLITE_DONE, stmt.Step());
+        }
+    ASSERT_EQ(BE_SQLITE_OK, b1->SaveChanges());
+    ASSERT_EQ(BE_SQLITE_OK, b1->PullMergePush("schema v2 with orphan custom attribute rows"));
+
+    auto orphanRowCount = [] (ECDbCR ecdb)
+        {
+        Statement stmt;
+        EXPECT_EQ(BE_SQLITE_OK, stmt.Prepare(ecdb, "SELECT count(*) FROM ec_CustomAttribute WHERE ContainerType=992 AND ContainerId NOT IN (SELECT Id FROM ec_Property)"));
+        EXPECT_EQ(BE_SQLITE_ROW, stmt.Step());
+        return stmt.GetValueInt(0);
+        };
+    ASSERT_EQ(2, orphanRowCount(*b1));
+
+    // b2 merges the schema changeset. This used to fail with "Detected orphan custom attribute rows".
+    TestIssueListener issueListener;
+    b2->AddIssueListener(issueListener);
+    ASSERT_EQ(BE_SQLITE_OK, b2->PullMergePush("pull schema v2")) << "Merging a schema changeset must not fail on orphan ec_CustomAttribute rows which are part of the timeline";
+
+    // the orphan rows were merged as is and are reported as a warning so the condition stays diagnosable
+    ASSERT_EQ(2, orphanRowCount(*b2));
+    int orphanWarnings = 0;
+    for (ReportedIssue const& issue : issueListener.m_issues)
+        {
+        if (issue.id == ECDbIssueId::ECDb_0110 || issue.id == ECDbIssueId::ECDb_0111)
+            {
+            ASSERT_EQ(ECN::IssueSeverity::Warning, issue.severity) << "Orphan custom attribute rows must only be a warning while applying a changeset: " << issue.message.c_str();
+            ++orphanWarnings;
+            }
+        else
+            {
+            ASSERT_NE(ECN::IssueSeverity::Error, issue.severity) << issue.message.c_str();
+            }
+        }
+    ASSERT_EQ(3, orphanWarnings) << "expected one warning per orphan row plus the summary";
+
+    // the merged schema is usable
+    ASSERT_EQ(JsonValue("[]"), TestHelper(*b2).ExecuteSelectECSql("SELECT A,B FROM TestSchema.Class1"));
+
+    // but a schema import still rejects the orphan rows
+    issueListener.ClearIssues();
+    SchemaItem schemaV3(R"schema(<?xml version='1.0' encoding='utf-8' ?>
+        <ECSchema schemaName="TestSchema" alias="ts" version="01.00.02" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+          <ECEntityClass typeName="Class1">
+            <ECProperty propertyName="A" typeName="string" />
+            <ECProperty propertyName="B" typeName="string" />
+            <ECProperty propertyName="C" typeName="string" />
+          </ECEntityClass>
+        </ECSchema>
+        )schema");
+    ASSERT_EQ(ERROR, TestHelper(*b2).ImportSchema(schemaV3)) << "Map validation must still reject orphan custom attribute rows on the schema import path";
+    bool reportedAsError = false;
+    for (ReportedIssue const& issue : issueListener.m_issues)
+        {
+        if (issue.id == ECDbIssueId::ECDb_0111 && issue.severity == ECN::IssueSeverity::Error)
+            reportedAsError = true;
+        }
+    ASSERT_TRUE(reportedAsError) << "schema import must report orphan custom attribute rows as an error";
     }
 END_ECDBUNITTESTS_NAMESPACE

--- a/iModelCore/ECDb/Tests/NonPublished/SchemaChangesetTests.cpp
+++ b/iModelCore/ECDb/Tests/NonPublished/SchemaChangesetTests.cpp
@@ -247,7 +247,7 @@ TEST_F(SchemaChangesetTestFixture, ApplySchemaChangesetWithOrphanCustomAttribute
           </ECEntityClass>
         </ECSchema>
         )schema");
-    ASSERT_EQ(SUCCESS, TestHelper(*b1).ImportSchema(schemaV1));
+    ASSERT_EQ(SchemaImportResult::OK, SchemaSyncTestFixture::ImportSchema(*b1, schemaV1));
     ASSERT_EQ(BE_SQLITE_OK, b1->PullMergePush("schema v1"));
     ASSERT_EQ(BE_SQLITE_OK, b2->PullMergePush("pull schema v1"));
 
@@ -260,7 +260,7 @@ TEST_F(SchemaChangesetTestFixture, ApplySchemaChangesetWithOrphanCustomAttribute
           </ECEntityClass>
         </ECSchema>
         )schema");
-    ASSERT_EQ(SUCCESS, TestHelper(*b1).ImportSchema(schemaV2));
+    ASSERT_EQ(SchemaImportResult::OK, SchemaSyncTestFixture::ImportSchema(*b1, schemaV2));
 
     // ... and the same changeset carries orphan custom attribute rows, i.e. custom attributes applied to an
     // ECProperty (container type 992) which doesn't exist. Older versions of the software produced those when
@@ -325,7 +325,7 @@ TEST_F(SchemaChangesetTestFixture, ApplySchemaChangesetWithOrphanCustomAttribute
           </ECEntityClass>
         </ECSchema>
         )schema");
-    ASSERT_EQ(ERROR, TestHelper(*b2).ImportSchema(schemaV3)) << "Map validation must still reject orphan custom attribute rows on the schema import path";
+    ASSERT_EQ(SchemaImportResult::ERROR, SchemaSyncTestFixture::ImportSchema(*b2, schemaV3)) << "Map validation must still reject orphan custom attribute rows on the schema import path";
     bool reportedAsError = false;
     for (ReportedIssue const& issue : issueListener.m_issues)
         {


### PR DESCRIPTION
Applying a schema changeset now treats pre-existing orphan `ec_CustomAttribute` rows as warnings instead of hard errors. Schema import still rejects them.

Fixes https://github.com/iTwin/itwinjs-backlog/issues/2331

itwinjs-core: https://github.com/iTwin/itwinjs-core/pull/9640