### PR TITLE
Version fixes for mend scan consistency

### DIFF
--- a/iModelCore/libsrc/compress/Zlib.mke
+++ b/iModelCore/libsrc/compress/Zlib.mke
@@ -63,6 +63,7 @@ always:
     ~linkfile "$(vcpkgStagingZip)zip.h=$(vcpkgMinizipDir)zip.h"
     ~linkfile "$(vcpkgStagingZip)unzip.h=$(vcpkgMinizipDir)unzip.h"
     ~linkfile "$(vcpkgStagingZip)ioapi.h=$(vcpkgMinizipDir)ioapi.h"
+    ~linkfile "$(vcpkgStagingZip)ints.h=$(vcpkgMinizipDir)ints.h"
     ~linkfile "$(vcpkgStagingZip)crypt.h=$(vcpkgMinizipDir)crypt.h"
     ~linkfile "$(vcpkgStagingZip)mztools.h=$(vcpkgMinizipDir)mztools.h"
     ~linkdir "$(BuildContext)VendorAPI/zlib=$(vcpkgStaging)"
@@ -72,19 +73,22 @@ always:
 #   Merge both vcpkg-built static libs into a single BeZlib archive.
 #--------------------------------------------------------------------------------------
 BeZlibOut = $(o)$(stlibprefix)$(appName)$(stlibext)
+# On Windows both libraries get an "s" static suffix and a "d" debug postfix.
 %if defined (DEBUG)
-    vcpkgMinizip = $(vcpkgDbgLibDir)$(stlibprefix)minizip$(stlibext)
     %if $(TARGET_PLATFORM) == "Windows"
         vcpkgZlib = $(vcpkgDbgLibDir)$(stlibprefix)zsd$(stlibext)
+        vcpkgMinizip = $(vcpkgDbgLibDir)$(stlibprefix)minizipsd$(stlibext)
     %else
         vcpkgZlib = $(vcpkgDbgLibDir)$(stlibprefix)z$(stlibext)
+        vcpkgMinizip = $(vcpkgDbgLibDir)$(stlibprefix)minizip$(stlibext)
     %endif
 %else
-    vcpkgMinizip = $(vcpkgLibDir)$(stlibprefix)minizip$(stlibext)
     %if $(TARGET_PLATFORM) == "Windows"
         vcpkgZlib = $(vcpkgLibDir)$(stlibprefix)zs$(stlibext)
+        vcpkgMinizip = $(vcpkgLibDir)$(stlibprefix)minizips$(stlibext)
     %else
         vcpkgZlib = $(vcpkgLibDir)$(stlibprefix)z$(stlibext)
+        vcpkgMinizip = $(vcpkgLibDir)$(stlibprefix)minizip$(stlibext)
     %endif
 %endif
 

--- a/iModelCore/libsrc/compress/vcpkg-configuration.json
+++ b/iModelCore/libsrc/compress/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "81de6771512413aaf89ea77add5ad1fda126b9d0",
+    "baseline": "83070c04235157ad9db23021f97c97141ed96534",
     "repository": "https://github.com/microsoft/vcpkg"
   }
 }

--- a/iModelCore/libsrc/compress/vcpkg.json
+++ b/iModelCore/libsrc/compress/vcpkg.json
@@ -8,11 +8,11 @@
     },
     {
       "name": "minizip",
-      "version>=": "1.3.1"
+      "version>=": "1.3.2"
     }
   ],
   "overrides": [
     { "name": "zlib", "version": "1.3.2#1" },
-    { "name": "minizip", "version": "1.3.1#1" }
+    { "name": "minizip", "version": "1.3.2" }
   ]
 }

--- a/iModelCore/libsrc/crashpad/vcpkg-configuration.json
+++ b/iModelCore/libsrc/crashpad/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "81de6771512413aaf89ea77add5ad1fda126b9d0",
+    "baseline": "83070c04235157ad9db23021f97c97141ed96534",
     "repository": "https://github.com/microsoft/vcpkg"
   }
 }

--- a/iModelCore/libsrc/crashpad/vcpkg.json
+++ b/iModelCore/libsrc/crashpad/vcpkg.json
@@ -8,9 +8,9 @@
     }
   ],
   "overrides": [
-    {
-      "name": "crashpad",
-      "version": "2024-04-11#13"
-    }
+    { "name": "crashpad", "version": "2024-04-11#13" },
+    { "name": "curl", "version": "8.21.0#1" },
+    { "name": "openssl", "version": "3.6.3" },
+    { "name": "zlib", "version": "1.3.2#1" }
   ]
 }


### PR DESCRIPTION
Prior to this, crashpad and minizip were pulling in earlier versions of other libraries. Mend had some complaints about the older libraries. This fixes that.

* crashpad: add version overrides
    * Match what is used elsewhere for curl, openssl, and zlib
* minizip: update to 1.3.2
    * This uses same zlib version as elsewhere
    * Update mke to deal with changes introduced by the minizip version update