### PR TITLE
Improve native test performance

### DIFF
--- a/iModelCore/ECDb/Tests/BackDoor/ECDbTestFixture.cpp
+++ b/iModelCore/ECDb/Tests/BackDoor/ECDbTestFixture.cpp
@@ -4,6 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 #include "PublicAPI/BackDoor/ECDb/ECDbTestFixture.h"
 #include "PublicAPI/BackDoor/ECDb/TestHelper.h"
+#include <Bentley/md5.h>
 #include <cstdlib>
 
 USING_NAMESPACE_BENTLEY_EC
@@ -117,31 +118,53 @@ BentleyStatus ECDbTestFixture::SetupECDb(Utf8CP ecdbFileName, SchemaItem const& 
         }
 
     BeAssert(schema.GetType() == SchemaItem::Type::String);
+    MD5 md5;
+    Utf8String schemaHash = md5(schema.GetXmlString());
     BeFileName seedFilePath;
-    if (!SeedECDbs().TryGetForXml(seedFilePath, schema.GetXmlString()))
+    if (SeedECDbs().TryGetForHash(seedFilePath, schemaHash))
+        return CloneECDb(ecdbFileName, seedFilePath, ecdbParam) == BE_SQLITE_OK ? SUCCESS : ERROR;
+
+    auto createSchemaDb = [&](BeFileName& filePath, Utf8CP fileName) -> BentleyStatus
         {
-        Utf8PrintfString seedFileName("seed_string_schema_%" PRIu64 ".ecdb", static_cast<uint64_t>(SeedECDbs().GetXmlSeedCount()));
-        ECDb seedECDb;
-        if (BE_SQLITE_OK != CreateECDb(seedECDb, seedFileName.c_str()))
+        ECDb ecdb;
+        if (BE_SQLITE_OK != CreateECDb(ecdb, fileName))
             return ERROR;
 
-        if (SUCCESS != TestHelper(seedECDb).ImportSchema(schema, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade))
+        if (SUCCESS != TestHelper(ecdb).ImportSchema(schema, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade))
             {
-            seedECDb.AbandonChanges();
+            ecdb.AbandonChanges();
             return ERROR;
             }
 
-        if (BE_SQLITE_OK != seedECDb.SaveChanges())
+        if (BE_SQLITE_OK != ecdb.SaveChanges())
             {
-            seedECDb.AbandonChanges();
+            ecdb.AbandonChanges();
             return ERROR;
             }
 
-        seedFilePath.AssignUtf8(seedECDb.GetDbFileName());
-        seedECDb.CloseDb();
-        SeedECDbs().AddForXml(schema.GetXmlString(), seedFilePath);
+        filePath.AssignUtf8(ecdb.GetDbFileName());
+        ecdb.CloseDb();
+        return SUCCESS;
+        };
+
+    if (!SeedECDbs().HasHash(schemaHash))
+        {
+        BeFileName ecdbPath;
+        if (SUCCESS != createSchemaDb(ecdbPath, ecdbFileName))
+            return ERROR;
+
+        if (BE_SQLITE_OK != m_ecdb.OpenBeSQLiteDb(ecdbPath, ecdbParam))
+            return ERROR;
+
+        SeedECDbs().AddHash(schemaHash);
+        return SUCCESS;
         }
 
+    Utf8PrintfString seedFileName("seed_string_schema_%s.ecdb", schemaHash.c_str());
+    if (SUCCESS != createSchemaDb(seedFilePath, seedFileName.c_str()))
+        return ERROR;
+
+    SeedECDbs().SetSeedForHash(schemaHash, seedFilePath);
     return CloneECDb(ecdbFileName, seedFilePath, ecdbParam) == BE_SQLITE_OK ? SUCCESS : ERROR;
     }
 
