### PR TITLE
Update vertical CRS code to support loading from workspaces

### DIFF
--- a/iModelCore/GeoCoord/BaseGeoCoord/basegeocoord.cpp
+++ b/iModelCore/GeoCoord/BaseGeoCoord/basegeocoord.cpp
@@ -9207,6 +9207,23 @@ public:
     }
 };
 
+static Utf8String GetVerticalGridFilePath(WStringCR gridFile, WStringCR dataDirectory)
+{
+    BeFileName fileName(gridFile);
+    if (!fileName.IsAbsolutePath())
+    {
+        BeFileName resourcePath(L"assets");
+        resourcePath.AppendToPath(gridFile.c_str());
+        return resourcePath.GetNameUtf8();
+    }
+
+    WString resolvedGridFilePath;
+    if (SUCCESS != BeFileName::ResolveRelativePath(resolvedGridFilePath, gridFile.c_str(), dataDirectory.c_str()))
+        return "";
+
+    return Utf8String(resolvedGridFilePath.c_str());
+}
+
 class VerticalGeoidSeparationGridTransform : public VerticalTransform
 {
     friend class VerticalTransform;
@@ -9407,11 +9424,9 @@ public:
         {
             if (0 != gridFile.length())
             {
-                WString resolvedGridFilePath;
-                
-                if (SUCCESS == BeFileName::ResolveRelativePath(resolvedGridFilePath, gridFile.c_str(), dataDirectory.c_str()))
+                Utf8String resolved = GetVerticalGridFilePath(gridFile, dataDirectory);
+                if (!resolved.empty())
                 {
-                    Utf8String resolved(resolvedGridFilePath.c_str());
                     csDatumCatalogEntry_* entry = CSnewDatumCatalogEntry2 (resolved.c_str(), // fullpath
                                                                         0,      // path is not relative
                                                                         0,      // buffer size used when streaming, will be overloaded by size of record entry if available and that is larger
@@ -9638,11 +9653,9 @@ public:
         {
             if (0 != gridFile.length())
             {
-                WString resolvedGridFilePath;
-                if (SUCCESS == BeFileName::ResolveRelativePath(resolvedGridFilePath, gridFile.c_str(), dataDirectory.c_str()))
+                Utf8String resolved = GetVerticalGridFilePath(gridFile, dataDirectory);
+                if (!resolved.empty())
                 {
-                    Utf8String resolved(resolvedGridFilePath.c_str());
-
                     csDatumCatalogEntry_* entry = CSnewDatumCatalogEntry2 (resolved.c_str(), // fullpath
                                                                         0,      // path is not relative
                                                                         0,      // buffer size used when streaming, will be overloaded by size of record entry if available and that is larger
@@ -10574,21 +10587,33 @@ StatusInt VerticalDatumDictionary::AddVerticalDatumsFromFile(const WString& file
     if (0 == filepath.length())
         return GEOCOORDERR_BadArg;
 
-    BeFile dictionaryFile;
-    if (BeFileStatus::Success != dictionaryFile.Open(filepath.c_str(), BeFileAccess::Read))
+    Utf8String filePathUtf8(filepath.c_str());
+    csFILE* dictionaryFile = CS_fopen(filePathUtf8.c_str(), "rb");
+    if (nullptr == dictionaryFile)
         return GeoCoordParse_MissingFile;
 
     s_verticalDatumDictionary->m_dictionaryPath = filepath;
 
-    bvector<Byte> dictionary;
-    if (BeFileStatus::Success != dictionaryFile.ReadEntireFile(dictionary) 
-        || (0 == dictionary.size())
-        || (nullptr == dictionary.data()))
+    if (0 != CS_fseek(dictionaryFile, 0, SEEK_END))
+    {
+        CS_fclose(dictionaryFile);
+        return GeoCoordParse_ReadError;
+    }
+
+    long dictionarySize = CS_ftell(dictionaryFile);
+    if (dictionarySize <= 0 || 0 != CS_fseek(dictionaryFile, 0, SEEK_SET))
+    {
+        CS_fclose(dictionaryFile);
+        return GeoCoordParse_ReadError;
+    }
+
+    bvector<Byte> dictionary((size_t)dictionarySize + 1);
+    size_t bytesRead = CS_fread(dictionary.data(), 1, (size_t)dictionarySize, dictionaryFile);
+    CS_fclose(dictionaryFile);
+    if (bytesRead != (size_t)dictionarySize)
         return GeoCoordParse_ReadError;
 
-    // Ensure dictionary is null terminated
-    dictionary.resize(dictionary.size() + 1);
-    dictionary[dictionary.size() - 1] = '\0';
+    dictionary[(size_t)dictionarySize] = '\0';
 
     return AddVerticalDatumsFromJsonString(reinterpret_cast<char*>(dictionary.data()));
 }
@@ -12252,6 +12277,16 @@ struct WorkspaceDb : RefCountedBase, NonCopyableClass {
         }
         return m_db->IsDbOpen() ? m_db : nullptr;
     }
+    bool ContainsResource(Utf8CP resourceName) {
+        auto db = GetDb();
+        if (nullptr == db)
+            return false;
+
+        Statement stmt;
+        stmt.Prepare(*db, "SELECT 1 FROM blobs WHERE id=? COLLATE NOCASE");
+        stmt.BindText(1, resourceName, Statement::MakeCopy::No);
+        return BE_SQLITE_ROW == stmt.Step();
+    }
     WorkspaceDb(int priority, Utf8StringCR dbName, CloudContainerP container) : m_priority(priority), m_dbName(dbName), m_container(container) {
         if (m_container) {
             // set up a listener for the container being disconnected and remove this entry (closes Db)
@@ -12403,10 +12438,14 @@ bool BaseGCS::AddWorkspaceDb(Utf8String dbName, CloudContainerP container, int p
     for (auto it=s_workspaceDbs.begin(); it != s_workspaceDbs.end(); ++it) {
         if (priority > (*it)->m_priority) {
             s_workspaceDbs.emplace(it, newDb);
+            if (VerticalDatumDictionary::Get().IsValid() && newDb->ContainsResource("VerticalDatumDefinitions.json"))
+                VerticalDatumDictionary::ClearAndReinitialize();
             return true;
         }
     }
     s_workspaceDbs.emplace_back(newDb);
+    if (VerticalDatumDictionary::Get().IsValid() && newDb->ContainsResource("VerticalDatumDefinitions.json"))
+        VerticalDatumDictionary::ClearAndReinitialize();
     return true;
 }
 
@@ -12427,14 +12466,6 @@ StatusInt BaseGCS::Initialize(Utf8CP dataDirectory) {
     ::CS_altdr(s_assetsDirPrefix.c_str());
     s_assetsDir = dataDirectory;
 
-    // Initialize vertical datum dictionary
-    if (!VerticalDatumDictionary::Get().IsValid())
-        {
-        BeFileName vdatumFileName(dataDirectory);
-        vdatumFileName.AppendToPath(L"VerticalDatumDefinitions.json");
-        VerticalDatumDictionary::Initialize(vdatumFileName, WString(dataDirectory, true));
-        }
-
 #if defined (BENTLEY_WIN32)||defined (BENTLEY_WINRT)
     if (s_assetsDir.StartsWith("\\\\?\\")) // fopen doesn't work correctly with long path prefix on Windows
         s_assetsDir = s_assetsDir.substr(4);
@@ -12443,6 +12474,10 @@ StatusInt BaseGCS::Initialize(Utf8CP dataDirectory) {
     BeFileName baseDbName(s_assetsDir);
     baseDbName.AppendToPath(L"base.itwin-workspace");
     AddWorkspaceDb(baseDbName.GetNameUtf8(), nullptr, 0);
+
+    // Initialize vertical datum dictionary
+    if (!VerticalDatumDictionary::Get().IsValid())
+        VerticalDatumDictionary::Initialize(L"assets/VerticalDatumDefinitions.json", WString(dataDirectory, true));
 
     s_geoCoordInitialized = true;
     return SUCCESS;

--- a/iModelCore/GeoCoord/BaseGeoCoord/basegeocoord.cpp
+++ b/iModelCore/GeoCoord/BaseGeoCoord/basegeocoord.cpp
@@ -10551,6 +10551,7 @@ StatusInt VerticalDatumDictionary::Initialize(const WString& dictionaryPath, con
     if (!s_verticalDatumDictionary.IsValid())
         return ERROR;
 
+    s_verticalDatumDictionary->m_dictionaryPath = dictionaryPath;
     StatusInt status = s_verticalDatumDictionary->AddVerticalDatumsFromFile(dictionaryPath);
     s_verticalDatumDictionary->SetStatus(status);
 

--- a/iModelCore/GeoCoord/Tests/NonPublished/VerticalDatumUnitTests.cpp
+++ b/iModelCore/GeoCoord/Tests/NonPublished/VerticalDatumUnitTests.cpp
@@ -5,6 +5,7 @@
 //:>
 //:>+--------------------------------------------------------------------------------------
 #include <Bentley/BeTest.h>
+#include <BeSQLite/BeSQLite.h>
 
 #include <GeoCoord/BaseGeoCoord.h>
 #include "GeoCoordTestCommon.h"
@@ -108,6 +109,116 @@ TEST_F(VerticalDatumUnitTests, VerticalTransformGeoidGridFileTest)
     EXPECT_EQ(status, SUCCESS);
     EXPECT_EQ(elevationType, GeoCoordinates::VerticalTransform::ElevationType::Offset);
     EXPECT_NEAR(elevationOffset, 38.3, 0.5);
+}
+
+/*---------------------------------------------------------------------------------**//**
+* A relative vertical grid path should resolve through a registered workspace without
+* requiring the corresponding local grid file.
++---------------+---------------+---------------+---------------+---------------+------*/
+TEST_F(VerticalDatumUnitTests, VerticalTransformGeoidGridFileFromWorkspaceTest)
+{
+    BeFileName gridPath(GeoCoordTestCommon::InitializedLibraryPath().c_str(), BentleyCharEncoding::Utf8);
+    gridPath.AppendToPath(L"WW15MGH._96");
+    BeFile gridFile;
+    ASSERT_EQ(gridFile.Open(gridPath.GetName(), BeFileAccess::Read), BeFileStatus::Success);
+    bvector<Byte> gridData;
+    ASSERT_EQ(gridFile.ReadEntireFile(gridData), BeFileStatus::Success);
+
+    BeFileName workspacePath;
+    BeTest::GetHost().GetTempDir(workspacePath);
+    workspacePath.AppendToPath(L"VerticalGridFromWorkspace.itwin-workspace");
+    if (BeFileName::DoesPathExist(workspacePath))
+        ASSERT_EQ(BeFileName::BeDeleteFile(workspacePath), BeFileNameStatus::Success);
+
+    BeSQLite::Db workspaceDb;
+    ASSERT_EQ(workspaceDb.CreateNewDb(workspacePath.GetNameUtf8().c_str()), BeSQLite::BE_SQLITE_OK);
+    ASSERT_EQ(workspaceDb.ExecuteSql("CREATE TABLE blobs(id TEXT PRIMARY KEY NOT NULL, value BLOB)"), BeSQLite::BE_SQLITE_OK);
+    {
+    BeSQLite::Statement insert;
+    ASSERT_EQ(insert.Prepare(workspaceDb, "INSERT INTO blobs(id,value) VALUES(?,?)"), BeSQLite::BE_SQLITE_OK);
+    ASSERT_EQ(insert.BindText(1, "WW15MGH._96", BeSQLite::Statement::MakeCopy::Yes), BeSQLite::BE_SQLITE_OK);
+    ASSERT_EQ(insert.BindBlob(2, gridData.data(), (int)gridData.size(), BeSQLite::Statement::MakeCopy::Yes), BeSQLite::BE_SQLITE_OK);
+    ASSERT_EQ(insert.Step(), BeSQLite::BE_SQLITE_DONE);
+    }
+    ASSERT_EQ(workspaceDb.SaveChanges(), BeSQLite::BE_SQLITE_OK);
+    workspaceDb.CloseDb();
+    ASSERT_TRUE(GeoCoordinates::BaseGCS::AddWorkspaceDb(workspacePath.GetNameUtf8(), nullptr, 10000));
+
+    BeJsDocument geoidJson;
+    geoidJson["target"] = "WGS84";
+    geoidJson["geoidSeparationGrid"]["direction"] = "Direct";
+    geoidJson["geoidSeparationGrid"]["format"] = "GRD";
+    geoidJson["geoidSeparationGrid"]["files"].appendValue() = "./WW15MGH.GRD";
+
+    GeoCoordinates::VerticalTransformPtr geoidTransform =
+        GeoCoordinates::VerticalTransform::CreateFromJson(geoidJson, "EGM96 workspace height", "WGS84");
+    ASSERT_TRUE(geoidTransform.IsValid());
+
+    GeoPoint point = { 23.700523, 37.944210, 0.0 };
+    double elevationOffset = 0.0;
+    GeoCoordinates::VerticalTransform::ElevationType elevationType = GeoCoordinates::VerticalTransform::ElevationType::Fixed;
+
+    GeoCoordinates::BaseGCS::EnableLocalGcsFiles(false);
+    StatusInt status = geoidTransform->GetElevation(elevationOffset, elevationType, point);
+    GeoCoordinates::BaseGCS::EnableLocalGcsFiles(true);
+
+    EXPECT_EQ(status, SUCCESS);
+    EXPECT_EQ(elevationType, GeoCoordinates::VerticalTransform::ElevationType::Offset);
+    EXPECT_NEAR(elevationOffset, 38.3, 0.5);
+}
+
+/*---------------------------------------------------------------------------------**//**
+* Registering a workspace that contains the vertical dictionary should reload the
+* dictionary from that workspace without requiring a local JSON file.
++---------------+---------------+---------------+---------------+---------------+------*/
+TEST_F(VerticalDatumUnitTests, VerticalDatumDictionaryFromWorkspaceTest)
+{
+    Utf8String dictionaryJson = R"json({
+        "version": 1,
+        "definitions": [{
+            "verticalCRS": {
+                "crsName": "Workspace test height",
+                "datumName": "Workspace test datum",
+                "type": "GEOID",
+                "units": "meter",
+                "extent": {
+                    "southWest": { "latitude": -90.0, "longitude": -180.0 },
+                    "northEast": { "latitude": 90.0, "longitude": 180.0 }
+                },
+                "transforms": [{ "target": "WGS84", "nullTransform": null }]
+            }
+        }]
+    })json";
+
+    BeFileName workspacePath;
+    BeTest::GetHost().GetTempDir(workspacePath);
+    workspacePath.AppendToPath(L"VerticalDatumDictionaryFromWorkspace.itwin-workspace");
+    if (BeFileName::DoesPathExist(workspacePath))
+        ASSERT_EQ(BeFileName::BeDeleteFile(workspacePath), BeFileNameStatus::Success);
+
+    BeSQLite::Db workspaceDb;
+    ASSERT_EQ(workspaceDb.CreateNewDb(workspacePath.GetNameUtf8().c_str()), BeSQLite::BE_SQLITE_OK);
+    ASSERT_EQ(workspaceDb.ExecuteSql("CREATE TABLE blobs(id TEXT PRIMARY KEY NOT NULL, value BLOB)"), BeSQLite::BE_SQLITE_OK);
+
+    {
+    BeSQLite::Statement insert;
+    ASSERT_EQ(insert.Prepare(workspaceDb, "INSERT INTO blobs(id,value) VALUES(?,?)"), BeSQLite::BE_SQLITE_OK);
+    ASSERT_EQ(insert.BindText(1, "VerticalDatumDefinitions.json", BeSQLite::Statement::MakeCopy::Yes), BeSQLite::BE_SQLITE_OK);
+    ASSERT_EQ(insert.BindBlob(2, dictionaryJson.data(), (int)dictionaryJson.size(), BeSQLite::Statement::MakeCopy::Yes), BeSQLite::BE_SQLITE_OK);
+    ASSERT_EQ(insert.Step(), BeSQLite::BE_SQLITE_DONE);
+    }
+    ASSERT_EQ(workspaceDb.SaveChanges(), BeSQLite::BE_SQLITE_OK);
+    workspaceDb.CloseDb();
+
+    GeoCoordinates::BaseGCS::EnableLocalGcsFiles(false);
+    bool added = GeoCoordinates::BaseGCS::AddWorkspaceDb(workspacePath.GetNameUtf8(), nullptr, 10001);
+    GeoCoordinates::BaseGCS::EnableLocalGcsFiles(true);
+    ASSERT_TRUE(added);
+
+    StatusInt status = ERROR;
+    GeoCoordinates::VerticalDatumInfoPtr datumInfo = GeoCoordinates::VerticalDatumDictionary::Get()->GetVerticalDatumInfoFromName("Workspace test height", status);
+    EXPECT_EQ(status, SUCCESS);
+    EXPECT_TRUE(datumInfo.IsValid());
 }
 
 /*---------------------------------------------------------------------------------**//**

--- a/iModelCore/GeoCoord/Tests/NonPublished/VerticalDatumUnitTests.cpp
+++ b/iModelCore/GeoCoord/Tests/NonPublished/VerticalDatumUnitTests.cpp
@@ -168,10 +168,10 @@ TEST_F(VerticalDatumUnitTests, VerticalTransformGeoidGridFileFromWorkspaceTest)
 }
 
 /*---------------------------------------------------------------------------------**//**
-* Registering a workspace that contains the vertical dictionary should reload the
-* dictionary from that workspace without requiring a local JSON file.
+* Registering a workspace after initialization should retry loading a vertical
+* dictionary that was unavailable during initialization.
 +---------------+---------------+---------------+---------------+---------------+------*/
-TEST_F(VerticalDatumUnitTests, VerticalDatumDictionaryFromWorkspaceTest)
+TEST_F(VerticalDatumUnitTests, VerticalDatumDictionaryFromLateWorkspaceTest)
 {
     Utf8String dictionaryJson = R"json({
         "version": 1,
@@ -210,9 +210,16 @@ TEST_F(VerticalDatumUnitTests, VerticalDatumDictionaryFromWorkspaceTest)
     ASSERT_EQ(workspaceDb.SaveChanges(), BeSQLite::BE_SQLITE_OK);
     workspaceDb.CloseDb();
 
+    GeoCoordTestCommon::Shutdown();
     GeoCoordinates::BaseGCS::EnableLocalGcsFiles(false);
+    BeFileName dataDirectory = workspacePath.GetDirectoryName();
+    StatusInt initializeStatus = GeoCoordinates::BaseGCS::Initialize(dataDirectory.GetNameUtf8().c_str());
+    StatusInt initialDictionaryStatus = GeoCoordinates::VerticalDatumDictionary::Get()->GetStatus();
     bool added = GeoCoordinates::BaseGCS::AddWorkspaceDb(workspacePath.GetNameUtf8(), nullptr, 10001);
     GeoCoordinates::BaseGCS::EnableLocalGcsFiles(true);
+
+    EXPECT_EQ(initializeStatus, SUCCESS);
+    EXPECT_EQ(initialDictionaryStatus, GeoCoordinates::GeoCoordParse_MissingFile);
     ASSERT_TRUE(added);
 
     StatusInt status = ERROR;


### PR DESCRIPTION
- Load `VerticalDatumDefinitions.json` through the existing workspace-aware `_csFile` abstraction, retaining local-file fallback.
- Resolve relative vertical grid references as logical `assets/...` resources so grids can be loaded from registered GeoCoord workspaces.
- Reload the vertical datum dictionary when a higher-priority workspace containing it is registered after initialization.
- Add workspace-only tests for vertical dictionary and EGM96 grid loading with local files disabled.
