### PR TITLE
Tests and fix for 5.13 regression "does not match the number of properties. Property maps: 135, properties: 138." during changeset apply

### DIFF
--- a/iModelCore/ECDb/ECDb/DbMapValidator.cpp
+++ b/iModelCore/ECDb/ECDb/DbMapValidator.cpp
@@ -825,19 +825,25 @@ BentleyStatus DbMapValidator::ValidateClassMap(ClassMap const& classMap) const
             const int propCount = (int) classMap.GetClass().GetPropertyCount(true);
             if (dataPropertyMapCount != propCount)
                 {
-                Issues().ReportV(IssueSeverity::Error, IssueCategory::BusinessProperties, IssueType::ECDbIssue, ECDbIssueId::ECDb_0160,
+                // Changeset apply loads classes beyond those changed by the changeset. Tolerate incomplete
+                // data maps in existing files while keeping schema import and the loaded maps' validation strict.
+                const bool tolerateMissingDataPropertyMaps = m_mode == DbMapValidationMode::ChangesetApply && dataPropertyMapCount < propCount;
+                Issues().ReportV(tolerateMissingDataPropertyMaps ? IssueSeverity::Warning : IssueSeverity::Error, IssueCategory::BusinessProperties, IssueType::ECDbIssue, ECDbIssueId::ECDb_0160,
                     "The number of property maps for ECClass '%s' does not match the number of properties. Property maps: %d, properties: %d.", classMap.GetClass().GetFullName(), dataPropertyMapCount, propCount);
-                return ERROR;
-                }
-
-            // check all properties are mapped. We already know that the count of mapped and actual properties matches, so we only need to compare the names in one direction
-            for (auto& prop : classMap.GetClass().GetProperties(true))
-                {
-                if (mappedDataPropertyNames.find(prop->GetName()) == mappedDataPropertyNames.end())
-                    {
-                    Issues().ReportV(IssueSeverity::Error, IssueCategory::BusinessProperties, IssueType::ECDbIssue, ECDbIssueId::ECDb_0161,
-                        "Mismatch of mapped properties for ECClass '%s'. The count of mapped properties is correct, but property %s is not mapped.", classMap.GetClass().GetFullName(), prop->GetName().c_str());
+                if (!tolerateMissingDataPropertyMaps)
                     return ERROR;
+                }
+            else
+                {
+                // With matching counts, comparing names in one direction establishes that every property is mapped.
+                for (auto& prop : classMap.GetClass().GetProperties(true))
+                    {
+                    if (mappedDataPropertyNames.find(prop->GetName()) == mappedDataPropertyNames.end())
+                        {
+                        Issues().ReportV(IssueSeverity::Error, IssueCategory::BusinessProperties, IssueType::ECDbIssue, ECDbIssueId::ECDb_0161,
+                            "Mismatch of mapped properties for ECClass '%s'. The count of mapped properties is correct, but property %s is not mapped.", classMap.GetClass().GetFullName(), prop->GetName().c_str());
+                        return ERROR;
+                        }
                     }
                 }
 

--- a/iModelCore/ECDb/ECDb/ECDbImpl.cpp
+++ b/iModelCore/ECDb/ECDb/ECDbImpl.cpp
@@ -274,7 +274,24 @@ void ECDb::Impl::RegisterECSqlPragmas() const
 //--------------------------------------------------------------------------------------
 // @bsimethod
 //---------------+---------------+---------------+---------------+---------------+------
+DbResult ECDb::Impl::AttachDbAsSQLite(Utf8CP dbFileName, Utf8CP tableSpaceName) const {
+    struct RestoreAttachmentAlias {
+        Utf8CP& m_alias;
+        Utf8CP m_previousAlias;
+        ~RestoreAttachmentAlias() { m_alias = m_previousAlias; }
+    } restoreAlias { m_sqliteOnlyAttachmentAlias, m_sqliteOnlyAttachmentAlias };
+
+    m_sqliteOnlyAttachmentAlias = tableSpaceName;
+    return m_ecdb.AttachDb(dbFileName, tableSpaceName);
+}
+
+//--------------------------------------------------------------------------------------
+// @bsimethod
+//---------------+---------------+---------------+---------------+---------------+------
 DbResult ECDb::Impl::OnDbAttached(Utf8CP dbFileName, Utf8CP tableSpaceName) const {
+    if (m_sqliteOnlyAttachmentAlias != nullptr && BeStringUtilities::StricmpAscii(m_sqliteOnlyAttachmentAlias, tableSpaceName) == 0)
+        return BE_SQLITE_OK;
+
     auto tryGetProfileVersion = [&](ProfileVersion& ver) {
         Statement stmt;
         auto rc = stmt.Prepare(m_ecdb, SqlPrintfString("SELECT [StrData] FROM [%s].[be_Prop] WHERE [Namespace]='ec_Db' AND [Name] ='SchemaVersion'", tableSpaceName).GetUtf8CP());

--- a/iModelCore/ECDb/ECDb/ECDbImpl.h
+++ b/iModelCore/ECDb/ECDb/ECDbImpl.h
@@ -172,6 +172,7 @@ private:
     mutable std::unique_ptr<SupportInstanceQueryFunc> m_supportInstanceQueryFunc;
     mutable EC::ECSqlConfig m_ecSqlConfig;
     mutable bool m_disableDDLTracking;
+    mutable Utf8CP m_sqliteOnlyAttachmentAlias = nullptr;
     mutable std::unique_ptr<PragmaManager> m_pragmaProcessor;
     mutable SnappyFromMemory m_snappyReader;
     mutable SnappyToBlob m_snappyWriter;
@@ -238,6 +239,7 @@ public:
     BeGuid GetId() const  {return m_id; }
     IdFactory& GetIdFactory() const;
     DbResult ExecuteDDL(Utf8CP) const;
+    DbResult AttachDbAsSQLite(Utf8CP dbFileName, Utf8CP tableSpaceName) const;
     PragmaManager& GetPragmaManager() const;
 
     template<typename T>

--- a/iModelCore/ECDb/ECDb/SchemaManagerDispatcher.h
+++ b/iModelCore/ECDb/ECDb/SchemaManagerDispatcher.h
@@ -23,10 +23,8 @@ enum class DbMapValidationMode
     //! Full validation. Any detected inconsistency fails the operation.
     SchemaImport,
     //! Used when replaying already accepted timeline changes (changeset apply).
-    //! Inconsistencies which can only originate from history written by older software - currently orphan rows
-    //! in ec_CustomAttribute - are logged as a warning instead of failing the operation. Everything else (in
-    //! particular the sqlite schema which the apply path just updated) is still validated strictly.
-    //! See https://github.com/iTwin/itwinjs-backlog/issues/2331
+    //! Missing entity data-property maps and orphan ec_CustomAttribute rows are reported as warnings for
+    //! compatibility with existing files. Loaded property maps and physical structures are validated strictly.
     ChangesetApply
     };
 

--- a/iModelCore/ECDb/ECDb/SchemaSync.cpp
+++ b/iModelCore/ECDb/ECDb/SchemaSync.cpp
@@ -1950,7 +1950,8 @@ SchemaSync::Status SchemaSync::MirrorToSyncDb(SyncDbUri const& syncDbUri) {
         return Status::ERROR;
     }
 
-    auto rc = m_conn.AttachDb(syncDbUri.GetDbAttachUri().c_str(), SchemaSyncHelper::ALIAS_SYNC_DB);
+    // The mirror uses SQLite; during initialization the target has no ECDb profile yet.
+    auto rc = m_conn.GetImpl().AttachDbAsSQLite(syncDbUri.GetDbAttachUri().c_str(), SchemaSyncHelper::ALIAS_SYNC_DB);
     if (rc != BE_SQLITE_OK) {
         m_conn.GetImpl().Issues().ReportV(
             IssueSeverity::Error, IssueCategory::SchemaSync, IssueType::ECDbIssue, ECDbIssueId::ECDb_0630,

--- a/iModelCore/ECDb/Tests/NonPublished/SchemaChangesetTests.cpp
+++ b/iModelCore/ECDb/Tests/NonPublished/SchemaChangesetTests.cpp
@@ -335,4 +335,117 @@ TEST_F(SchemaChangesetTestFixture, ApplySchemaChangesetWithOrphanCustomAttribute
         }
     ASSERT_TRUE(reportedAsError) << "schema import must report orphan custom attribute rows as an error";
     }
+
+//---------------------------------------------------------------------------------------
+// A changeset may load an existing class whose persisted data maps are incomplete. Keep
+// that historical state intact while still rejecting the same state during import.
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+------
+TEST_F(SchemaChangesetTestFixture, ApplyChangesetWithIncompleteDerivedClassMaps)
+    {
+    Utf8String schemaXml(R"xml(<?xml version='1.0' encoding='utf-8' ?>
+        <ECSchema schemaName="HistoryMapProbe" alias="hmp" version="01.00.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+          <ECSchemaReference name="ECDbMap" version="02.00.00" alias="ecdbmap"/>
+          <ECEntityClass typeName="Root">
+            <ECCustomAttributes>
+              <ClassMap xmlns="ECDbMap.02.00.00">
+                <MapStrategy>TablePerHierarchy</MapStrategy>
+              </ClassMap>
+            </ECCustomAttributes>
+          </ECEntityClass>
+          <ECEntityClass typeName="Child" modifier="Sealed">
+            <BaseClass>Root</BaseClass>
+)xml");
+    for (int propertyIndex = 1; propertyIndex <= 138; ++propertyIndex)
+        schemaXml.append(Utf8PrintfString("            <ECProperty propertyName=\"P%d\" typeName=\"string\" />\r\n", propertyIndex));
+    schemaXml.append(R"xml(          </ECEntityClass>
+          <ECRelationshipClass typeName="RootReferencesRoot" modifier="Sealed" strength="referencing">
+            <Source multiplicity="(0..*)" roleLabel="references" polymorphic="true">
+              <Class class="Root"/>
+            </Source>
+            <Target multiplicity="(0..*)" roleLabel="is referenced by" polymorphic="true">
+              <Class class="Root"/>
+            </Target>
+          </ECRelationshipClass>
+        </ECSchema>
+)xml");
+
+    ASSERT_EQ(BentleyStatus::SUCCESS, SetupECDb("historyMapProbe.ecdb", SchemaItem(schemaXml)));
+    ASSERT_FALSE(m_ecdb.Schemas().GetSchemaSync().IsEnabled());
+    ASSERT_ECSQL(m_ecdb, ECSqlStatus::Success, BE_SQLITE_DONE, "INSERT INTO HistoryMapProbe.Child (P1) VALUES ('intact')");
+    ASSERT_EQ(BE_SQLITE_OK, m_ecdb.SaveChanges());
+
+    ASSERT_EQ(BE_SQLITE_OK, m_ecdb.ExecuteSql(R"sql(
+        DELETE FROM ec_PropertyMap
+        WHERE ClassId = (SELECT c.Id FROM ec_Class c JOIN ec_Schema s ON s.Id=c.SchemaId
+                         WHERE c.Name='Child' AND s.Name='HistoryMapProbe')
+          AND PropertyPathId IN (SELECT Id FROM ec_PropertyPath WHERE AccessString IN ('P136','P137','P138'))
+)sql"));
+    ASSERT_EQ(BE_SQLITE_OK, m_ecdb.SaveChanges());
+    m_ecdb.ClearECDbCache();
+
+    SchemaChangesetTestChangeTracker tracker(m_ecdb);
+    tracker.EnableTracking(true);
+    ASSERT_EQ(BE_SQLITE_OK, m_ecdb.ExecuteSql("UPDATE ec_Schema SET Description='unrelated description' WHERE Name='HistoryMapProbe'"));
+    SchemaChangesetTestChangeSet changeset;
+    ASSERT_EQ(BE_SQLITE_OK, changeset.FromChangeTrack(tracker));
+    tracker.EndTracking();
+    ASSERT_EQ(BE_SQLITE_OK, m_ecdb.AbandonChanges());
+
+    TestIssueListener issueListener;
+    m_ecdb.AddIssueListener(issueListener);
+    ASSERT_EQ(BE_SQLITE_OK, changeset.ApplyChanges(m_ecdb));
+    ASSERT_EQ(BE_SQLITE_OK, m_ecdb.AfterSchemaChangeSetApplied());
+
+    bool incompleteMapWarning = false;
+    for (ReportedIssue const& issue : issueListener.m_issues)
+        {
+        ASSERT_NE(ECN::IssueSeverity::Error, issue.severity) << issue.message.c_str();
+        if (Utf8String(issue.id.m_issueId).CompareToIAscii("ECDb_0160") == 0)
+            {
+            ASSERT_EQ(ECN::IssueSeverity::Warning, issue.severity);
+            ASSERT_TRUE(issue.message.Contains("Property maps: 135, properties: 138."));
+            incompleteMapWarning = true;
+            }
+        }
+    ASSERT_TRUE(incompleteMapWarning);
+
+    ECClassCP childClass = m_ecdb.Schemas().GetClass("HistoryMapProbe", "Child");
+    ASSERT_NE(nullptr, childClass);
+    ASSERT_EQ(138U, childClass->GetPropertyCount(true));
+    ASSERT_STREQ("unrelated description", childClass->GetSchema().GetDescription().c_str());
+    Statement mapCount;
+    ASSERT_EQ(BE_SQLITE_OK, mapCount.Prepare(m_ecdb, R"sql(
+        SELECT count(*) FROM ec_PropertyMap pm JOIN ec_PropertyPath pp ON pp.Id=pm.PropertyPathId
+        WHERE pm.ClassId = (SELECT c.Id FROM ec_Class c JOIN ec_Schema s ON s.Id=c.SchemaId
+                            WHERE c.Name='Child' AND s.Name='HistoryMapProbe')
+          AND pp.AccessString NOT IN ('ECInstanceId','ECClassId')
+)sql"));
+    ASSERT_EQ(BE_SQLITE_ROW, mapCount.Step());
+    ASSERT_EQ(135, mapCount.GetValueInt(0));
+    mapCount.Finalize();
+    ASSERT_EQ(JsonValue(R"json([{"P1":"intact"}])json"), GetHelper().ExecuteSelectECSql("SELECT P1 FROM HistoryMapProbe.Child"));
+
+    ASSERT_EQ(BE_SQLITE_OK, m_ecdb.SaveChanges());
+    issueListener.ClearIssues();
+    SchemaItem unrelatedSchema(R"xml(<?xml version='1.0' encoding='utf-8' ?>
+        <ECSchema schemaName="UnrelatedHistoryProbe" alias="uhp" version="01.00.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+          <ECSchemaReference name="ECDbMap" version="02.00.00" alias="ecdbmap"/>
+          <ECEntityClass typeName="UnrelatedRoot"/>
+        </ECSchema>
+)xml");
+    ASSERT_EQ(BentleyStatus::ERROR, ImportSchema(unrelatedSchema));
+
+    bool incompleteMapImportError = false;
+    for (ReportedIssue const& issue : issueListener.m_issues)
+        {
+        if (Utf8String(issue.id.m_issueId).CompareToIAscii("ECDb_0160") == 0)
+            {
+            ASSERT_EQ(ECN::IssueSeverity::Error, issue.severity);
+            incompleteMapImportError = true;
+            }
+        }
+    ASSERT_TRUE(incompleteMapImportError);
+    m_ecdb.RemoveIssueListener();
+    }
 END_ECDBUNITTESTS_NAMESPACE

--- a/iModelCore/ECDb/Tests/NonPublished/SchemaRemapTests.cpp
+++ b/iModelCore/ECDb/Tests/NonPublished/SchemaRemapTests.cpp
@@ -2,6 +2,8 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the repository root for full copyright notice.
 *--------------------------------------------------------------------------------------------*/
+#include "../../ECDb/ECDbPch.h"
+#undef LOG
 #include "ECDbPublishedTests.h"
 #include <set>
 #include <ECObjects/SchemaComparer.h>
@@ -3191,6 +3193,146 @@ TEST_F(SchemaRemapTestFixture, MovePropertyFromOverflow)
     auto result = GetHelper().ExecuteSelectECSql("SELECT Base1,Base2,Base3,A1,A2,A3 FROM TestSchema.A");
     ASSERT_EQ(JsonValue(R"json([{"Base1":"Base1","Base2":"Base2","Base3":"Base3","A1":"A1","A2":"A2","A3":"A3"}])json"), result);
     }
+    }
+
+//---------------------------------------------------------------------------------------
+// @bsimethod
+//+---------------+---------------+---------------+---------------+---------------+------
+TEST_F(SchemaRemapTestFixture, RemappingSiblingPropertiesPreservesUnchangedOverrides)
+    {
+    // One shared joined-table column puts GUID in the joined table and Padding in overflow.
+    // DRY_WEIGHT and the sibling ItemTag then share the next overflow column.
+    const auto schemaXml = R"xml(
+      <ECSchema schemaName="OpmRemap" alias="opm" version="01.00.%02d" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+        <ECSchemaReference name="ECDbMap" version="02.00.00" alias="ecdbmap"/>
+        <ECSchemaReference name="CoreCustomAttributes" version="01.00.03" alias="CoreCA"/>
+        <ECCustomAttributes><DynamicSchema xmlns="CoreCustomAttributes.01.00.03"/></ECCustomAttributes>
+        <ECEntityClass typeName="Root" modifier="Abstract">
+          <ECCustomAttributes>
+            <ClassMap xmlns="ECDbMap.02.00.00"><MapStrategy>TablePerHierarchy</MapStrategy></ClassMap>
+            <JoinedTablePerDirectSubclass xmlns="ECDbMap.02.00.00"/>
+          </ECCustomAttributes>
+        </ECEntityClass>
+        <ECEntityClass typeName="JoinedBase" modifier="Abstract">
+          <BaseClass>Root</BaseClass>
+          <ECCustomAttributes>
+            <ShareColumns xmlns="ECDbMap.02.00.00">
+              <MaxSharedColumnsBeforeOverflow>1</MaxSharedColumnsBeforeOverflow>
+              <ApplyToSubclassesOnly>True</ApplyToSubclassesOnly>
+            </ShareColumns>
+          </ECCustomAttributes>
+        </ECEntityClass>
+        <ECEntityClass typeName="PlantBase">
+          <BaseClass>JoinedBase</BaseClass>
+          <ECProperty propertyName="GUID" typeName="string"/>
+          <ECProperty propertyName="Padding" typeName="string"/>
+        </ECEntityClass>
+        <ECEntityClass typeName="NamedItem">
+          <BaseClass>PlantBase</BaseClass>
+          %s
+        </ECEntityClass>
+        <ECEntityClass typeName="Device">
+          <BaseClass>NamedItem</BaseClass>
+          <ECProperty propertyName="DRY_WEIGHT" typeName="double"/>
+        </ECEntityClass>
+        <ECEntityClass typeName="Fastener">
+          <BaseClass>Device</BaseClass>
+          <ECProperty propertyName="DRY_WEIGHT" typeName="double"/>
+        </ECEntityClass>
+        <ECEntityClass typeName="Bolt">
+          <BaseClass>Fastener</BaseClass>
+        </ECEntityClass>
+        <ECEntityClass typeName="Valve">
+          <BaseClass>NamedItem</BaseClass>
+          <ECProperty propertyName="ItemTag" typeName="string"/>
+        </ECEntityClass>
+      </ECSchema>)xml";
+
+    auto verifyUnchangedMappingsAndValue = [&]()
+        {
+        for (Utf8CP className : {"Device", "Fastener", "Bolt"})
+            {
+            SCOPED_TRACE(className);
+            Statement mappings;
+            ASSERT_EQ(BE_SQLITE_OK, mappings.Prepare(m_ecdb, R"sql(
+              SELECT COUNT(*), COUNT(DISTINCT pm.PropertyPathId), COUNT(DISTINCT pm.ColumnId)
+              FROM ec_PropertyMap pm JOIN ec_Class c ON c.Id=pm.ClassId
+                JOIN ec_Schema s ON s.Id=c.SchemaId JOIN ec_PropertyPath pp ON pp.Id=pm.PropertyPathId
+              WHERE s.Name='OpmRemap' AND c.Name=? AND pp.AccessString='DRY_WEIGHT')sql"));
+            ASSERT_EQ(BE_SQLITE_OK, mappings.BindText(1, className, Statement::MakeCopy::No));
+            ASSERT_EQ(BE_SQLITE_ROW, mappings.Step());
+            EXPECT_EQ(1, mappings.GetValueInt(0));
+            EXPECT_EQ(1, mappings.GetValueInt(1));
+            EXPECT_EQ(1, mappings.GetValueInt(2));
+            }
+
+        ECSqlStatement query;
+        ASSERT_EQ(ECSqlStatus::Success, query.Prepare(m_ecdb, "SELECT DRY_WEIGHT FROM ONLY OpmRemap.Bolt"));
+        ASSERT_EQ(BE_SQLITE_ROW, query.Step());
+        EXPECT_DOUBLE_EQ(12.5, query.GetValueDouble(0));
+        EXPECT_EQ(BE_SQLITE_DONE, query.Step());
+        };
+
+    ASSERT_EQ(SUCCESS, SetupECDb("remappingSiblingPropertiesPreservesUnchangedOverrides.ecdb", SchemaItem(Utf8PrintfString(schemaXml, 0, ""))));
+
+    const auto originalGuidColumn = GetHelper().GetPropertyMapColumn(AccessString("OpmRemap", "Device", "GUID"));
+    ASSERT_TRUE(originalGuidColumn.Exists());
+    ASSERT_EQ(Column::Kind::SharedData, originalGuidColumn.GetKind());
+    ASSERT_STREQ("opm_JoinedBase", originalGuidColumn.GetTableName().c_str());
+
+    const auto originalItemTagColumn = GetHelper().GetPropertyMapColumn(AccessString("OpmRemap", "Valve", "ItemTag"));
+    ASSERT_TRUE(originalItemTagColumn.Exists());
+    ASSERT_EQ(Column::Kind::SharedData, originalItemTagColumn.GetKind());
+    ASSERT_STREQ("opm_JoinedBase_Overflow", originalItemTagColumn.GetTableName().c_str());
+    {
+    Statement sharedMappings;
+    ASSERT_EQ(BE_SQLITE_OK, sharedMappings.Prepare(m_ecdb, R"sql(
+      SELECT COUNT(*), COUNT(DISTINCT pm.PropertyPathId), MIN(declaring.Name),
+        COUNT(DISTINCT pm.ColumnId), MIN(t.Name), MIN(col.Name)
+      FROM ec_PropertyMap pm JOIN ec_Class c ON c.Id=pm.ClassId
+        JOIN ec_Schema s ON s.Id=c.SchemaId JOIN ec_PropertyPath pp ON pp.Id=pm.PropertyPathId
+        JOIN ec_Property p ON p.Id=pp.RootPropertyId JOIN ec_Class declaring ON declaring.Id=p.ClassId
+        JOIN ec_Column col ON col.Id=pm.ColumnId JOIN ec_Table t ON t.Id=col.TableId
+      WHERE s.Name='OpmRemap' AND c.Name IN ('Device','Fastener','Bolt') AND pp.AccessString='DRY_WEIGHT')sql"));
+    ASSERT_EQ(BE_SQLITE_ROW, sharedMappings.Step());
+    ASSERT_EQ(3, sharedMappings.GetValueInt(0));
+    ASSERT_EQ(1, sharedMappings.GetValueInt(1));
+    ASSERT_STREQ("Device", sharedMappings.GetValueText(2));
+    ASSERT_EQ(1, sharedMappings.GetValueInt(3));
+    ASSERT_STREQ(originalItemTagColumn.GetTableName().c_str(), sharedMappings.GetValueText(4));
+    ASSERT_STREQ(originalItemTagColumn.GetName().c_str(), sharedMappings.GetValueText(5));
+    }
+
+    ASSERT_ECSQL(m_ecdb, ECSqlStatus::Success, BE_SQLITE_DONE, "INSERT INTO OpmRemap.Bolt (DRY_WEIGHT) VALUES (12.5)");
+    ASSERT_EQ(BE_SQLITE_OK, m_ecdb.SaveChanges());
+    ASSERT_EQ(BE_SQLITE_OK, ReopenECDb());
+    ASSERT_NO_FATAL_FAILURE(verifyUnchangedMappingsAndValue());
+
+    // Both linked tables must free columns in this import to exercise circular-remap column blocking.
+    const Utf8CP newOverrides = R"xml(
+      <ECProperty propertyName="GUID" typeName="string"/>
+      <ECProperty propertyName="ItemTag" typeName="string"/>)xml";
+    ASSERT_EQ(SUCCESS, ImportSchema(SchemaItem(Utf8PrintfString(schemaXml, 1, newOverrides)), SchemaManager::SchemaImportOptions::AllowDataTransformDuringSchemaUpgrade));
+    ASSERT_EQ(BE_SQLITE_OK, m_ecdb.SaveChanges());
+    ASSERT_EQ(BE_SQLITE_OK, ReopenECDb());
+
+    const auto remappedGuidColumn = GetHelper().GetPropertyMapColumn(AccessString("OpmRemap", "Device", "GUID"));
+    ASSERT_TRUE(remappedGuidColumn.Exists());
+    EXPECT_TRUE(originalGuidColumn.GetTableName() != remappedGuidColumn.GetTableName() || originalGuidColumn.GetName() != remappedGuidColumn.GetName());
+    const auto remappedItemTagColumn = GetHelper().GetPropertyMapColumn(AccessString("OpmRemap", "Valve", "ItemTag"));
+    ASSERT_TRUE(remappedItemTagColumn.Exists());
+    EXPECT_TRUE(originalItemTagColumn.GetTableName() != remappedItemTagColumn.GetTableName() || originalItemTagColumn.GetName() != remappedItemTagColumn.GetName());
+
+    // Validation inspects cached class maps; load Bolt's persisted mapping without querying DRY_WEIGHT.
+    ASSERT_FALSE(m_ecdb.Schemas().GetClassMapStrategy("OpmRemap", "Bolt").IsEmpty());
+    TestIssueListener issueListener;
+    ASSERT_EQ(SUCCESS, m_ecdb.AddIssueListener(issueListener));
+    SchemaImportContext validationContext(m_ecdb, SchemaManager::SchemaImportOptions::None);
+    const auto validationStatus = DbMapValidator(validationContext, DbMapValidationMode::SchemaImport).Validate();
+    m_ecdb.RemoveIssueListener();
+    ASSERT_EQ(SUCCESS, validationStatus) << issueListener.GetLastMessage().c_str();
+
+    ASSERT_NO_FATAL_FAILURE(verifyUnchangedMappingsAndValue());
     }
 
 //---------------------------------------------------------------------------------------

--- a/iModelCore/ECDb/Tests/NonPublished/SchemaSyncImportTests.cpp
+++ b/iModelCore/ECDb/Tests/NonPublished/SchemaSyncImportTests.cpp
@@ -738,6 +738,65 @@ TEST_F(SchemaSyncImportTestFixture, InitMirrorsProfilePropertiesWithoutLocalSync
 // ---------------------------------------------------------------------------------------
 // @bsitest
 // +---------------+---------------+---------------+---------------+---------------+------
+TEST_F(SchemaSyncImportTestFixture, InitProfilelessSyncDbWithoutAttachErrors)
+    {
+    TestIssueListener issues;
+    ECDbHub hub;
+    auto briefcase = hub.CreateBriefcase();
+    ASSERT_EQ(SUCCESS, briefcase->AddIssueListener(issues));
+
+    const auto syncPath = BuildECDbPath("schemasync-init-profileless.db");
+    const auto ordinaryPath = BuildECDbPath("schemasync-ordinary-profileless.db");
+    for (auto const& filePath : {syncPath, ordinaryPath})
+        {
+        if (filePath.DoesPathExist())
+            ASSERT_EQ(BeFileNameStatus::Success, BeFileName::BeDeleteFile(filePath));
+
+        Db db;
+        ASSERT_EQ(BE_SQLITE_OK, db.CreateNewDb(filePath));
+        ASSERT_FALSE(db.TableExists("ec_Schema"));
+        ASSERT_EQ(BE_SQLITE_OK, db.SaveChanges());
+        db.CloseDb();
+        }
+
+    const auto hasIssue = [&](Utf8CP issueId)
+        {
+        return std::any_of(issues.m_issues.begin(), issues.m_issues.end(), [&](ReportedIssue const& issue)
+            {
+            return Utf8String(issue.id.m_issueId).Equals(issueId);
+            });
+        };
+
+    {
+    TestLogger logger;
+    LogCatcher logCatcher(logger);
+    const SchemaSync::SyncDbUri syncUri(syncPath.GetNameUtf8().c_str());
+    ASSERT_EQ(SchemaSync::Status::OK, briefcase->Schemas().GetSchemaSync().Init(syncUri, "upstream-container", false));
+    for (auto const& [severity, message] : logger.m_messages)
+        EXPECT_NE(NativeLogging::LOG_ERROR, severity) << message;
+    }
+    EXPECT_FALSE(hasIssue("ECDb_0735"));
+    EXPECT_FALSE(hasIssue("ECDb_0736"));
+    ASSERT_EQ(BE_SQLITE_OK, briefcase->SaveChanges());
+    EXPECT_TRUE(briefcase->Schemas().GetSchemaSync().IsEnabled());
+
+    {
+    ECDb initializedSyncDb;
+    ASSERT_EQ(BE_SQLITE_OK, initializedSyncDb.OpenDb(syncPath, ECDb::OpenParams(Db::OpenMode::Readonly)));
+    EXPECT_EQ(briefcase->GetECDbProfileVersion(), initializedSyncDb.GetECDbProfileVersion());
+    ExpectECTablesIdentical(*briefcase, initializedSyncDb, "initialized profileless sync db");
+    }
+
+    issues.ClearIssues();
+    ASSERT_EQ(BE_SQLITE_OK, briefcase->AttachDb(ordinaryPath.GetNameUtf8().c_str(), "schema_sync_db"));
+    EXPECT_TRUE(hasIssue("ECDb_0735"));
+    EXPECT_TRUE(hasIssue("ECDb_0736"));
+    ASSERT_EQ(BE_SQLITE_OK, briefcase->DetachDb("schema_sync_db"));
+    }
+
+// ---------------------------------------------------------------------------------------
+// @bsitest
+// +---------------+---------------+---------------+---------------+---------------+------
 TEST_F(SchemaSyncImportTestFixture, SyncDbMappingMatchesBriefcaseMapping)
     {
     ECDbHub hub;

--- a/iModelCore/ECDb/Tests/NonPublished/SchemaSyncImportTests.cpp
+++ b/iModelCore/ECDb/Tests/NonPublished/SchemaSyncImportTests.cpp
@@ -782,7 +782,7 @@ TEST_F(SchemaSyncImportTestFixture, InitProfilelessSyncDbWithoutAttachErrors)
 
     {
     ECDb initializedSyncDb;
-    ASSERT_EQ(BE_SQLITE_OK, initializedSyncDb.OpenDb(syncPath, ECDb::OpenParams(Db::OpenMode::Readonly)));
+    ASSERT_EQ(BE_SQLITE_OK, initializedSyncDb.OpenBeSQLiteDb(syncPath, ECDb::OpenParams(Db::OpenMode::Readonly)));
     EXPECT_EQ(briefcase->GetECDbProfileVersion(), initializedSyncDb.GetECDbProfileVersion());
     ExpectECTablesIdentical(*briefcase, initializedSyncDb, "initialized profileless sync db");
     }


### PR DESCRIPTION
Tolerate historical property-map count deficits during changeset apply while keeping schema-import validation strict.

- Add ECDb regressions for changeset compatibility and shared-column remapping corruption.
- Fix SchemaSync initialization against a database that does not yet have an ECDb profile.

Companion to #1584, which prevents new duplicate property mappings. These PRs should merge together.