@@ -291,7 +314,8 @@ DbResult ECDbTestFixture::CloneECDb(ECDbR clone, Utf8CP cloneFileName, BeFileNam
 DbResult ECDbTestFixture::CloneECDb(ECDbR clone, BeFileNameCR cloneFilePath, BeFileNameCR seedFilePath, ECDb::OpenParams const& openParams)
     {
     BeFileName::CreateNewDirectory(BeFileName::GetDirectoryName(cloneFilePath).c_str());
-    BeFileName::BeCopyFile(seedFilePath, cloneFilePath);
+    if (BeFileName::BeCopyFile(seedFilePath, cloneFilePath) != BeFileNameStatus::Success)
+        return BE_SQLITE_ERROR;
 
     //clone Change cache file
     BeFileName seedChangeCachePath = ECDb::GetDefaultChangeCachePath(seedFilePath.GetNameUtf8().c_str());
@@ -299,8 +323,8 @@ DbResult ECDbTestFixture::CloneECDb(ECDbR clone, BeFileNameCR cloneFilePath, BeF
     if (cloneChangeCachePath.DoesPathExist() && cloneChangeCachePath.BeDeleteFile() != BeFileNameStatus::Success)
         return BE_SQLITE_ERROR;
 
-    if (seedChangeCachePath.DoesPathExist())
-        BeFileName::BeCopyFile(seedChangeCachePath, cloneChangeCachePath);
+    if (seedChangeCachePath.DoesPathExist() && BeFileName::BeCopyFile(seedChangeCachePath, cloneChangeCachePath) != BeFileNameStatus::Success)
+        return BE_SQLITE_ERROR;
 
     return clone.OpenBeSQLiteDb(cloneFilePath, openParams);
     }

--- a/iModelCore/ECDb/Tests/BackDoor/ECDbTestFixture.cpp
+++ b/iModelCore/ECDb/Tests/BackDoor/ECDbTestFixture.cpp
@@ -117,28 +117,32 @@ BentleyStatus ECDbTestFixture::SetupECDb(Utf8CP ecdbFileName, SchemaItem const& 
         }
 
     BeAssert(schema.GetType() == SchemaItem::Type::String);
-    BeFileName ecdbPath;
-    {
-    ECDb ecdb;
-    if (BE_SQLITE_OK != CreateECDb(ecdb, ecdbFileName))
+    BeFileName seedFilePath;
+    if (!SeedECDbs().TryGetForXml(seedFilePath, schema.GetXmlString()))
         {
-        //EXPECT_TRUE(false) << "Creating test ECDb failed (" << ecdbFileName << ")";
-        return ERROR;
+        Utf8PrintfString seedFileName("seed_string_schema_%" PRIu64 ".ecdb", static_cast<uint64_t>(SeedECDbs().GetXmlSeedCount()));
+        ECDb seedECDb;
+        if (BE_SQLITE_OK != CreateECDb(seedECDb, seedFileName.c_str()))
+            return ERROR;
+
+        if (SUCCESS != TestHelper(seedECDb).ImportSchema(schema, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade))
+            {
+            seedECDb.AbandonChanges();
+            return ERROR;
+            }
+
+        if (BE_SQLITE_OK != seedECDb.SaveChanges())
+            {
+            seedECDb.AbandonChanges();
+            return ERROR;
+            }
+
+        seedFilePath.AssignUtf8(seedECDb.GetDbFileName());
+        seedECDb.CloseDb();
+        SeedECDbs().AddForXml(schema.GetXmlString(), seedFilePath);
         }
 
-    if (SUCCESS != TestHelper(ecdb).ImportSchema(schema, SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade))
-        {
-        //EXPECT_TRUE(false) << "Importing schema failed.";
-        ecdb.AbandonChanges();
-        return ERROR;
-        }
-
-    ecdbPath.AssignUtf8(ecdb.GetDbFileName());
-    ecdb.SaveChanges();
-    }
-
-    //reopen the file after creating and importing the schema
-    return BE_SQLITE_OK == m_ecdb.OpenBeSQLiteDb(ecdbPath, ecdbParam) ? SUCCESS : ERROR;
+    return CloneECDb(ecdbFileName, seedFilePath, ecdbParam) == BE_SQLITE_OK ? SUCCESS : ERROR;
     }
 
 //---------------------------------------------------------------------------------------
@@ -291,8 +295,12 @@ DbResult ECDbTestFixture::CloneECDb(ECDbR clone, BeFileNameCR cloneFilePath, BeF
 
     //clone Change cache file
     BeFileName seedChangeCachePath = ECDb::GetDefaultChangeCachePath(seedFilePath.GetNameUtf8().c_str());
+    BeFileName cloneChangeCachePath = ECDb::GetDefaultChangeCachePath(cloneFilePath.GetNameUtf8().c_str());
+    if (cloneChangeCachePath.DoesPathExist() && cloneChangeCachePath.BeDeleteFile() != BeFileNameStatus::Success)
+        return BE_SQLITE_ERROR;
+
     if (seedChangeCachePath.DoesPathExist())
-        BeFileName::BeCopyFile(seedChangeCachePath, ECDb::GetDefaultChangeCachePath(cloneFilePath.GetNameUtf8().c_str()));
+        BeFileName::BeCopyFile(seedChangeCachePath, cloneChangeCachePath);
 
     return clone.OpenBeSQLiteDb(cloneFilePath, openParams);
     }

--- a/iModelCore/ECDb/Tests/BackDoor/PublicAPI/BackDoor/ECDb/ECDbTestFixture.h
+++ b/iModelCore/ECDb/Tests/BackDoor/PublicAPI/BackDoor/ECDb/ECDbTestFixture.h
@@ -91,6 +91,7 @@ private:
         {
     private:
         bmap<BeFileName, BeFileName> m_seedFilePathsBySchemaFileName;
+        bmap<Utf8String, BeFileName> m_seedFilePathsBySchemaXml;
 
         //not copyable
         SeedECDbManager(SeedECDbManager const&) = delete;
@@ -118,6 +119,24 @@ private:
             return ret.first->second;
             }
 
+        bool TryGetForXml(BeFileName& seedPath, Utf8StringCR schemaXml) const
+            {
+            auto it = m_seedFilePathsBySchemaXml.find(schemaXml);
+            if (it == m_seedFilePathsBySchemaXml.end())
+                return false;
+
+            seedPath = it->second;
+            return true;
+            }
+
+        BeFileNameCR AddForXml(Utf8StringCR schemaXml, BeFileNameCR seedPath)
+            {
+            BeAssert(m_seedFilePathsBySchemaXml.find(schemaXml) == m_seedFilePathsBySchemaXml.end());
+            auto ret = m_seedFilePathsBySchemaXml.insert(bpair<Utf8String, BeFileName>(schemaXml, seedPath));
+            return ret.first->second;
+            }
+
+        size_t GetXmlSeedCount() const { return m_seedFilePathsBySchemaXml.size(); }
         };
 
     static bool s_isInitialized;

--- a/iModelCore/ECDb/Tests/BackDoor/PublicAPI/BackDoor/ECDb/ECDbTestFixture.h
+++ b/iModelCore/ECDb/Tests/BackDoor/PublicAPI/BackDoor/ECDb/ECDbTestFixture.h
@@ -91,7 +91,7 @@ private:
         {
     private:
         bmap<BeFileName, BeFileName> m_seedFilePathsBySchemaFileName;
-        bmap<Utf8String, BeFileName> m_seedFilePathsBySchemaXml;
+        bmap<Utf8String, BeFileName> m_seedFilePathsBySchemaHash;
 
         //not copyable
         SeedECDbManager(SeedECDbManager const&) = delete;
@@ -119,24 +119,30 @@ private:
             return ret.first->second;
             }
 
-        bool TryGetForXml(BeFileName& seedPath, Utf8StringCR schemaXml) const
+        bool HasHash(Utf8StringCR schemaHash) const { return m_seedFilePathsBySchemaHash.find(schemaHash) != m_seedFilePathsBySchemaHash.end(); }
+
+        bool TryGetForHash(BeFileName& seedPath, Utf8StringCR schemaHash) const
             {
-            auto it = m_seedFilePathsBySchemaXml.find(schemaXml);
-            if (it == m_seedFilePathsBySchemaXml.end())
+            auto it = m_seedFilePathsBySchemaHash.find(schemaHash);
+            if (it == m_seedFilePathsBySchemaHash.end() || it->second.IsEmpty())
                 return false;
 
             seedPath = it->second;
             return true;
             }
 
-        BeFileNameCR AddForXml(Utf8StringCR schemaXml, BeFileNameCR seedPath)
+        void AddHash(Utf8StringCR schemaHash)
             {
-            BeAssert(m_seedFilePathsBySchemaXml.find(schemaXml) == m_seedFilePathsBySchemaXml.end());
-            auto ret = m_seedFilePathsBySchemaXml.insert(bpair<Utf8String, BeFileName>(schemaXml, seedPath));
-            return ret.first->second;
+            BeAssert(!HasHash(schemaHash));
+            m_seedFilePathsBySchemaHash.insert(bpair<Utf8String, BeFileName>(schemaHash, BeFileName()));
             }
 
