### PR TITLE
Update Curl to 8.22.0

### DIFF
--- a/iModelCore/libsrc/README.md
+++ b/iModelCore/libsrc/README.md
@@ -10,7 +10,7 @@ Libraries built in `iModelCore/libsrc/`.
 | `compress/snappy` | Google Snappy | 1.2.2 | No |
 | `crashpad` | Chromium Crashpad | 2024-04-11#13 | Yes |
 | `csmap` | CS-MAP | rev 2778 | No |
-| `curl` | libcurl | 8.21.0 | Yes |
+| `curl` | libcurl | 8.22.0 | Yes |
 | `curl` | c-ares (macOS/Linux only) | 1.34.8 | Yes |
 | `facebook` | Facebook Folly | 57.0 | No |
 | `flatbuffers` | FlatBuffers | 1.12.0 | No |

--- a/iModelCore/libsrc/crashpad/vcpkg-configuration.json
+++ b/iModelCore/libsrc/crashpad/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "7e43e0768a5af180a9cf75d87d692dce1b9da34f",
+    "baseline": "d732fa81bae15d672b7b9a174bc39e088342c042",
     "repository": "https://github.com/microsoft/vcpkg"
   }
 }

--- a/iModelCore/libsrc/crashpad/vcpkg.json
+++ b/iModelCore/libsrc/crashpad/vcpkg.json
@@ -9,7 +9,7 @@
   ],
   "overrides": [
     { "name": "crashpad", "version": "2024-04-11#13" },
-    { "name": "curl", "version": "8.21.0#1" },
+    { "name": "curl", "version": "8.22.0" },
     { "name": "openssl", "version": "3.6.4" },
     { "name": "zlib", "version": "1.3.2#1" }
   ]

--- a/iModelCore/libsrc/curl/vcpkg-configuration.json
+++ b/iModelCore/libsrc/curl/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "7e43e0768a5af180a9cf75d87d692dce1b9da34f",
+    "baseline": "d732fa81bae15d672b7b9a174bc39e088342c042",
     "repository": "https://github.com/microsoft/vcpkg"
   }
 }

--- a/iModelCore/libsrc/curl/vcpkg.json
+++ b/iModelCore/libsrc/curl/vcpkg.json
@@ -4,6 +4,7 @@
   "dependencies": [
     {
       "name": "curl",
+      "version>=": "8.22.0",
       "default-features": false,
       "features": [
         "non-http",
@@ -20,7 +21,7 @@
     }
   ],
   "overrides": [
-    { "name": "curl", "version": "8.21.0#1" },
+    { "name": "curl", "version": "8.22.0" },
     { "name": "openssl", "version": "3.6.4" },
     { "name": "zlib", "version": "1.3.2#1" },
     { "name": "c-ares", "version": "1.34.8" }


### PR DESCRIPTION
## Summary
- update the vcpkg-managed Curl dependency and override to 8.22.0
- update Crashpad's transitive Curl override to 8.22.0
- advance the Curl and Crashpad vcpkg baselines to the registry commit that introduced Curl 8.22.0
- update the third-party library inventory

## Testing
- not run locally; BentleyBuild requires the internal initialized build environment

*generated with GPT-5.6 Sol*