-        size_t GetXmlSeedCount() const { return m_seedFilePathsBySchemaXml.size(); }
+        void SetSeedForHash(Utf8StringCR schemaHash, BeFileNameCR seedPath)
+            {
+            auto it = m_seedFilePathsBySchemaHash.find(schemaHash);
+            BeAssert(it != m_seedFilePathsBySchemaHash.end() && it->second.IsEmpty());
+            it->second = seedPath;
+            }
         };
 
     static bool s_isInitialized;

--- a/iModelCore/ECDb/Tests/NonPublished/ConcurrentQueryTest_V2.cpp
+++ b/iModelCore/ECDb/Tests/NonPublished/ConcurrentQueryTest_V2.cpp
@@ -586,11 +586,11 @@ TEST_F(ConcurrentQueryFixture, InterruptCheck_Timeout) {
 
     ASSERT_EQ(DbResult::BE_SQLITE_OK, SetupECDb("conn_query.ecdb"));
     auto config = ConcurrentQueryMgr::Config::Get();
-    config.SetQuota(QueryQuota(std::chrono::seconds(2), 1024));
+    config.SetQuota(QueryQuota(std::chrono::seconds(1), 1024));
     config.SetIgnoreDelay(false);
     ConcurrentQueryMgr::Config::Reset(config);
 
-    const auto delay = std::chrono::milliseconds(5000);
+    const auto delay = std::chrono::milliseconds(2000);
     ConcurrentQueryMgr::WithInstance(m_ecdb, [&](auto& mgr) {
         auto req = ECSqlRequest::MakeRequest("with cnt(x) as (values(0) union select x+1 from cnt where x < ? ) select x from cnt", ECSqlParams().BindInt(1, 1));
         req->SetDelay(delay);
@@ -880,7 +880,7 @@ TEST_F(ConcurrentQueryFixture, DelayRequest) {
 
     ConcurrentQueryMgr::WithInstance(m_ecdb, [&](auto& mgr) {
         auto req = ECSqlRequest::MakeRequest("with cnt(x) as (values(0) union select x+1 from cnt where x < ? ) select x from cnt", ECSqlParams().BindInt(1, 1));
-        const auto delay = std::chrono::milliseconds(2000);
+        const auto delay = std::chrono::milliseconds(250);
         req->SetDelay(delay);
         auto r = mgr.Enqueue(std::move(req)).Get();
         EXPECT_EQ(r->GetStatus(), QueryResponse::Status::Done);

--- a/iModelCore/ECDb/Tests/NonPublished/ECInstanceUpdaterTests.cpp
+++ b/iModelCore/ECDb/Tests/NonPublished/ECInstanceUpdaterTests.cpp
@@ -167,7 +167,7 @@ TEST_F(ECInstanceUpdaterTests, UpdateWithCurrentTimeStampTrigger)
     ASSERT_TRUE(firstLastMod.IsValid());
 
     //now update an ECInstance
-    BeThreadUtilities::BeSleep(1000); //so that new last mod differs significantly from old last mod
+    BeThreadUtilities::BeSleep(250); //so that new last mod differs significantly from old last mod
     v.Clear();
 
     v.SetInteger(2);

--- a/iModelCore/ECDb/Tests/NonPublished/MockHubApi.cpp
+++ b/iModelCore/ECDb/Tests/NonPublished/MockHubApi.cpp
@@ -1496,31 +1496,10 @@ BeFileName ECDbHub::BuildECDbPath(Utf8CP name) const {
 /*---------------------------------------------------------------------------------**//**
 * @bsimethod
 +---------------+---------------+---------------+---------------+---------------+------*/
-DbResult ECDbHub::CreateSeedFile() {
-    m_seedFile = BuildECDbPath("seed");
-    if (m_seedFile.DoesPathExist()) {
-        if (m_seedFile.BeDeleteFile() != BeFileNameStatus::Success) {
-            throw std::runtime_error("unable to delete file");
-        }
-    }
-/* Use this instead of the block below to create a new DB. Currently this will change the Checksums used in all tests...
-    auto ecdb = std::make_unique<TrackedECDb>();
-    if (BE_SQLITE_OK != ecdb->CreateNewDb(m_seedFile)) {
-        return BE_SQLITE_ERROR;
-    }
-    ecdb->SaveChanges();
-    ecdb->CloseDb();*/
-
-    BeFileName seed4003FileName;
-    BeTest::GetHost().GetDocumentsRoot(seed4003FileName);
-    seed4003FileName.AppendToPath(L"ECDb").AppendToPath(L"profileseeds").AppendToPath(L"4003-sync-seed.ecdb");
-    ECDb ecdb;
-    if (ECDbTestFixture::CloneECDb(ecdb, m_seedFile, seed4003FileName) != DbResult::BE_SQLITE_OK)
-        return BE_SQLITE_ERROR;
-
-    ecdb.SaveChanges();
-    ecdb.CloseDb();
-    return BE_SQLITE_OK;
+DbResult ECDbHub::FindSeedFile() {
+    BeTest::GetHost().GetDocumentsRoot(m_seedFile);
+    m_seedFile.AppendToPath(L"ECDb").AppendToPath(L"profileseeds").AppendToPath(L"4003-sync-seed.ecdb");
+    return m_seedFile.DoesPathExist() ? BE_SQLITE_OK : BE_SQLITE_ERROR;
 }
 
 /*---------------------------------------------------------------------------------**//**
@@ -1534,7 +1513,8 @@ ECDbHub::ECDbHub():m_id(true), m_briefcaseid(10) {
         BeFileName::CreateNewDirectory(outPath.GetName());
     }
     m_basePath = outPath;
-    CreateSeedFile();
+    if (FindSeedFile() != BE_SQLITE_OK)
+        throw std::runtime_error("unable to find ECDbHub seed file");
 }
 
 /*---------------------------------------------------------------------------------**//**

--- a/iModelCore/ECDb/Tests/NonPublished/MockHubApi.h
+++ b/iModelCore/ECDb/Tests/NonPublished/MockHubApi.h
@@ -147,7 +147,7 @@ struct ECDbHub {
         BeBriefcaseId m_briefcaseid;
 
     private:
-        DbResult CreateSeedFile();
+        DbResult FindSeedFile();
         BeFileName BuildECDbPath(Utf8CP name) const;
         BeBriefcaseId GetNextBriefcaseId() { return (m_briefcaseid = m_briefcaseid.GetNextBriefcaseId()); }
 

--- a/iModelCore/ECDb/Tests/NonPublished/NavigationPropsTests.cpp
+++ b/iModelCore/ECDb/Tests/NonPublished/NavigationPropsTests.cpp
@@ -26,6 +26,11 @@ struct ECSqlNavigationPropertyTestFixture : ECDbTestFixture
             }
     };
 
+struct ECSqlNavigationPropertyExtendedTests : ECSqlNavigationPropertyTestFixture
+    {
+    ECDB_EXTENDED_TIER_GATE(ECSqlNavigationPropertyTestFixture)
+    };
+
 //---------------------------------------------------------------------------------------
 // @bsiclass
 //+---------------+---------------+---------------+---------------+---------------+------
@@ -2920,7 +2925,7 @@ TEST_F(ECSqlNavigationPropertyTestFixture, JoinedTable)
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //+---------------+---------------+---------------+---------------+---------------+------
-TEST_F(ECSqlNavigationPropertyTestFixture, MultiplicityPermutations)
+TEST_F(ECSqlNavigationPropertyExtendedTests, MultiplicityPermutations)
     {
     enum class Multiplicity { Zero, One, GreaterThanOne, Many };
     std::array<Multiplicity, 4> multiplicities = { Multiplicity::Zero, Multiplicity::One, Multiplicity::GreaterThanOne, Multiplicity::Many };

--- a/iModelCore/ECDb/Tests/NonPublished/SchemaRemapTests.cpp
+++ b/iModelCore/ECDb/Tests/NonPublished/SchemaRemapTests.cpp
@@ -22,6 +22,11 @@ struct SchemaRemapTestFixture : public ECDbTestFixture
         BentleyStatus ImportSchemaFromFile(BeFileName const& fileName);
     };
 
+struct SchemaRemapExtendedTests : SchemaRemapTestFixture
+    {
+    ECDB_EXTENDED_TIER_GATE(SchemaRemapTestFixture)
+    };
+
 #define ASSERT_ECSQL(ECDB_OBJ, PREPARESTATUS, STEPSTATUS, ECSQL)   {\
                                                                     ECSqlStatement stmt;\
                                                                     ASSERT_EQ(PREPARESTATUS, stmt.Prepare(ECDB_OBJ, ECSQL));\
@@ -537,7 +542,7 @@ TEST_F(SchemaRemapTestFixture, MovePropertyUpInHierarchyUsingOverflowTable)
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //+---------------+---------------+---------------+---------------+---------------+------
-TEST_F(SchemaRemapTestFixture, MovePropertyUpInHierarchySimplified)
+TEST_F(SchemaRemapExtendedTests, MovePropertyUpInHierarchySimplified)
     {
     SchemaItem schemaItem(R"schema(<?xml version='1.0' encoding='utf-8' ?>
         <ECSchema schemaName="TestSchema" alias="ts" version="01.00.01" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
@@ -609,7 +614,7 @@ TEST_F(SchemaRemapTestFixture, MovePropertyUpInHierarchySimplified)
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //+---------------+---------------+---------------+---------------+---------------+------
-TEST_F(SchemaRemapTestFixture, MovePropertyUpInHierarchyRemoveOriginal)
+TEST_F(SchemaRemapExtendedTests, MovePropertyUpInHierarchyRemoveOriginal)
     {
     SchemaItem schemaItem(R"schema(<?xml version='1.0' encoding='utf-8' ?>
         <ECSchema schemaName="TestSchema" alias="ts" version="01.00.01" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
@@ -679,7 +684,7 @@ TEST_F(SchemaRemapTestFixture, MovePropertyUpInHierarchyRemoveOriginal)
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //+---------------+---------------+---------------+---------------+---------------+------
-TEST_F(SchemaRemapTestFixture, MovePropertyUpInHierarchyDeleteBeforeAddInSchema)
+TEST_F(SchemaRemapExtendedTests, MovePropertyUpInHierarchyDeleteBeforeAddInSchema)
     {
     // like previous test, but the base class comes later in the schema, so the change to "delete" the property is detected first
 
@@ -1029,7 +1034,7 @@ TEST_F(SchemaRemapTestFixture, AddNewBaseClassInMiddleMovePropertyUp)
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //+---------------+---------------+---------------+---------------+---------------+------
-TEST_F(SchemaRemapTestFixture, AddNewBaseClassInMiddleMovePropertyUpRemoveOriginal)
+TEST_F(SchemaRemapExtendedTests, AddNewBaseClassInMiddleMovePropertyUpRemoveOriginal)
     {
     SchemaItem schemaItem(R"schema(<?xml version='1.0' encoding='utf-8' ?>
         <ECSchema schemaName="TestSchema" alias="ts" version="01.00.01" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
@@ -1108,7 +1113,7 @@ TEST_F(SchemaRemapTestFixture, AddNewBaseClassInMiddleMovePropertyUpRemoveOrigin
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //+---------------+---------------+---------------+---------------+---------------+------
-TEST_F(SchemaRemapTestFixture, AddNewBaseClassInMiddleMovePropertyUpReversed)
+TEST_F(SchemaRemapExtendedTests, AddNewBaseClassInMiddleMovePropertyUpReversed)
     {
     SchemaItem schemaItem(R"schema(<?xml version='1.0' encoding='utf-8' ?>
         <ECSchema schemaName="TestSchema" alias="ts" version="01.00.01" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
@@ -1182,7 +1187,7 @@ TEST_F(SchemaRemapTestFixture, AddNewBaseClassInMiddleMovePropertyUpReversed)
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //+---------------+---------------+---------------+---------------+---------------+------
-TEST_F(SchemaRemapTestFixture, AddNewBaseClassInMiddleMovePropertyUpRemoveOriginalReversed)
+TEST_F(SchemaRemapExtendedTests, AddNewBaseClassInMiddleMovePropertyUpRemoveOriginalReversed)
     {
     SchemaItem schemaItem(R"schema(<?xml version='1.0' encoding='utf-8' ?>
         <ECSchema schemaName="TestSchema" alias="ts" version="01.00.01" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
@@ -1323,7 +1328,7 @@ TEST_F(SchemaRemapTestFixture, MovePropertyToNonSharedColumn)
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //+---------------+---------------+---------------+---------------+---------------+------
-TEST_F(SchemaRemapTestFixture, MoveMultiColumnPropertyUp)
+TEST_F(SchemaRemapExtendedTests, MoveMultiColumnPropertyUp)
     {
     SchemaItem schemaItem(R"schema(<?xml version='1.0' encoding='utf-8' ?>
         <ECSchema schemaName="TestSchema" alias="ts" version="01.00.01" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
@@ -1404,7 +1409,7 @@ TEST_F(SchemaRemapTestFixture, MoveMultiColumnPropertyUp)
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //+---------------+---------------+---------------+---------------+---------------+------
-TEST_F(SchemaRemapTestFixture, MoveMultiColumnPropertiesUp)
+TEST_F(SchemaRemapExtendedTests, MoveMultiColumnPropertiesUp)
     {
     SchemaItem schemaItem(R"schema(<?xml version='1.0' encoding='utf-8' ?>
         <ECSchema schemaName="TestSchema" alias="ts" version="01.00.01" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
@@ -1603,7 +1608,7 @@ TEST_F(SchemaRemapTestFixture, MovePropertyToMixin)
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //+---------------+---------------+---------------+---------------+---------------+------
-TEST_F(SchemaRemapTestFixture, MovePropertiesInNonSharedColumns)
+TEST_F(SchemaRemapExtendedTests, MovePropertiesInNonSharedColumns)
     {
     SchemaItem schemaItem(R"schema(<?xml version='1.0' encoding='utf-8' ?>
         <ECSchema schemaName="TestSchema" alias="ts" version="01.00.01" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
@@ -1715,7 +1720,7 @@ TEST_F(SchemaRemapTestFixture, MovePropertiesInNonSharedColumns)
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //+---------------+---------------+---------------+---------------+---------------+------
-TEST_F(SchemaRemapTestFixture, MovePropertiesInDefaultTables)
+TEST_F(SchemaRemapExtendedTests, MovePropertiesInDefaultTables)
     {
     SchemaItem schemaItem(R"schema(<?xml version='1.0' encoding='utf-8' ?>
         <ECSchema schemaName="TestSchema" alias="ts" version="01.00.01" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
@@ -1896,7 +1901,7 @@ TEST_F(SchemaRemapTestFixture, ModifyAndMoveStruct)
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //+---------------+---------------+---------------+---------------+---------------+------
-TEST_F(SchemaRemapTestFixture, MovePropertyToMixinAndRemoveOriginal)
+TEST_F(SchemaRemapExtendedTests, MovePropertyToMixinAndRemoveOriginal)
     {
     SchemaItem schemaItem(R"schema(<?xml version="1.0" encoding="utf-8" ?>
         <ECSchema schemaName="TestSchema" alias="ts" version="01.00.01" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
@@ -2660,7 +2665,7 @@ TEST_F(SchemaRemapTestFixture, InsertBaseClassHierarchyAndMovePropertyUp)
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //+---------------+---------------+---------------+---------------+---------------+------
-TEST_F(SchemaRemapTestFixture, MovePropertyFromMixin)
+TEST_F(SchemaRemapExtendedTests, MovePropertyFromMixin)
     {
     SchemaItem schemaItem(R"schema(<?xml version="1.0" encoding="utf-8" ?>
         <ECSchema schemaName="TestSchema" alias="ts" version="01.00.01" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
@@ -2886,7 +2891,7 @@ TEST_F(SchemaRemapTestFixture, InvalidRootPropertyId)
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //+---------------+---------------+---------------+---------------+---------------+------
-TEST_F(SchemaRemapTestFixture, MoveMultiplePropertiesUp)
+TEST_F(SchemaRemapExtendedTests, MoveMultiplePropertiesUp)
     {
     SchemaItem schemaItem(R"schema(<?xml version='1.0' encoding='utf-8' ?>
         <ECSchema schemaName="TestSchema" alias="ts" version="01.00.01" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
@@ -3286,7 +3291,7 @@ TEST_F(SchemaRemapTestFixture, SwapColumnsWithOverflow)
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //+---------------+---------------+---------------+---------------+---------------+------
-TEST_F(SchemaRemapTestFixture, MovePropertyFromOverflowDropOverflowTable)
+TEST_F(SchemaRemapExtendedTests, MovePropertyFromOverflowDropOverflowTable)
     {
     //This is currently unsupported. The schema update will return an error and say that there is an overflow table with no data in it.
     //This is a very rare scenario that should be supported with a future update.
@@ -3362,7 +3367,7 @@ TEST_F(SchemaRemapTestFixture, MovePropertyFromOverflowDropOverflowTable)
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //+---------------+---------------+---------------+---------------+---------------+------
-TEST_F(SchemaRemapTestFixture, SwapColumnsForProperty)
+TEST_F(SchemaRemapExtendedTests, SwapColumnsForProperty)
     {
     SchemaItem schemaItem(R"schema(<?xml version='1.0' encoding='utf-8' ?>
         <ECSchema schemaName="TestSchema" alias="ts" version="01.00.01" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
@@ -3443,7 +3448,7 @@ TEST_F(SchemaRemapTestFixture, SwapColumnsForProperty)
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //+---------------+---------------+---------------+---------------+---------------+------
-TEST_F(SchemaRemapTestFixture, MoveMultiplePropertiesInCircle)
+TEST_F(SchemaRemapExtendedTests, MoveMultiplePropertiesInCircle)
     {
     SchemaItem schemaItem(R"schema(<?xml version='1.0' encoding='utf-8' ?>
         <ECSchema schemaName="TestSchema" alias="ts" version="01.00.01" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
@@ -3547,7 +3552,7 @@ TEST_F(SchemaRemapTestFixture, MoveMultiplePropertiesInCircle)
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //+---------------+---------------+---------------+---------------+---------------+------
-TEST_F(SchemaRemapTestFixture, MovePropertyToOverflowUsingDifferentIdColumn)
+TEST_F(SchemaRemapExtendedTests, MovePropertyToOverflowUsingDifferentIdColumn)
     {
     SchemaItem schemaItem(R"schema(<?xml version='1.0' encoding='utf-8' ?>
         <ECSchema schemaName="TestSchema" alias="ts" version="01.00.01" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
@@ -5522,7 +5527,7 @@ TEST_F(SchemaRemapTestFixture, PutSiblingsIntoHierarchy)
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //+---------------+---------------+---------------+---------------+---------------+------
-TEST_F(SchemaRemapTestFixture, PutMultipleSiblingsIntoHierarchy)
+TEST_F(SchemaRemapExtendedTests, PutMultipleSiblingsIntoHierarchy)
     {
     //Move Building and Facility classes from GeometricElement3d below CompositeElement
     SchemaItem schemaItem(R"schema(<?xml version='1.0' encoding='utf-8' ?>
@@ -5730,7 +5735,7 @@ TEST_F(SchemaRemapTestFixture, PutSiblingsIntoHierarchyWithStruct)
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //+---------------+---------------+---------------+---------------+---------------+------
-TEST_F(SchemaRemapTestFixture, InsertBaseClassRemapSiblingsWithStruct)
+TEST_F(SchemaRemapExtendedTests, InsertBaseClassRemapSiblingsWithStruct)
     {
     //Insert a new base class "NewBase" into existing Hierarchy
     SchemaItem schemaItem(R"schema(<?xml version='1.0' encoding='utf-8' ?>
@@ -5820,7 +5825,7 @@ TEST_F(SchemaRemapTestFixture, InsertBaseClassRemapSiblingsWithStruct)
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //+---------------+---------------+---------------+---------------+---------------+------
-TEST_F(SchemaRemapTestFixture, InsertTwoConnectedBaseClassesRemapSiblings)
+TEST_F(SchemaRemapExtendedTests, InsertTwoConnectedBaseClassesRemapSiblings)
     {
     //Insert new classes "NewBase" and "NewBase2" into existing hierarchy
     SchemaItem schemaItem(R"schema(<?xml version='1.0' encoding='utf-8' ?>
@@ -6083,7 +6088,7 @@ TEST_F(SchemaRemapTestFixture, PutTwoClassesIntoHierarchy)
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //+---------------+---------------+---------------+---------------+---------------+------
-TEST_F(SchemaRemapTestFixture, PutSiblingsIntoHierarchyWithNestedStruct)
+TEST_F(SchemaRemapExtendedTests, PutSiblingsIntoHierarchyWithNestedStruct)
     {
     //move A and B below X, with A using a nested struct
     SchemaItem schemaItem(R"schema(<?xml version='1.0' encoding='utf-8' ?>
@@ -6187,7 +6192,7 @@ TEST_F(SchemaRemapTestFixture, PutSiblingsIntoHierarchyWithNestedStruct)
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //+---------------+---------------+---------------+---------------+---------------+------
-TEST_F(SchemaRemapTestFixture, PutSiblingsIntoHierarchyWithPropertyOverrides)
+TEST_F(SchemaRemapExtendedTests, PutSiblingsIntoHierarchyWithPropertyOverrides)
     {
     //Siblings X and A are changed so A derives from X. Class B overrides some properties from A
     SchemaItem schemaItem(R"schema(<?xml version='1.0' encoding='utf-8' ?>
@@ -6494,7 +6499,7 @@ TEST_F(SchemaRemapTestFixture, CreateBaseClassTurnPropertiesIntoOverrides)
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //+---------------+---------------+---------------+---------------+---------------+------
-TEST_F(SchemaRemapTestFixture, PutSiblingsWithSwappedPropertiesIntoHierarchy)
+TEST_F(SchemaRemapExtendedTests, PutSiblingsWithSwappedPropertiesIntoHierarchy)
     {
     //Siblings Duck and Fish both have a name and description but in different order. Making Fish derive from Duck requires its properties to move to the same columns.
     SchemaItem schemaItem(R"schema(<?xml version='1.0' encoding='utf-8' ?>
@@ -6682,7 +6687,7 @@ TEST_F(SchemaRemapTestFixture, InjectBaseClassInBaseSchema)
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //+---------------+---------------+---------------+---------------+---------------+------
-TEST_F(SchemaRemapTestFixture, InjectBaseClassInBaseSchema2)
+TEST_F(SchemaRemapExtendedTests, InjectBaseClassInBaseSchema2)
     {
     //Similar to V1 but with deeper hierarchy and a new sibling class alongside class D
     //Turn hierarchy from S1:A -> S1:B -> S1:C -> S2:D -> S2:E to S1:A -> S1:B -> S1:B2 -> S1:C -> S2:D -> S2:E
@@ -6785,7 +6790,7 @@ TEST_F(SchemaRemapTestFixture, InjectBaseClassInBaseSchema2)
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //+---------------+---------------+---------------+---------------+---------------+------
-TEST_F(SchemaRemapTestFixture, InjectBaseClassInBaseSchema3)
+TEST_F(SchemaRemapExtendedTests, InjectBaseClassInBaseSchema3)
     {
     //Similar to "InjectBaseClassInBaseSchema" but different in that class "B" does not exist before the schema update, meaning
     //its properties are mapped during the update, not before it.
@@ -6869,7 +6874,7 @@ TEST_F(SchemaRemapTestFixture, InjectBaseClassInBaseSchema3)
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //+---------------+---------------+---------------+---------------+---------------+------
-TEST_F(SchemaRemapTestFixture, InjectBaseClassInBaseSchema4)
+TEST_F(SchemaRemapExtendedTests, InjectBaseClassInBaseSchema4)
     {
     //Covers the same scenario as the tests InjectBaseClassInBaseSchema1-3, but is based on classes from real
     //schemas, condensed into fewer schemas but still reflecting the actual class hierarchy encountered

--- a/iModelCore/ECDb/Tests/NonPublished/SchemaSyncImportTests.cpp
+++ b/iModelCore/ECDb/Tests/NonPublished/SchemaSyncImportTests.cpp
@@ -1230,7 +1230,7 @@ TEST_F(SchemaSyncImportTestFixture, ConcurrentImportsDoNotShareAColumn)
 // ---------------------------------------------------------------------------------------
 // @bsitest
 // +---------------+---------------+---------------+---------------+---------------+------
-TEST_F(SchemaSyncImportTestFixture, ConcurrentImportsConvergeAfterExchange)
+TEST_F(SchemaSyncImportExtendedTests, ConcurrentImportsConvergeAfterExchange)
     {
     ECDbHub hub;
     SchemaSyncDb syncDb("upstream-converge-exchange");
@@ -1296,6 +1296,8 @@ TEST_F(SchemaSyncImportTestFixture, SyncDbRefusesConflictingPropertyType)
     syncDb.WithReadWrite([&](ECDbR sync) {
         EXPECT_NE(SchemaImportResult::OK, ImportSchema(sync, conflicting, SchemaManager::SchemaImportOptions::DoNotCreateOrUpdateDataTables))
             << "the sync db accepted a conflicting property type - the authority is not authoritative";
+        ASSERT_EQ(BE_SQLITE_OK, sync.AbandonChanges());
+        EXPECT_STREQ("1.0.1", VersionOf(sync, "Machinery").c_str());
     });
     }
 
@@ -1328,6 +1330,8 @@ TEST_F(SchemaSyncImportTestFixture, SyncDbRefusesImportNeedingDataTransform)
                   ImportSchema(sync, RemapSchema("01.00.01", true), SchemaManager::SchemaImportOptions::DoNotCreateOrUpdateDataTables))
             << "a data-moving change was accepted on the additive path; it must be routed to the "
                "upgrade front door instead";
+        ASSERT_EQ(BE_SQLITE_OK, sync.AbandonChanges());
+        EXPECT_STREQ("1.0.0", VersionOf(sync, "RemapTest").c_str());
     });
     }
 
@@ -2490,7 +2494,7 @@ TEST_F(SchemaSyncImportTestFixture, ConcurrentLabelEditsInReversedPushOrder)
 // ---------------------------------------------------------------------------------------
 // @bsitest
 // +---------------+---------------+---------------+---------------+---------------+------
-TEST_F(SchemaSyncImportTestFixture, ConcurrentEditsToANewClassInReversedPushOrder)
+TEST_F(SchemaSyncImportExtendedTests, ConcurrentEditsToANewClassInReversedPushOrder)
     {
     ConcurrentEditScenario scenario("upstream-new-class-reversed");
     scenario.Start({ MetadataOnlySchema("01.00.00", "unchanged throughout") });
@@ -3013,7 +3017,7 @@ TEST_F(SchemaSyncImportTestFixture, DataSurvivesASpillArrivingOnTopOfUnpushedRow
 // +---------------+---------------+---------------+---------------+---------------+------
 // The same spill with the rows spread over three unpushed txns, so the catch-up at the end of the
 // rebase has to cover all of them.
-TEST_F(SchemaSyncImportTestFixture, DataSurvivesASpillArrivingOnTopOfSeveralUnpushedTxns)
+TEST_F(SchemaSyncImportExtendedTests, DataSurvivesASpillArrivingOnTopOfSeveralUnpushedTxns)
     {
     ECDbHub hub;
     SchemaSyncDb syncDb("upstream-census-unpushed-txns");

--- a/iModelCore/ECDb/Tests/NonPublished/SchemaUpgradeTests.cpp
+++ b/iModelCore/ECDb/Tests/NonPublished/SchemaUpgradeTests.cpp
@@ -102,6 +102,10 @@ struct SchemaUpgradeTestFixture : public ECDbTestFixture
             }
     };
 
+struct SchemaUpgradeExtendedTests : SchemaUpgradeTestFixture
+    {
+    ECDB_EXTENDED_TIER_GATE(SchemaUpgradeTestFixture)
+    };
 
 void AssertECProperties(ECDbCR ecdb, Utf8CP assertExpression, bool strict = true)
     {
@@ -4805,7 +4809,7 @@ TEST_F(SchemaUpgradeTestFixture, AddPropertyToSubclassThenPropertyToBaseClass_TP
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //+---------------+---------------+---------------+---------------+---------------+------
-TEST_F(SchemaUpgradeTestFixture, AddPropertyToSubclassThenPropertyToBaseClass_TPH_JoinedTable_SharedCols)
+TEST_F(SchemaUpgradeExtendedTests, AddPropertyToSubclassThenPropertyToBaseClass_TPH_JoinedTable_SharedCols)
     {
     ASSERT_EQ(BentleyStatus::SUCCESS, SetupECDb("AddPropertyToSubclassThenPropertyToBaseClass_TPH_JoinedTable_SharedCols.ecdb", SchemaItem(
         R"xml(<?xml version="1.0" encoding="utf-8"?>
@@ -5235,7 +5239,7 @@ TEST_F(SchemaUpgradeTestFixture, AddPropertyToSubclassThenPropertyToBaseClass_TP
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //+---------------+---------------+---------------+---------------+---------------+------
-TEST_F(SchemaUpgradeTestFixture, AddPropertyToSubclassThenPropertyToBaseClass_TPH_JoinedTable_SharedCols_AddedBasePropToOverflow)
+TEST_F(SchemaUpgradeExtendedTests, AddPropertyToSubclassThenPropertyToBaseClass_TPH_JoinedTable_SharedCols_AddedBasePropToOverflow)
     {
     ASSERT_EQ(BentleyStatus::SUCCESS, SetupECDb("AddPropertyToSubclassThenPropertyToBaseClass_TPH_JoinedTable_SharedCols_AddedBasePropToOverflow.ecdb", SchemaItem(
         R"xml(<?xml version="1.0" encoding="utf-8"?>
@@ -6205,7 +6209,7 @@ TEST_F(SchemaUpgradeTestFixture, Delete_ECEntityClass_OwnTable)
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //+---------------+---------------+---------------+---------------+---------------+------
-TEST_F(SchemaUpgradeTestFixture, Delete_Add_ECEntityClass_TPH)
+TEST_F(SchemaUpgradeExtendedTests, Delete_Add_ECEntityClass_TPH)
     {
     //Setup Db ===================================================================================================
     SchemaItem schemaItem(
@@ -6364,7 +6368,7 @@ TEST_F(SchemaUpgradeTestFixture, Delete_Add_ECEntityClass_TPH)
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //+---------------+---------------+---------------+---------------+---------------+------
-TEST_F(SchemaUpgradeTestFixture, Delete_Add_ECEntityClass_TPH_ShareColumns)
+TEST_F(SchemaUpgradeExtendedTests, Delete_Add_ECEntityClass_TPH_ShareColumns)
     {
     //Setup Db ===================================================================================================
     SchemaItem schemaItem(
@@ -6733,7 +6737,7 @@ TEST_F(SchemaUpgradeTestFixture, Delete_Add_ECEntityClass_TPH_MaxSharedColumnsBe
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //+---------------+---------------+---------------+---------------+---------------+------
-TEST_F(SchemaUpgradeTestFixture, Delete_Add_ECEntityClass_JoinedTable)
+TEST_F(SchemaUpgradeExtendedTests, Delete_Add_ECEntityClass_JoinedTable)
     {
     //Setup Db ===================================================================================================
     SchemaItem schemaItem(
@@ -6979,7 +6983,7 @@ TEST_F(SchemaUpgradeTestFixture, Delete_Add_ECEntityClass_JoinedTable)
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //+---------------+---------------+---------------+---------------+---------------+------
-TEST_F(SchemaUpgradeTestFixture, Delete_Add_ECEntityClass_JoinedTable_ShareColumns)
+TEST_F(SchemaUpgradeExtendedTests, Delete_Add_ECEntityClass_JoinedTable_ShareColumns)
     {
     //Setup Db ===================================================================================================
     SchemaItem schemaItem(
@@ -17776,7 +17780,7 @@ TEST_F(SchemaUpgradeTestFixture, MajorSchemaUpgradePropertyTypeChangeFromPrim)
         }
     }
 
-TEST_F(SchemaUpgradeTestFixture, MajorSchemaUpgradePropertyTypeChangeFromEnum)
+TEST_F(SchemaUpgradeExtendedTests, MajorSchemaUpgradePropertyTypeChangeFromEnum)
     {
     ASSERT_EQ(BE_SQLITE_OK, SetupECDb("schemaupgrade_MajorSchemaUpgradePropertyTypeChangeFromEnum.ecdb"));
 
@@ -18722,7 +18726,7 @@ TEST_F(SchemaUpgradeTestFixture, TooManyColumnsInResultSet)
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //+---------------+---------------+---------------+---------------+---------------+------
-TEST_F(SchemaUpgradeTestFixture, TooManyColumnsInResultSetHierarchical)
+TEST_F(SchemaUpgradeExtendedTests, TooManyColumnsInResultSetHierarchical)
     {
     // Performance note: The update schema import is the bottleneck (~14s per 1099 new props per subclass).
     // We front-load most Foo/Goo properties in the initial setup so the update only adds ~100 new properties each.
@@ -18931,7 +18935,7 @@ TEST_F(SchemaUpgradeTestFixture, TooManyColumnsInResultSetHierarchical)
 //---------------------------------------------------------------------------------------
 // @bsimethod
 //+---------------+---------------+---------------+---------------+---------------+------
-TEST_F(SchemaUpgradeTestFixture, TooManyColumnsInResultSetAbstractClass)
+TEST_F(SchemaUpgradeExtendedTests, TooManyColumnsInResultSetAbstractClass)
     {
     // Performance note: The update schema import is the bottleneck (~14s for 1099 new props).
     // We front-load most Foo properties in the initial setup so the update only adds ~100 new properties.


### PR DESCRIPTION
Optimized some tests.

- Cache ECDbs created from identical inline schema XML and clone the immutable seed for each test, preserving per-test isolation.
- Reuse the immutable SchemaSync mock-hub profile seed instead of recreating an identical private seed for every hub.
- Remove unnecessarily long waits from timeout, delay and timestamp tests.
- Clear a clone's existing change-cache sidecar before copying the seed sidecar.
- Explicitly abandon changes after expected failed schema imports.

I recently introduced the `IMODEL_RUN_EXTENDED_TESTS` environment variable, and this PR moves more tests into the extended suite to increase speed of developer and CI builds.

The normal tier keeps representative coverage for each mapping, schema upgrade, remap, SchemaSync conflict and data-shape behavior. Repetitive permutation and scale cases now use `ExtendedTests` fixtures and run when `IMODEL_RUN_EXTENDED_TESTS=1` is set.

## Timings

Measured in full local Debug builds on the same machine. Timings are for the ECDb test executable.

| Run | Before | After | Saved |
| --- | ---: | ---: | ---: |
| Normal/core | 6:23 | 5:04 | 1:19 (20.5%) |
| Full, including extended | 9:24 | 9:01 | 0:23 (4.1%) |

The normal run passed 1,533 tests and skipped 255 extended tests. The full run passed all 1,788 tests.

---

Some measurements after merging this comparing the CI pipeline old vs new:

ECDbTest was faster on every platform that ran it:

| Configuration | Previous |  New | Saved |
| --- | ---: | ---: | ---: |
| Linux ARM64  | 591.9 s  | 388.9 s | 203.0 s / 34.3% 
|  Linux x64     | 309.2 s  | 282.2 s | 27.0 s / 8.7%   
| macOS ARM64   | 82.6 s   | 66.4 s  | 16.2 s / 19.6%  
| Windows MSVC  | 849.6 s  | 842.4 s | 7.2 s / 0.8%    
| Windows Clang | 339.2 s  | 322.8 s | 16.4 s / 4.8%   

 Summed across the five runners, ECDb went from 36:13 to 31:43, saving 4:30 / 12.4% of CI runner time.

 Linux ARM64 is the clearest win: its whole Build step dropped by 226 seconds, of which ECDb accounts for 203 seconds. Windows MSVC is effectively unchanged and deserves another sample before drawing conclusions.

 Why the job timings barely moved

 ECDbTest runs inside the large Azure Build step. Other variations often hid its improvement:

 - Linux x64 ECDb saved 27 seconds, but Pull and initialization became slower.
 - Windows MSVC ECDb saved 7 seconds, while CMake configure became 41 seconds slower.
 - Windows Clang ECDb saved 16 seconds, while Pull and initialization added about 34 seconds.
 - iOS became 80 seconds slower and does not run ECDb.
 - Android saved 6:37, mostly because Pull fell from 5:32 to 0:38. It does not run ECDb.

 Android remained the longest native job at 50:41, so ECDb was not on the native critical path. The change saves machine time without shortening pipeline wall time.

 ECDb is still significant within some jobs:

 - Linux ARM64: about 37% of the job.
 - Windows MSVC: about 37%.
 - Windows Clang: about 19%.
 - Linux x64: about 17%.
 - macOS: about 9%.